### PR TITLE
[507] UI-only: Link standard tags in /explorer directly to the right entries for the CRE

### DIFF
--- a/application/frontend/src/components/FilterButton/FilterButton.tsx
+++ b/application/frontend/src/components/FilterButton/FilterButton.tsx
@@ -1,13 +1,8 @@
-import axios from 'axios';
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import React, { FunctionComponent, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Button } from 'semantic-ui-react';
 
-import { useEnvironment } from '../../hooks';
-import { Document, LinkedDocument } from '../../types';
-import { getDocumentDisplayName, groupLinksByType } from '../../utils';
-import { getApiEndpoint, getInternalUrl } from '../../utils/document';
-import { LoadingAndErrorIndicator } from '../LoadingAndErrorIndicator';
+import { Document } from '../../types';
 
 export interface FilterButton {
   document: Document;

--- a/application/frontend/src/hooks/applyFilters.tsx
+++ b/application/frontend/src/hooks/applyFilters.tsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-import { DocumentNode } from '../components/DocumentNode';
+import { TYPE_LINKED_TO } from '../const';
 import { Document, LinkedDocument } from '../types';
 
 const filterLinks = (document: Document, filters: string[]): Document | undefined => {
@@ -47,6 +47,11 @@ export const applyFilters = (node: Document): Document => {
       filteredNodes.push(newDocNode);
     }
   });
+
+  //filter by sources specifically (for Standards links in the /explorer page)
+  if (filters.some((filter) => filter === 'sources')) {
+    filteredNodes = filteredNodes.filter((node) => node.ltype === TYPE_LINKED_TO);
+  }
   node.links = filteredNodes;
   return node;
 };

--- a/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
+++ b/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
@@ -72,7 +72,7 @@ export const CommonRequirementEnumeration = () => {
 
           {currentUrlParams.get('applyFilters') === 'true' ? (
             <div className="cre-page__filters">
-              Filtering on:
+              Filtering on:{' '}
               {currentUrlParams.getAll('filters').map((filter) => (
                 <b key={filter}>{filter.replace('s:', '').replace('c:', '')}, </b>
               ))}

--- a/application/frontend/src/pages/Explorer/LinkedStandards.scss
+++ b/application/frontend/src/pages/Explorer/LinkedStandards.scss
@@ -1,0 +1,19 @@
+main#explorer-content {
+  .tags {
+    display: flex;
+    gap: 4px;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+
+    .ui.label {
+      border: 1px solid #4183c4;
+      text-shadow: none;
+    }
+
+    a:hover .label {
+      background: #4183c4;
+      color: white;
+    }
+  }
+}

--- a/application/frontend/src/pages/Explorer/LinkedStandards.tsx
+++ b/application/frontend/src/pages/Explorer/LinkedStandards.tsx
@@ -1,0 +1,74 @@
+import './LinkedStandards.scss';
+
+import React, { Fragment } from 'react';
+import { Link } from 'react-router-dom';
+import { Icon, Label, List } from 'semantic-ui-react';
+
+import { LinkedTreeDocument } from '../../types';
+
+export const LinkedStandards = ({ creCode, linkedTo, applyHighlight, filter }) => {
+  /**
+   * Get a link to a filtered version of the CRE to show the relevant standards
+   */
+  function getLinkedToUrl(x: LinkedTreeDocument, creCode: string): string {
+    return `/cre/${creCode}?applyFilters=true&filters=${x.document.name}&filters=sources`;
+  }
+
+  /**
+   * Check if this linked document should point to an external address
+   * - whether it has other sub-standards with the same name
+   * - whether it contains a hyperlink
+   * @param x
+   * @param linkedTo
+   */
+  function isExternalLink(x: LinkedTreeDocument, linkedTo: any) {
+    if (!x.document.hyperlink) {
+      console.log(x.document);
+      return false;
+    }
+    const siblingCount = linkedTo.reduce((count, obj) => {
+      count += obj.document.name !== x.document.name ? 0 : 1;
+      return count;
+    }, 0);
+    return siblingCount <= 1;
+  }
+
+  /**
+   * Avoid repeating tags with the same name
+   * @param linkedTo
+   */
+  function getUniqueByName(linkedTo: any) {
+    const seen = new Set();
+    return linkedTo.filter((x) => {
+      const isDuplicate = seen.has(x.document.name);
+      seen.add(x.document.name);
+      return !isDuplicate;
+    });
+  }
+
+  const uniqueLinkedTo = getUniqueByName(linkedTo);
+
+  return (
+    <List.Description>
+      <Label.Group size="small" className="tags">
+        {uniqueLinkedTo.map((x: LinkedTreeDocument) => (
+          <Fragment key={x.document.name}>
+            {isExternalLink(x, linkedTo) && (
+              <a href={x.document.hyperlink} target="_blank">
+                <Label>
+                  <Icon name="external" />
+                  {applyHighlight(x.document.name, filter)}
+                </Label>
+              </a>
+            )}
+            {!isExternalLink(x, linkedTo) && (
+              <Link to={getLinkedToUrl(x, creCode)}>
+                <Label>{applyHighlight(x.document.name, filter)}</Label>
+              </Link>
+            )}
+          </Fragment>
+        ))}
+      </Label.Group>
+    </List.Description>
+  );
+};

--- a/application/frontend/src/pages/Explorer/explorer.scss
+++ b/application/frontend/src/pages/Explorer/explorer.scss
@@ -92,24 +92,6 @@ main#explorer-content {
     }
   }
 
-  .tags {
-    display: flex;
-    gap: 4px;
-    height: 100%;
-    justify-content: center;
-    align-items: center;
-
-    .ui.label {
-      border: 1px solid #4183c4;
-      text-shadow: none;
-    }
-
-    a:hover .label {
-      background: #4183c4;
-      color: white;
-    }
-  }
-
   .highlight {
     background-color: yellow;
   }

--- a/application/frontend/src/pages/Explorer/explorer.tsx
+++ b/application/frontend/src/pages/Explorer/explorer.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { Label, List } from 'semantic-ui-react';
 
 import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndicator';
+import { TYPE_CONTAINS, TYPE_LINKED_TO } from '../../const';
 import { useDataStore } from '../../providers/DataProvider';
 import { LinkedTreeDocument, TreeDocument } from '../../types';
 
@@ -74,12 +75,18 @@ export const Explorer = () => {
     }
   }, [filter, dataTree, setFilteredTree]);
 
+  /**
+   * Get a link to a filtered version of the CRE to show the relevant standards
+   */
+  function getLinkedToUrl(standardName: string, creCode: string): string {
+    return `/cre/${creCode}?applyFilters=true&filters=${standardName}&filters=sources`;
+  }
   function processNode(item) {
     if (!item) {
       return <></>;
     }
-    const contains = item.links.filter((x) => x.ltype === 'Contains');
-    const linkedTo = item.links.filter((x) => x.ltype === 'Linked To');
+    const contains = item.links.filter((x) => x.ltype === TYPE_CONTAINS);
+    const linkedTo = item.links.filter((x) => x.ltype === TYPE_LINKED_TO);
 
     const creCode = item.id;
     const creName = item.displayName.split(' : ').pop();
@@ -106,7 +113,7 @@ export const Explorer = () => {
                 {[...new Set(linkedTo.map((x: LinkedTreeDocument) => x.document.name))]
                   .sort()
                   .map((x: string) => (
-                    <Link key={Math.random()} to={`/node/standard/${x}`}>
+                    <Link key={Math.random()} to={getLinkedToUrl(x, creCode)}>
                       <Label>{applyHighlight(x, filter)}</Label>
                     </Link>
                   ))}

--- a/application/frontend/src/pages/Explorer/explorer.tsx
+++ b/application/frontend/src/pages/Explorer/explorer.tsx
@@ -2,12 +2,13 @@ import './explorer.scss';
 
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Label, List } from 'semantic-ui-react';
+import { List } from 'semantic-ui-react';
 
 import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndicator';
 import { TYPE_CONTAINS, TYPE_LINKED_TO } from '../../const';
 import { useDataStore } from '../../providers/DataProvider';
 import { LinkedTreeDocument, TreeDocument } from '../../types';
+import { LinkedStandards } from './LinkedStandards';
 
 export const Explorer = () => {
   const { dataLoading, dataTree } = useDataStore();
@@ -75,12 +76,6 @@ export const Explorer = () => {
     }
   }, [filter, dataTree, setFilteredTree]);
 
-  /**
-   * Get a link to a filtered version of the CRE to show the relevant standards
-   */
-  function getLinkedToUrl(standardName: string, creCode: string): string {
-    return `/cre/${creCode}?applyFilters=true&filters=${standardName}&filters=sources`;
-  }
   function processNode(item) {
     if (!item) {
       return <></>;
@@ -107,19 +102,12 @@ export const Explorer = () => {
               <span className="cre-name">{applyHighlight(creName, filter)}</span>
             </Link>
           </List.Header>
-          {linkedTo.length > 0 && (
-            <List.Description>
-              <Label.Group size="small" className="tags">
-                {[...new Set(linkedTo.map((x: LinkedTreeDocument) => x.document.name))]
-                  .sort()
-                  .map((x: string) => (
-                    <Link key={Math.random()} to={getLinkedToUrl(x, creCode)}>
-                      <Label>{applyHighlight(x, filter)}</Label>
-                    </Link>
-                  ))}
-              </Label.Group>
-            </List.Description>
-          )}
+          <LinkedStandards
+            linkedTo={linkedTo}
+            applyHighlight={applyHighlight}
+            creCode={creCode}
+            filter={filter}
+          />
           {contains.length > 0 && !isCollapsed(item.id) && (
             <List.List>{contains.map((child) => processNode(child.document))}</List.List>
           )}


### PR DESCRIPTION
[Ticket](https://github.com/OWASP/OpenCRE/issues/507)
This PR makes it so that the standards on the /explorer page now link to the filtered CRE page filtered by them.
For example:
1. A CRE has links to all of these standards: 
![Screenshot from 2024-06-08 18-19-23](https://github.com/OWASP/OpenCRE/assets/8710269/a43f3c28-cb93-42ad-80e5-1dc11af74959)
2. You click on NIST 
![Screenshot from 2024-06-08 18-20-41](https://github.com/OWASP/OpenCRE/assets/8710269/83e693c4-9a63-4f73-a1c8-3a42b4496732)
3. You get the CRE page showing the NIST sections that are related to that CRE: 
![Screenshot from 2024-05-26 21-57-47](https://github.com/OWASP/OpenCRE/assets/8710269/c0dc7121-63d1-4109-888f-34dca2228fa7)

4. If the link is to an ungrouped standard and has an external link, you would be linked directly to that page:
![Screenshot from 2024-06-08 18-20-00](https://github.com/OWASP/OpenCRE/assets/8710269/84b3599a-36d0-478b-9b6c-c321704c0a25)
![Screenshot from 2024-06-08 18-20-22](https://github.com/OWASP/OpenCRE/assets/8710269/ef6ebae9-0d35-4e94-b569-381c320b1a08)






 