### PR TITLE
Visual fix for landing page not spanning full height on large views

### DIFF
--- a/application/frontend/src/app.scss
+++ b/application/frontend/src/app.scss
@@ -19,13 +19,11 @@ body {
   background-color: white;
 }
 
-.mount {
-  display: flex;
-  justify-content: flex-start;
-  align-items: stretch;
-  flex-direction: row-reverse;
+#mount {
   height: 100vh;
   width: 100vw;
-  position: relative;
-  z-index: 1;
+}
+
+.app {
+  height: 100%;
 }

--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -7,6 +7,7 @@
   justify-content: center;
   padding-top: 40px;
   padding-bottom: 40px;
+  min-height: 100%;
 
   .search-page__heading {
     text-align: center;


### PR DESCRIPTION


#### What does this PR do?


Landing page was not stretching the full width of the page on large view, causing a white box to appear after the page content. This is now fixed.
(fixes #114 )


