### PR TITLE
[ticket-508] Ensure autolinks appear on the CRE page

### DIFF
--- a/application/frontend/src/utils/document.ts
+++ b/application/frontend/src/utils/document.ts
@@ -32,7 +32,7 @@ export const groupLinksByType = (node: Document): LinksByType =>
   node.links ? groupBy(node.links, (link) => link.ltype) : {};
 
 export const orderLinksByType = (lbt: LinksByType): LinksByType => {
-  const order = ['Contains', 'Linked To', 'SAME', 'SAM', 'Is Part Of', 'Related'];
+  const order = ['Contains', 'Linked To', 'Automatically linked to', 'SAME', 'SAM', 'Is Part Of', 'Related'];
   const res: LinksByType = {};
   for (const itm of order) {
     if (lbt[itm]) {


### PR DESCRIPTION
[Ticket](https://github.com/OWASP/OpenCRE/issues/508)
This is a tiny bugfix to ensure that links of type "Autolinked To" show on the CRE details page:
![Screenshot from 2024-05-21 13-05-19](https://github.com/OWASP/OpenCRE/assets/8710269/4913d0bc-eafd-469a-ab47-379a3f9c6e85)
