### PR TITLE
:wrench: Failing CI - add missing Python 'click' package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==24.4.2 # do not touch, same version as superlinter
+click
 compliance-trestle
 coverage
 dacite


### PR DESCRIPTION
The CI run was failing [here](https://github.com/OWASP/OpenCRE/actions/runs/10183980036/job/28170207299?pr=542) because of missing Python click package. This PR adds it. That doesn't resolve the issue, I'll investigate further