### PR TITLE
Bugfix/514 :bug: Fix explorer incomplete

### DIFF
--- a/application/frontend/src/pages/Explorer/LinkedStandards.tsx
+++ b/application/frontend/src/pages/Explorer/LinkedStandards.tsx
@@ -23,7 +23,6 @@ export const LinkedStandards = ({ creCode, linkedTo, applyHighlight, filter }) =
    */
   function isExternalLink(x: LinkedTreeDocument, linkedTo: any) {
     if (!x.document.hyperlink) {
-      console.log(x.document);
       return false;
     }
     const siblingCount = linkedTo.reduce((count, obj) => {

--- a/application/frontend/src/pages/Explorer/explorer.tsx
+++ b/application/frontend/src/pages/Explorer/explorer.tsx
@@ -9,6 +9,8 @@ import { TYPE_CONTAINS, TYPE_LINKED_TO } from '../../const';
 import { useDataStore } from '../../providers/DataProvider';
 import { LinkedTreeDocument, TreeDocument } from '../../types';
 import { LinkedStandards } from './LinkedStandards';
+import { getDocumentDisplayName } from '../../utils';
+import { getInternalUrl } from '../../utils/document';
 
 export const Explorer = () => {
   const { dataLoading, dataTree } = useDataStore();
@@ -80,6 +82,10 @@ export const Explorer = () => {
     if (!item) {
       return <></>;
     }
+    item.displayName = item.displayName ?? getDocumentDisplayName(item);
+    item.url = item.url ?? getInternalUrl(item);
+    item.links = item.links ?? [];
+
     const contains = item.links.filter((x) => x.ltype === TYPE_CONTAINS);
     const linkedTo = item.links.filter((x) => x.ltype === TYPE_LINKED_TO);
 

--- a/application/frontend/src/providers/DataProvider.tsx
+++ b/application/frontend/src/providers/DataProvider.tsx
@@ -46,7 +46,9 @@ export const DataProvider = ({ children }: { children: React.ReactNode }) => {
     );
 
     if (!creLinks.length) {
-      storedDoc.links = [];
+      // leaves of the tree can be links that are included in the keyPath.
+      // If we don't add this here, the leaves are filtered out above (see ticket #514 on OpenCRE)
+      storedDoc.links = initialLinks.filter((x) => x.ltype === 'Contains' && !!x.document);
       return storedDoc;
     }
 


### PR DESCRIPTION
[Ticket](https://github.com/OWASP/OpenCRE/issues/514)

This PR ensures that all leaf CREs are also included in the explorer. Previously if a link was in the keypath of the tree traversal it was excluded. This is fine for nodes, but was causing a bug for leaves.

The fix apples to the /explorer and the Graph. They should now include all linked CREs:

![Screenshot from 2024-06-23 18-36-09](https://github.com/OWASP/OpenCRE/assets/8710269/8c863220-375a-441a-bccd-ccdc013b8eb4)
![Screenshot from 2024-06-23 18-35-37](https://github.com/OWASP/OpenCRE/assets/8710269/7c036edc-3008-4c71-94d2-cf2b381a8027)


