### PR TITLE
Use allShortestPaths over shortestPath

### DIFF
--- a/application/database/db.py
+++ b/application/database/db.py
@@ -427,7 +427,7 @@ class NEO_DB:
             """
             OPTIONAL MATCH (BaseStandard:NeoStandard {name: $name1})
             OPTIONAL MATCH (CompareStandard:NeoStandard {name: $name2})
-            OPTIONAL MATCH p = shortestPath((BaseStandard)-[*..20]-(CompareStandard)) 
+            OPTIONAL MATCH p = allShortestPaths((BaseStandard)-[*..20]-(CompareStandard)) 
             WITH p
             WHERE length(p) > 1 AND ALL(n in NODES(p) WHERE n:NeoCRE or n = BaseStandard or n = CompareStandard) 
             RETURN p
@@ -440,7 +440,7 @@ class NEO_DB:
             """
             OPTIONAL MATCH (BaseStandard:NeoStandard {name: $name1})
             OPTIONAL MATCH (CompareStandard:NeoStandard {name: $name2})
-            OPTIONAL MATCH p = shortestPath((BaseStandard)-[:(LINKED_TO|CONTAINS)*..20]-(CompareStandard)) 
+            OPTIONAL MATCH p = allShortestPaths((BaseStandard)-[:(LINKED_TO|CONTAINS)*..20]-(CompareStandard)) 
             WITH p
             WHERE length(p) > 1 AND ALL(n in NODES(p) WHERE n:NeoCRE or n = BaseStandard or n = CompareStandard) 
             RETURN p


### PR DESCRIPTION
Experiment to use allShortestPaths over shortestPath

At the cost of a noticeable longer load time we do get more results with allShortestPaths eg (http://localhost:9001/map_analysis?base=ASVS&compare=NIST%20800-53%20v5 first result returns 23 more results with allShortestPaths) 