### PR TITLE
Feature/502 Update the header and main navigation

### DIFF
--- a/application/frontend/src/hooks/useLocationFromOutsideRoute.tsx
+++ b/application/frontend/src/hooks/useLocationFromOutsideRoute.tsx
@@ -6,7 +6,7 @@ import { ROUTES } from '../routes';
 interface UseLocationFromOutsideRouteReturn {
   params: Record<string, string>;
   url: string;
-  showHeader: boolean;
+  showHeaderSearch: boolean;
   showFilter: boolean;
 }
 
@@ -14,15 +14,15 @@ export const useLocationFromOutsideRoute = (): UseLocationFromOutsideRouteReturn
   // The current URL
   const { pathname } = useLocation();
   // The current ROUTE, from our URL
-  const currentRoute = ROUTES.map(({ path, showHeader, showFilter }) => ({
+  const currentRoute = ROUTES.map(({ path, showHeaderSearch, showFilter }) => ({
     ...matchPath(pathname, path),
-    showHeader,
+    showHeaderSearch,
     showFilter,
   })).find((matchedPath) => matchedPath?.isExact);
   return {
     params: currentRoute?.params || {},
     url: currentRoute?.url || '',
-    showHeader: currentRoute?.showHeader || false,
+    showHeaderSearch: currentRoute?.showHeaderSearch || false,
     showFilter: currentRoute?.showFilter || false,
   };
 };

--- a/application/frontend/src/hooks/useLocationFromOutsideRoute.tsx
+++ b/application/frontend/src/hooks/useLocationFromOutsideRoute.tsx
@@ -6,7 +6,6 @@ import { ROUTES } from '../routes';
 interface UseLocationFromOutsideRouteReturn {
   params: Record<string, string>;
   url: string;
-  showHeaderSearch: boolean;
   showFilter: boolean;
 }
 
@@ -14,15 +13,13 @@ export const useLocationFromOutsideRoute = (): UseLocationFromOutsideRouteReturn
   // The current URL
   const { pathname } = useLocation();
   // The current ROUTE, from our URL
-  const currentRoute = ROUTES.map(({ path, showHeaderSearch, showFilter }) => ({
+  const currentRoute = ROUTES.map(({ path, showFilter }) => ({
     ...matchPath(pathname, path),
-    showHeaderSearch,
     showFilter,
   })).find((matchedPath) => matchedPath?.isExact);
   return {
     params: currentRoute?.params || {},
     url: currentRoute?.url || '',
-    showHeaderSearch: currentRoute?.showHeaderSearch || false,
     showFilter: currentRoute?.showFilter || false,
   };
 };

--- a/application/frontend/src/pages/BrowseRootCres/browseRootCres.scss
+++ b/application/frontend/src/pages/BrowseRootCres/browseRootCres.scss
@@ -1,7 +1,5 @@
 .cre-page {
-  padding-left: 20px;
-  padding-right: 20px;
-  padding-bottom: 20px;
+  padding: 30px;
 
   &__links-container {
     margin-top: 10px;

--- a/application/frontend/src/pages/BrowseRootCres/browseRootCres.tsx
+++ b/application/frontend/src/pages/BrowseRootCres/browseRootCres.tsx
@@ -41,7 +41,7 @@ export const BrowseRootCres = () => {
   }, []);
   return (
     <div className="cre-page">
-      <h1 className="standard-page__heading">Root CREs:</h1>
+      <h1 className="standard-page__heading">Root CREs</h1>
       <LoadingAndErrorIndicator loading={loading} error={error} />
       {!loading && !error && (
         <div className="ui grid">

--- a/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
+++ b/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
@@ -224,8 +224,9 @@ export const GapAnalysis = () => {
   );
 
   return (
-    <div style={{ margin: '0 auto', maxWidth: '95vw' }}>
-      <Table celled padded compact style={{ margin: '5px' }}>
+    <div style={{ padding: '30px' }}>
+      <h1 className="standard-page__heading">Map Analysis</h1>
+      <Table celled padded compact>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>

--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -8,17 +8,21 @@ import { SearchBody } from './components/BodyText';
 export const Search = () => {
   return (
     <div className="search-page">
-      <Header as="h1" className="search-page__heading">
-        Open Common Requirement Enumeration
-      </Header>
+      <div className="home-hero">
+        <div className="hero-container">
+          <Header as="h1" className="search-page__heading">
+            Open Common Requirement Enumeration
+          </Header>
 
-      <Header as="h4" className="search-page__sub-heading">
-        Your gateway to security topics
-      </Header>
-      <div>
-        <Button primary fluid href="/root_cres">
-          Browse Topics
-        </Button>
+          <Header as="h4" className="search-page__sub-heading">
+            Your gateway to security topics
+          </Header>
+          <div>
+            <Button primary fluid href="/root_cres" className="browse-button">
+              Browse Topics
+            </Button>
+          </div>
+        </div>
       </div>
       <SearchBody />
     </div>

--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { Button, Header } from 'semantic-ui-react';
 
 import { SearchBody } from './components/BodyText';
-import { SearchBar } from './components/SearchBar';
 
 export const Search = () => {
   return (
@@ -17,8 +16,6 @@ export const Search = () => {
         Your gateway to security topics
       </Header>
       <div>
-        <SearchBar />
-        <div className='or-line'>OR</div>
         <Button primary fluid href="/root_cres">
           Browse Topics
         </Button>

--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -18,6 +18,7 @@ export const Search = () => {
       </Header>
       <div>
         <SearchBar />
+        <div className='or-line'>OR</div>
         <Button primary fluid href="/root_cres">
           Browse Topics
         </Button>

--- a/application/frontend/src/pages/Search/components/BodyText.tsx
+++ b/application/frontend/src/pages/Search/components/BodyText.tsx
@@ -8,53 +8,30 @@ export const SearchBody = () => {
       <h1>OpenCRE</h1>
       <p>
         <strong>
-          OpenCRE is the interactive content linking platform for uniting security standards and guidelines
-          into one overview. It offers easy and robust access to relevant information when designing,
-          developing, testing, procuring and organising secure software.
+          The OWASP Open Source project “OpenCRE “ links all security standards and guidelines together at the level of requirements into one harmonized resource:
+threats, weaknesses, what to verify, how to program, how to test,  which tool settings,  in-depth discussion,  training material. Everything organized.
         </strong>
       </p>
+      <h2>Examples of use:</h2>
       <p>
-        <strong>
-          Use the search bar or <a href="/root_cres">browse the catalogue of all top-level topics</a>, try
-          <a href="/node/standard/OWASP%20Top%2010%202021"> the Top10 2021 page</a> and click around, or{' '}
-          <a href="/search/session">search for "Session"</a>, or check out{' '}
-          <a href="/cre/764-507"> CRE 764-507 </a> or <a href="/cre/581-525">CRE 581-525</a> to see the{' '}
-          <b>Multilink</b>
-          feature: one link to OpenCRE gives access to a wide range of standards and related topics: testing
-          advice, development, in-depth technical information, threat descriptions, articles, and tool
-          settings.
-        </strong>
+        <ul>
+      
+          <li><a href="/cre/764-507">CRE 764-507 </a>: the central ‘multilink’ feature of OpenCRE - one link to a common requirement shows its coverage in all the resources plus related requirements</li>
+          <li><a href="/cre/581-525">CRE 581-525</a></li>
+          <li><a href="/chatbot">OpenCRE Chat</a> to ask any security question. In collaboration with Google, we injected all the standards in OpenCRE into an AI model to create the world's first security-specialized chatbot. It provides a more reliable answer, and also a reference to the relevant standard text.</li>
+          <li><a href="/map_analysis">Map Analysis</a> to find how any two standards connect with eachother</li>     
+          <li><a href="/smartlink/standard/CWE/611">www.opencre.org/smartlink/standard/CWE/611</a>: the ‘smartlink’ feature which uses an existing standard to link to related information</li>
+          <li><a href="/node/standard/OWASP%20Top%2010%202021">OWASP Top 10 2021</a></li>
+          <li><a href="/root_cres">Browse</a> to explore our catalog (semantic web) of common requirements across development processes, technical controls, etc.</li>
+          <li><a href="https://zeljkoobrenovic.github.io/opencre-explorer/">Explore</a> our catalog in one list</li>
+          <li><a href="https://zeljkoobrenovic.github.io/opencre-explorer/visuals/force-graph-3d-contains.html">Fly</a> through our catalog in 3D</li>
+        </ul>         
+        
       </p>
+      <h2>How it works:</h2>
       <p>
-        <strong>
-          Use <a href="/chatbot">OpenCRE Chat</a> to ask any security question (Google account required to
-          maximize queries per minute). In collaboration with Google, we injected all the standards in OpenCRE
-          into an AI model to create the world's first security-specialized chatbot. This ensures you get a
-          more reliable answer, and also a reference to a reputable source.
-        </strong>
+        OpenCRE links each section of a resource to the corresponding’Common Requirement’, causing that section to also link with all other resources that link to the same requirement. This 1) enables users to find all relevant information, 2) facilitates a shared and better understanding of cyber security, and 3) allows standard makers to have links that keep working and offer all the information that readers need, alleviating their need to cover everything themselves. OpenCRE maintains itself: links to OpenCRE in the standard text are scanned automatically. 
       </p>
-      <p>
-        <strong>
-          Use <a href="/map_analysis">Map Analysis</a> to find how any two standards connect with eachother
-        </strong>
-      </p>
-      <h2>HOW?</h2>
-      <p>
-        OpenCRE links each section of a resource (like a standard or guideline) to a shared topic, known as a
-        Common Requirement, causing that section to also link with all other resources that link to the same
-        topic. This 1) enables users to find all combined information from relevant sources, 2) facilitates a
-        shared and better understanding of cyber security, and 3) allows standard makers to have links that
-        keep working and offer all the information that readers need, alleviating their need to cover
-        everything themselves. OpenCRE maintains itself: links to OpenCRE in the standard text are scanned
-        automatically. Furthermore, topics are linked with related other topics, creating a semantic web for
-        security to explore.
-      </p>
-      <p>
-        An easy way to link to OpenCRE topics, is to use a familiar standard. For example, using CWE to link
-        to OpenCRE content on the topic of XXE injection:
-        <a href="/smartlink/standard/CWE/611">www.opencre.org/smartlink/standard/CWE/611</a>.
-      </p>
-      <h2>WHO?</h2>
       <p>
         OpenCRE is the brainchild of software security professionals Spyros Gasteratos and Rob van der Veer,
         who joined forces to tackle the complexities and segmentation in current security standards and
@@ -64,13 +41,7 @@ export const SearchBody = () => {
         . The goal is to foster better coordination among security initiatives.
       </p>
       <p>
-        OpenCRE currently links OWASP standards (Top 10, ASVS, Proactive Controls, Cheat sheets, Testing
-        guide, ZAP, Juice shop, SAMM), plus several other sources (CWE, CAPEC, NIST-800 53, NIST-800 63b,
-        Cloud Control Matrix, ISO27001, ISO27002, and NIST SSDF).
-      </p>
-      <p>
-        Contact us via (rob.vanderveer [at] owasp.org) for any questions, remarks or to join the movement.
-        Currently, a stakeholder group is being formed.
+        The ever-growing list of resources: OWASP standards (Top 10, ASVS, Proactive Controls, Cheat sheets, Testing guide, ZAP, Juice shop, SAMM), plus several other sources (CWE, CAPEC, NIST-800 53, NIST-800 63b, Cloud Control Matrix, ISO27002, and NIST SSDF).
       </p>
       <p>
         For more details, see this
@@ -81,12 +52,8 @@ export const SearchBody = () => {
         </a>
         , follow our
         <a href="https://www.linkedin.com/company/96695329"> LinkedIn page </a>, click the diagram below, or{' '}
-        <a href="https://zeljkoobrenovic.github.io/opencre-explorer/">
-          browse our catalogue textually or graphically
-        </a>
-        .
+        contact project leaders Rob van der Veer and Spyros Gasteratos via (rob.vanderveer [at] owasp.org) . 
       </p>
-
       <a href="/opencregraphic2.png" target="_blank">
         <img className="align-middle mx-auto " src="/tn_opencregraphic2.jpg" alt="Diagram" />
       </a>

--- a/application/frontend/src/pages/Search/components/SearchBar.scss
+++ b/application/frontend/src/pages/Search/components/SearchBar.scss
@@ -1,9 +1,9 @@
 #SearchBar {
   margin: auto;
-  padding-bottom: 7px;
+  padding: 0;
 }
 
 #SearchButton{
   margin: auto;
-  padding-bottom: 7px;
+  padding: 0;
 }

--- a/application/frontend/src/pages/Search/components/SearchBar.scss
+++ b/application/frontend/src/pages/Search/components/SearchBar.scss
@@ -3,7 +3,7 @@
   padding: 0;
 }
 
-#SearchButton{
+#SearchButton {
   margin: auto;
   padding: 0;
 }

--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   padding-top: 40px;
   padding-bottom: 40px;
-  min-height: 100%;
+  min-height: calc(100% - 104px);
 
   .search-page__heading {
     text-align: center;
@@ -22,6 +22,24 @@
     margin-top: 0px;
     margin-bottom: 30px;
     color: #eee;
+  }
+
+  .or-line {
+    color: white;
+    margin: 16px 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &::before,
+    &::after {
+      content: '';
+      display: block;
+      width: 60px;
+      height: 1px;
+      background-color: #8596a9;
+      margin: 0 4px;
+    }
   }
 }
 

--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -1,14 +1,26 @@
-
 .search-page {
-  background-color: #242e4c;
   display: flex;
   align-items: center;
   flex-direction: column;
   justify-content: center;
-  padding-top: 40px;
-  padding-bottom: 40px;
-  min-height: calc(100% - 104px);
+  padding: 0 0 40px;
 
+  .home-hero {
+    padding: 60px 0;
+    background-color: #2e3b61;
+    width: 100%;
+    .hero-container {
+      width: 70%;
+      margin: 0 auto;
+    }
+    .search-page__sub-heading {
+      text-align: center;
+    }
+    .browse-button {
+      max-width: 200px;
+      margin: 0 auto;
+    }
+  }
   .search-page__heading {
     text-align: center;
   }

--- a/application/frontend/src/routes.tsx
+++ b/application/frontend/src/routes.tsx
@@ -26,7 +26,6 @@ import { StandardSection } from './pages/Standard/StandardSection';
 export interface IRoute {
   path: string;
   component: ReactNode | ReactNode[];
-  showHeaderSearch: boolean;
   showFilter: boolean;
 }
 
@@ -35,84 +34,70 @@ export const ROUTES: IRoute[] = [
     path: INDEX,
     component: Search,
     showFilter: false,
-    showHeaderSearch: false,
   },
   {
     path: GAP_ANALYSIS,
     component: GapAnalysis,
-    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `/node${STANDARD}/:id${SECTION}/:section`,
     component: StandardSection,
-    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `/node${STANDARD}/:id${SECTION_ID}/:sectionID`,
     component: StandardSection,
-    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `/node/:type/:id`,
     component: Standard,
-    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `${CRE}/:id`,
     component: CommonRequirementEnumeration,
-    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `${GRAPH}/:id`,
     component: Graph,
-    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${SEARCH}/:searchTerm`,
     component: SearchName,
-    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `/chatbot`,
     component: Chatbot,
-    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: '/members_required',
     component: MembershipRequired,
-    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${BROWSEROOT}`,
     component: BrowseRootCres,
-    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${EXPLORER}/circles`,
     component: ExplorerCircles,
-    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${EXPLORER}/force_graph`,
     component: ExplorerForceGraph,
-    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${EXPLORER}`,
     component: Explorer,
-    showHeaderSearch: true,
     showFilter: false,
   },
 ];

--- a/application/frontend/src/routes.tsx
+++ b/application/frontend/src/routes.tsx
@@ -26,7 +26,7 @@ import { StandardSection } from './pages/Standard/StandardSection';
 export interface IRoute {
   path: string;
   component: ReactNode | ReactNode[];
-  showHeader: boolean;
+  showHeaderSearch: boolean;
   showFilter: boolean;
 }
 
@@ -35,84 +35,84 @@ export const ROUTES: IRoute[] = [
     path: INDEX,
     component: Search,
     showFilter: false,
-    showHeader: false,
+    showHeaderSearch: false,
   },
   {
     path: GAP_ANALYSIS,
     component: GapAnalysis,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `/node${STANDARD}/:id${SECTION}/:section`,
     component: StandardSection,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `/node${STANDARD}/:id${SECTION_ID}/:sectionID`,
     component: StandardSection,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `/node/:type/:id`,
     component: Standard,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `${CRE}/:id`,
     component: CommonRequirementEnumeration,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `${GRAPH}/:id`,
     component: Graph,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${SEARCH}/:searchTerm`,
     component: SearchName,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: true,
   },
   {
     path: `/chatbot`,
     component: Chatbot,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: '/members_required',
     component: MembershipRequired,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${BROWSEROOT}`,
     component: BrowseRootCres,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${EXPLORER}/circles`,
     component: ExplorerCircles,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${EXPLORER}/force_graph`,
     component: ExplorerForceGraph,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
   {
     path: `${EXPLORER}`,
     component: Explorer,
-    showHeader: true,
+    showHeaderSearch: true,
     showFilter: false,
   },
 ];

--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -37,15 +37,15 @@ export const Header = () => {
 
   const history = useHistory();
 
-  const { params, url, showHeaderSearch, showFilter } = useLocationFromOutsideRoute();
+  const { params, url, showFilter } = useLocationFromOutsideRoute();
   // console.log(useLocationFromOutsideRoute())
   const links = useMemo(() => getLinks(), [params]);
 
   return (
     <nav className="header">
       <Menu className="header__nav-bar" secondary>
-        <Link to='/' className="header__nav-bar-logo">
-          <img alt='Open CRE' src='/logo.png'/>
+        <Link to="/" className="header__nav-bar-logo">
+          <img alt="Open CRE" src="/logo.png" />
         </Link>
         <Menu.Menu position="left">
           {links.map(({ to, name }) => (
@@ -54,14 +54,13 @@ export const Header = () => {
               className={`header__nav-bar__link ${url === to ? 'header__nav-bar__link--active' : ''}`}
               to={to}
             >
-              <Menu.Item as="span" onClick={() => {
-              }}>
+              <Menu.Item as="span" onClick={() => {}}>
                 {name}
               </Menu.Item>
             </Link>
           ))}
         </Menu.Menu>
-        {showHeaderSearch && <Menu.Menu position="right">
+        <Menu.Menu position="right">
           <Menu.Item>
             <SearchBar />
 
@@ -79,7 +78,7 @@ export const Header = () => {
               ''
             )}
           </Menu.Item>
-        </Menu.Menu>}
+        </Menu.Menu>
       </Menu>
     </nav>
   );

--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -45,7 +45,8 @@ export const Header = () => {
     <nav className="header">
       <Menu className="header__nav-bar" secondary>
         <Link to="/" className="header__nav-bar-logo">
-          <img alt="Open CRE" src="/logo.png" />
+          <img alt="Open CRE" src="/logo2.svg" />
+          <h1>OpenCRE</h1>
         </Link>
         <Menu.Menu position="left">
           {links.map(({ to, name }) => (

--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -1,6 +1,6 @@
 import './header.scss';
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { Button, Menu } from 'semantic-ui-react';
 
@@ -11,7 +11,7 @@ import { SearchBar } from '../../pages/Search/components/SearchBar';
 const getLinks = (): { to: string; name: string }[] => [
   {
     to: `/`,
-    name: 'Open CRE',
+    name: 'Home',
   },
   {
     to: `/root_cres`,
@@ -23,7 +23,7 @@ const getLinks = (): { to: string; name: string }[] => [
   },
   {
     to: `/map_analysis`,
-    name: 'Map analysis',
+    name: 'Map Analysis',
   },
 ];
 
@@ -33,34 +33,35 @@ export const Header = () => {
   const HandleDoFilter = () => {
     currentUrlParams.set('applyFilters', 'true');
     history.push(window.location.pathname + '?' + currentUrlParams.toString());
-    window.location.href = window.location.href;
   };
 
   const history = useHistory();
 
-  const { params, url, showHeader, showFilter } = useLocationFromOutsideRoute();
+  const { params, url, showHeaderSearch, showFilter } = useLocationFromOutsideRoute();
   // console.log(useLocationFromOutsideRoute())
   const links = useMemo(() => getLinks(), [params]);
 
-  if (!showHeader) {
-    return null;
-  }
-
   return (
-    <div className="header">
+    <nav className="header">
       <Menu className="header__nav-bar" secondary>
-        {links.map(({ to, name }) => (
-          <Link
-            key={name}
-            className={`header__nav-bar__link ${url === to || true ? 'header__nav-bar__link--active' : ''}`}
-            to={to}
-          >
-            <Menu.Item as="span" onClick={() => {}}>
-              {name}
-            </Menu.Item>
-          </Link>
-        ))}
-        <Menu.Menu position="right">
+        <Link to='/' className="header__nav-bar-logo">
+          <img alt='Open CRE' src='/logo.png'/>
+        </Link>
+        <Menu.Menu position="left">
+          {links.map(({ to, name }) => (
+            <Link
+              key={name}
+              className={`header__nav-bar__link ${url === to ? 'header__nav-bar__link--active' : ''}`}
+              to={to}
+            >
+              <Menu.Item as="span" onClick={() => {
+              }}>
+                {name}
+              </Menu.Item>
+            </Link>
+          ))}
+        </Menu.Menu>
+        {showHeaderSearch && <Menu.Menu position="right">
           <Menu.Item>
             <SearchBar />
 
@@ -78,8 +79,8 @@ export const Header = () => {
               ''
             )}
           </Menu.Item>
-        </Menu.Menu>
+        </Menu.Menu>}
       </Menu>
-    </div>
+    </nav>
   );
 };

--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -14,6 +14,10 @@ const getLinks = (): { to: string; name: string }[] => [
     name: 'Open CRE',
   },
   {
+    to: `/root_cres`,
+    name: 'Browse',
+  },
+  {
     to: `/chatbot`,
     name: 'OpenCRE Chat',
   },

--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -1,12 +1,19 @@
 .header__nav-bar {
   padding: 0 10px;
   &.ui.secondary.menu {
-    margin-top: 0px;
-    border-bottom: none;
-    background-color: #242e4c;
-    margin-bottom: 20px;
-    padding-left: 20px;
+    margin: 0;
+    padding: 0 30px;
+    background: white;
+    border-bottom: 1px solid #ccc;
 
+    .header__nav-bar-logo {
+      padding: 20px 0;
+      margin-right: 30px;
+
+      img {
+        max-width: 100px;
+      }
+    }
     .item {
       .ui.form {
         .fields {
@@ -14,56 +21,62 @@
         }
       }
     }
-  }
 
-  &__link {
-    padding-top: 10px;
-    padding-bottom: 10px;
-    text-align: center;
-    margin: 0 2px;
+    .header__nav-bar__link {
+      padding-top: 10px;
+      padding-bottom: 10px;
+      text-align: center;
+      margin: 0 2px;
 
-    .item {
-      color: white !important;
-      width: 100%;
-      height: 100%;
-    }
+      .item {
+        width: 100%;
+        height: 100%;
+      }
+      &:hover:not(.header__nav-bar__link--active) .item {
+        text-decoration: underline;
+      }
+      &--active {
+        transition: all 0.2s ease;
 
-    .visible.menu.transition {
-      margin-top: 10px !important;
-      border-radius: 0px !important;
-      border: none !important;
-      left: -5px !important;
-    }
-  }
-
-  &__link:hover,
-  &__link--active {
-    background-color: white !important;
-    transition: all 0.2s ease;
-
-    .item {
-      color: #242e4c !important;
-      transition: all 0.2s ease;
-      border-radius: 0 !important;
-      background-color: transparent !important;
+        .item {
+          font-weight: bold;
+          transition: all 0.2s ease;
+          border-radius: 0 !important;
+          background-color: transparent !important;
+        }
+      }
     }
   }
 }
 
+nav + * {
+  padding-top: 30px;
+}
+
 
 // mobile
-@media (min-width: 0px) and (max-width: 599px) {
-
-  .ui.menu:not(.vertical) .right.menu {
-    display: block;
-  }
-
+@media (min-width: 0px) and (max-width: 799px) {
   .header__nav-bar {
     flex-wrap: wrap;
-
+    .right.menu {
+      display: block;
+    }
     &__link {
       padding-top: 0;
       padding-bottom: 0;
+    }
+  }
+}
+
+@media (min-width: 0px) and (max-width: 520px) {
+  .header__nav-bar {
+    justify-content: center;
+
+    &.ui.menu:not(.vertical) .right.menu {
+      display: flex;
+      justify-content: center;
+      width: 100%;
+      margin-left: unset !important;
     }
   }
 }

--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -1,20 +1,32 @@
 .header__nav-bar {
   padding: 0 10px;
+
   &.ui.secondary.menu {
     margin: 0;
     padding: 0 30px;
-    background: white;
-    border-bottom: 1px solid #ccc;
+    background-color: #242e4c;
 
     .header__nav-bar-logo {
       padding: 20px 0;
       margin-right: 30px;
+      display: flex;
+      align-items: center;
 
       img {
         max-width: 100px;
+        max-height: 30px;
+      }
+
+      h1 {
+        display: inline;
+        margin: 0 10px;
+        color: white;
+        font-size: 20px;
       }
     }
     .item {
+      color: white;
+      font-size: 14px;
       .ui.form {
         .fields {
           margin-bottom: 0px !important;
@@ -53,7 +65,6 @@ nav + * {
   padding-top: 30px;
 }
 
-
 // mobile
 @media (min-width: 0px) and (max-width: 799px) {
   .header__nav-bar {
@@ -80,4 +91,3 @@ nav + * {
     }
   }
 }
-


### PR DESCRIPTION
[Ticket](https://github.com/OWASP/OpenCRE/issues/502)
This PR updates the style and content of the main navigation.

**Changes**:
- add a new main nav link: "Browse"
- style the header and show it on the home page too. Remove the search from the header only on the home page, to avoid duplication.
- add "OR" to the homepage to separate Browse from Search
- adjust page titles (Root CREs and Map Analysis)
- tweak the margins and padding on the pages, so they align with the logo nicely
- Style the header for mobile

**Screenshots**
#### Map Analysis page
![Screenshot from 2024-05-03 18-50-47](https://github.com/OWASP/OpenCRE/assets/8710269/483cb6c3-68ca-4305-852f-7d62e2fb36e9)

#### Browse page
![Screenshot from 2024-05-03 18-50-37](https://github.com/OWASP/OpenCRE/assets/8710269/8eadae69-068a-468a-824e-91a5cab22bad)

#### Home page
![Screenshot from 2024-05-03 18-50-28](https://github.com/OWASP/OpenCRE/assets/8710269/7a891acc-ff0d-4ea5-a06c-8043867ed822)
