### PR TITLE
Switch to new challenge search syntax

### DIFF
--- a/application/utils/external_project_parsers/juiceshop.py
+++ b/application/utils/external_project_parsers/juiceshop.py
@@ -36,7 +36,7 @@ def parse(
             name="OWASP Juice Shop",
             section=challenge["name"],
             sectionID=challenge["key"],
-            hyperlink="https://demo.owasp-juice.shop//#/score-board?challenge="
+            hyperlink="https://demo.owasp-juice.shop//#/score-board?searchQuery="
             + urllib.parse.quote(challenge["name"]),
             tooltype=defs.ToolTypes.Training,
             tags=[challenge["category"]],


### PR DESCRIPTION
Since v16.x the new Score Board with its generic `searchQuery=` parameter is available and the default in Juice Shop. While `challenge=` is still working as an alias for now, it will likely be removed in release v17.x. See here for new syntax: https://pwning.owasp-juice.shop/companion-guide/latest/part4/integration.html#_generating_links_to_juice_shop