### PR TITLE
Issue 492: Style update for the explorer

### DIFF
--- a/application/frontend/src/pages/Explorer/explorer.scss
+++ b/application/frontend/src/pages/Explorer/explorer.scss
@@ -1,3 +1,72 @@
+main#explorer-content {
+  padding: 20px 40px;
+
+  .search-field {
+    input {
+      font-size: 16px;
+      height: 32px;
+      width: 320px;
+      margin-bottom: 10px;
+      border-radius: 3px;
+      border: 1px solid #858585;
+      padding: 0 5px;
+    }
+  }
+
+  #graphs-menu {
+    display: flex;
+    margin-bottom: 20px;
+    .menu-title {
+      margin: 0;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      font-size: 15px;
+    }
+    li {
+      padding: 0 8px;
+      +li {
+        border-left: 1px solid #b1b0b0;
+      }
+    }
+  }
+
+  .list {
+    padding: 0;
+  }
+
+  .item {
+    border-top: 1px dotted lightgrey;
+    border-left: 6px solid lightgrey;
+    margin: 4px 4px 4px 40px;
+    background-color: rgba(200, 200, 200, 0.2);
+    vertical-align: middle;
+
+    .header {
+      margin-left: 5px;
+      overflow: hidden;
+      white-space: nowrap;
+
+      a {
+        font-size: 120%;
+        line-height: 30px;
+        font-weight: bold;
+      }
+    }
+  }
+
+  .highlight {
+    background-color: yellow;
+  }
+
+  > .list > .item {
+    margin-left: 0;
+  }
+}
+
 // #explorer-content {
 //   font-family: Vollkorn, Ubuntu, Optima, Segoe, Segoe UI, Candara, Calibri, Arial, sans-serif;
 //   margin: 40px;

--- a/application/frontend/src/pages/Explorer/explorer.tsx
+++ b/application/frontend/src/pages/Explorer/explorer.tsx
@@ -14,7 +14,7 @@ export const Explorer = () => {
   const [filteredTree, setFilteredTree] = useState<TreeDocument[]>();
   const applyHighlight = (text, term) => {
     if (!term) return text;
-    var index = text.toLowerCase().indexOf(term);
+    let index = text.toLowerCase().indexOf(term);
     if (index >= 0) {
       return (
         <>
@@ -69,7 +69,6 @@ export const Explorer = () => {
     const linkedTo = item.links.filter((x) => x.ltype === 'Linked To');
     return (
       <List.Item key={Math.random()}>
-        <List.Icon name="folder" />
         <List.Content>
           <List.Header>
             <Link to={item.url}>{applyHighlight(item.displayName, filter)}</Link>
@@ -100,44 +99,39 @@ export const Explorer = () => {
 
   return (
     <>
-      <div id="explorer-content">
-        <h1>
-          <b>Explorer</b>
-        </h1>
+      <main id="explorer-content">
+        <h1>Open CRE Explorer</h1>
         <p>
           A visual explorer of Open Common Requirement Enumerations (CREs). Originally created by:{' '}
           <a target="_blank" href="https://zeljkoobrenovic.github.io/opencre-explorer/">
             Zeljko Obrenovic
-          </a>
-          .
+          </a>.
         </p>
 
         <div id="explorer-wrapper">
-          <div>
-            <input id="filter" type="text" placeholder="search..." onKeyUp={update} />
+          <div className='search-field'>
+            <input id="filter" type="text" placeholder="Search..." onKeyUp={update} />
             <div id="search-summary"></div>
           </div>
-          <div id="graphs">
-            graphs (3D):
-            <a target="_blank" href="force_graph">
-              CRE dependencies
-            </a>{' '}
-            -
+          <div id="graphs-menu">
+            <h4 className='menu-title'>Explore visually:</h4>
+            <ul>
+              <li>
+                <a target="_blank" href="force_graph">Dependency Graph</a>
+              </li>
+              <li>
+                <a target="_blank" href="circles">Zoomable circles</a>
+              </li>
+            </ul>
             {/* <a target="_blank" href="visuals/force-graph-3d-contains.html">
               hierarchy only
-            </a>{' '}
-            -
+            </a>
             <a target="_blank" href="visuals/force-graph-3d-related.html">
               related only
-            </a>{' '}
-            |
+            </a>
             <a target="_blank" href="visuals/force-graph-3d-linked.html">
               links to external standards
-            </a>{' '} */}
-            |
-            <a target="_blank" href="circles">
-              zoomable circles
-            </a>
+            </a>*/}
           </div>
         </div>
         <LoadingAndErrorIndicator loading={dataLoading} error={null} />
@@ -146,7 +140,7 @@ export const Explorer = () => {
             return processNode(item);
           })}
         </List>
-      </div>
+      </main>
     </>
   );
 };

--- a/application/frontend/src/pages/Explorer/explorer.tsx
+++ b/application/frontend/src/pages/Explorer/explorer.tsx
@@ -117,10 +117,10 @@ export const Explorer = () => {
             <h4 className='menu-title'>Explore visually:</h4>
             <ul>
               <li>
-                <a target="_blank" href="force_graph">Dependency Graph</a>
+                <a href="/explorer/force_graph">Dependency Graph</a>
               </li>
               <li>
-                <a target="_blank" href="circles">Zoomable circles</a>
+                <a href="/explorer/circles">Zoomable circles</a>
               </li>
             </ul>
             {/* <a target="_blank" href="visuals/force-graph-3d-contains.html">


### PR DESCRIPTION
Closes https://github.com/OWASP/OpenCRE/issues/492

This PR contains a style change to make /explorer look like the original https://zeljkoobrenovic.github.io/opencre-explorer/:

Updated style:
![Screenshot from 2024-04-19 16-04-31](https://github.com/OWASP/OpenCRE/assets/8710269/b692a337-a4f3-4e12-bf3d-005467ecf0b5)
