### PR TITLE
add pr info to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Unsure where to begin contributing? You can start by looking through these `begi
 
 ### Pull Requests
 
-
+Each Pull Request should close a single ticket and only make changes necessary in order for this to be done. Please reference the relevant ticket in the Pull Request.
 After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
 
 ## Styleguides


### PR DESCRIPTION
closes #460 by including language around PR to Issue mapping on contributing.md