### PR TITLE
fix bug 552 by ensuring that ALL db cre links are from Higher->Lower …

### DIFF
--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -68,23 +68,23 @@ def register_node(node: defs.Node, collection: db.Node_collection) -> db.Node:
             db_link = collection.add_node(link.document)
             if cres:
                 for cre in cres:
-                    collection.add_link(cre=cre, node=linked_node, type=link.ltype)
+                    collection.add_link(cre=cre, node=linked_node, ltype=link.ltype)
                     for unlinked_standard in cre_less_nodes:  # if anything in this
                         collection.add_link(
                             cre=cre,
                             node=db.dbNodeFromNode(unlinked_standard),
-                            type=link.ltype,
+                            ltype=link.ltype,
                         )
             else:
                 cres = collection.find_cres_of_node(linked_node)
                 if cres:
                     for cre in cres:
-                        collection.add_link(cre=cre, node=db_link, type=link.ltype)
+                        collection.add_link(cre=cre, node=db_link, ltype=link.ltype)
                         for unlinked_node in cre_less_nodes:
                             collection.add_link(
                                 cre=cre,
                                 node=db.dbNodeFromNode(unlinked_node),
-                                type=link.ltype,
+                                ltype=link.ltype,
                             )
                 else:  # if neither the root nor a linked node has a CRE, add both as unlinked nodes
                     cre_less_nodes.append(link.document)
@@ -96,13 +96,13 @@ def register_node(node: defs.Node, collection: db.Node_collection) -> db.Node:
             # dbcre,_ = register_cre(link.document, collection) # CREs are idempotent
             c = collection.get_CREs(name=link.document.name)[0]
             dbcre = db.dbCREfromCRE(c)
-            collection.add_link(dbcre, linked_node, type=link.ltype)
+            collection.add_link(dbcre, linked_node, ltype=link.ltype)
             cres_added.append(dbcre)
             for unlinked_standard in cre_less_nodes:  # if anything in this
                 collection.add_link(
                     cre=dbcre,
                     node=db.dbNodeFromNode(unlinked_standard),
-                    type=link.ltype,
+                    ltype=link.ltype,
                 )
             cre_less_nodes = []
 
@@ -124,19 +124,19 @@ def register_cre(cre: defs.CRE, collection: db.Node_collection) -> Tuple[db.CRE,
                 collection.add_internal_link(
                     higher=dbcre,
                     lower=other_cre,
-                    type=defs.LinkTypes.Contains,
+                    ltype=defs.LinkTypes.Contains,
                 )
             elif link.ltype == defs.LinkTypes.PartOf:
                 collection.add_internal_link(
                     higher=other_cre,
                     lower=dbcre,
-                    type=defs.LinkTypes.Contains,
+                    ltype=defs.LinkTypes.Contains,
                 )
             elif link.ltype == defs.LinkTypes.Related:
                 collection.add_internal_link(
                     higher=other_cre,
                     lower=dbcre,
-                    type=defs.LinkTypes.Related,
+                    ltype=defs.LinkTypes.Related,
                 )
             else:
                 raise ValueError(f"Unknown link type {link.ltype}")
@@ -144,7 +144,7 @@ def register_cre(cre: defs.CRE, collection: db.Node_collection) -> Tuple[db.CRE,
             collection.add_link(
                 cre=dbcre,
                 node=register_node(node=link.document, collection=collection),
-                type=link.ltype,
+                ltype=link.ltype,
             )
     return dbcre, existing
 
@@ -460,6 +460,7 @@ def donwload_graph_from_upstream(cache: str) -> None:
         cre = defs.Document.from_dict(credict)
         if cre.id in imported_cres:
             return
+
         register_cre(cre, collection)
         imported_cres[cre.id] = ""
         for link in cre.links:
@@ -536,8 +537,6 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
         )
     elif args.add and args.cre_loc and not args.from_spreadsheet:
         add_from_disk(cache_loc=args.cache_file, cre_loc=args.cre_loc)
-    elif args.print_graph:
-        print_graph()
     # elif args.review and args.osib_in:
     #     review_osib_from_file(
     #         file_loc=args.osib_in, cache=args.cache_file, cre_loc=args.cre_loc
@@ -639,8 +638,6 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
 
     if args.generate_embeddings:
         generate_embeddings(args.cache_file)
-    if args.owasp_proj_meta:
-        owasp_metadata_to_cre(args.owasp_proj_meta)
     if args.populate_neo4j_db:
         populate_neo4j_db(args.cache_file)
     if args.start_worker:

--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -117,14 +117,14 @@ def register_cre(cre: defs.CRE, collection: db.Node_collection) -> Tuple[db.CRE,
     dbcre: db.CRE = collection.add_cre(cre)
     for link in cre.links:
         if type(link.document) == defs.CRE:
-            logger.info(f"{link.document.id} {link.ltype} {cre.id}")
             other_cre, _ = register_cre(link.document, collection)
 
+            # the following flips the PartOf relationship so that we only have contains relationship in the database
             if link.ltype == defs.LinkTypes.Contains:
                 collection.add_internal_link(
                     higher=dbcre,
                     lower=other_cre,
-                    type=link.ltype,
+                    type=defs.LinkTypes.Contains,
                 )
             elif link.ltype == defs.LinkTypes.PartOf:
                 collection.add_internal_link(

--- a/application/database/inmemory_graph.py
+++ b/application/database/inmemory_graph.py
@@ -1,60 +1,87 @@
 import sys
+import logging
 import networkx as nx
 from typing import List, Tuple
 from application.defs import cre_defs as defs
 
 
-class CRE_Graph:
-    graph: nx.Graph = None
-    __parent_child_subgraph = None
-    __instance: "CRE_Graph" = None
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Singleton_Graph_Storage(nx.DiGraph):
+    __instance: "Singleton_Graph_Storage" = None
 
     @classmethod
-    def instance(cls, documents: List[defs.Document] = None) -> "CRE_Graph":
+    def instance(cls) -> "Singleton_Graph_Storage":
         if cls.__instance is None:
-            cls.__instance = cls.__new__(cls)
-            cls.graph = nx.DiGraph()
-            cls.graph = cls.__load_cre_graph(documents=documents)
+            cls.__instance = nx.DiGraph()
         return cls.__instance
 
-    def __init__(sel):
+    def __init__():
         raise ValueError("CRE_Graph is a singleton, please call instance() instead")
 
-    def add_node(self, *args, **kwargs):
-        return self.graph.add_node(*args, **kwargs)
+
+class CRE_Graph:
+    __graph: nx.Graph = None
+    __parent_child_subgraph = None
+
+    def get_raw_graph(self):
+        return self.__graph
+
+    def with_graph(cls, graph: nx.Graph, graph_data: List[defs.Document]):
+        cls.__graph = graph
+        if not len(graph.edges):
+            cls.__load_cre_graph(graph_data)
 
     def introduces_cycle(self, doc_from: defs.Document, link_to: defs.Link):
         try:
-            existing_cycle = nx.find_cycle(self.graph)
-            if existing_cycle:
+            ex = self.has_cycle()
+            if ex:
                 raise ValueError(
                     "Existing graph contains cycle,"
                     "this not a recoverable error,"
-                    f" manual database actions are required {existing_cycle}"
+                    f" manual database actions are required {ex}"
                 )
         except nx.exception.NetworkXNoCycle:
             pass  # happy path, we don't want cycles
-        new_graph = self.graph.copy()
+
+        # TODO: when this becomes too slow (e.g. when we are importing 1000s of CREs at once)
+        # we can instead add the edge find the cycle and then remove the edge
+        new_graph = self.__graph.copy()
 
         # this needs our special add_edge but with the copied graph
-        new_graph = self.add_graph_edge(
+        new_graph = self.__add_graph_edge(
             doc_from=doc_from, link_to=link_to, graph=new_graph
         )
         try:
             return nx.find_cycle(new_graph)
-        except nx.NetworkXNoCycle:
-            return False
+        except nx.exception.NetworkXNoCycle:
+            return None
+
+    def has_cycle(self):
+        try:
+            ex = nx.find_cycle(self.__graph)
+            return ex
+        except nx.exception.NetworkXNoCycle:
+            return None
 
     def get_hierarchy(self, rootIDs: List[str], creID: str):
+
+        if len(self.__graph.edges) == 0:
+            logger.error("graph is empty")
+            return -1
+
         if creID in rootIDs:
             return 0
 
         if self.__parent_child_subgraph == None:
-            if len(self.graph.edges) == 0:
+            if len(self.__graph.edges) == 0:
                 raise ValueError("Graph has no edges")
             include_cres = []
-            for el in self.graph.edges:
-                edge_data = self.graph.get_edge_data(*el)
+            for el in self.__graph.edges:
+                edge_data = self.__graph.get_edge_data(*el)
                 if (
                     el[0].startswith("CRE")
                     and el[1].startswith("CRE")
@@ -71,7 +98,7 @@ class CRE_Graph:
                     el not in include_cres
                 ):  # If the root is not in the parent/children graph, add it to prevent an error and continue, there is not path to our CRE anyway
                     include_cres.append(f"CRE: {el}")
-            self.__parent_child_subgraph = self.graph.subgraph(set(include_cres))
+            self.__parent_child_subgraph = self.__graph.subgraph(set(include_cres))
 
         shortest_path = sys.maxsize
         for root in rootIDs:
@@ -87,49 +114,61 @@ class CRE_Graph:
                     )
                     - 1,
                 )
-            except (
-                nx.NodeNotFound
-            ) as nnf:  # If the CRE is not in the parent/children graph it means that it's a lone CRE, so it's a root and we return 0
+            except nx.exception.NodeNotFound:
+                # If the CRE is not in the parent/children graph it means that it's a lone CRE, so it's a root and we return 0
+                if f"CRE: {root}" not in self.__graph.nodes():
+                    raise ValueError(f"CRE: {root} isn't in the graph")
+                if f"CRE: {creID}" not in self.__graph.nodes():
+                    raise ValueError(f"CRE: {creID} isn't in the graph")
                 return 0
-            except (
-                nx.NetworkXNoPath
-            ) as nxnp:  # If there is no path to the CRE, continue
+            except nx.exception.NetworkXNoPath:
+                # If there is no path to the CRE, continue
                 continue
         return shortest_path
 
     def get_path(self, start: str, end: str) -> List[Tuple[str, str]]:
         try:
-            return nx.shortest_path(self.graph, start, end)
+            return nx.shortest_path(self.__graph, start, end)
         except nx.NetworkXNoPath:
             return []
 
-    @classmethod
-    def add_cre(cls, dbcre: defs.CRE, graph: nx.DiGraph) -> nx.DiGraph:
-        if dbcre:
-            cls.graph.add_node(f"CRE: {dbcre.id}", internal_id=dbcre.id)
-        else:
-            logger.error("Called with dbcre being none")
-        return graph
-
-    @classmethod
-    def add_dbnode(cls, dbnode: defs.Node, graph: nx.DiGraph) -> nx.DiGraph:
-        if dbnode:
-            cls.graph.add_node(
-                "Node: " + str(dbnode.id),
-                internal_id=dbnode.id,
+    def add_cre(cls, cre: defs.CRE):
+        if not isinstance(cre, defs.CRE):
+            raise ValueError(
+                f"inmemory graph add_cre takes only cre objects, instead got {type(cre)}"
             )
+        graph_cre = f"{defs.Credoctypes.CRE.value}: {cre.id}"
+        if cre and graph_cre not in cls.__graph.nodes():
+            cls.__graph.add_node(graph_cre, internal_id=cre.id)
+
+    def add_dbnode(cls, dbnode: defs.Node):
+        graph_node = "Node: " + str(dbnode.id)
+
+        if dbnode and graph_node not in cls.__graph.nodes():
+            cls.__graph.add_node(graph_node, internal_id=dbnode.id)
         else:
             logger.error("Called with dbnode being none")
-        return graph
 
-    @classmethod
-    def add_graph_edge(
+    def add_link(self, doc_from: defs.Document, link_to: defs.Link):
+        self.__graph = self.__add_graph_edge(
+            doc_from=doc_from, link_to=link_to, graph=self.__graph
+        )
+
+    def __add_graph_edge(
         cls,
         doc_from: defs.Document,
         link_to: defs.Link,
         graph: nx.DiGraph,
     ) -> nx.digraph:
-
+        """
+        Adds a directed edge to the graph provided
+        called by both graph population and speculative cycle finding methods
+        hence why it accepts a graph and returns a graph
+        """
+        if doc_from.name == link_to.document.name:
+            raise ValueError(
+                f"cannot add an edge from a document to itself, from: {doc_from}, to: {link_to.document}"
+            )
         to_doctype = defs.Credoctypes.CRE.value
         if link_to.document.doctype != defs.Credoctypes.CRE.value:
             to_doctype = "Node"
@@ -137,56 +176,57 @@ class CRE_Graph:
         if doc_from.doctype == defs.Credoctypes.CRE:
             if link_to.ltype == defs.LinkTypes.Contains:
                 graph.add_edge(
-                    f"{doc_from.doctype}: {doc_from.id}",
+                    f"{doc_from.doctype.value}: {doc_from.id}",
                     f"{to_doctype}: {link_to.document.id}",
-                    ltype=link_to.ltype,
+                    ltype=link_to.ltype.value,
                 )
             elif link_to.ltype == defs.LinkTypes.PartOf:
                 graph.add_edge(
                     f"{to_doctype}: {link_to.document.id}",
-                    f"{doc_from.doctype}: {doc_from.id}",
-                    ltype=defs.LinkTypes.Contains,
+                    f"{doc_from.doctype.value}: {doc_from.id}",
+                    ltype=defs.LinkTypes.Contains.value,
                 )
             elif link_to.ltype == defs.LinkTypes.Related:
                 # do nothing if the opposite already exists in the graph, otherwise we introduce a cycle
                 if graph.has_edge(
                     f"{to_doctype}: {link_to.document.id}",
-                    f"{doc_from.doctype}: {doc_from.id}",
+                    f"{doc_from.doctype.value}: {doc_from.id}",
                 ):
                     return graph
 
                 graph.add_edge(
-                    f"{doc_from.doctype}: {doc_from.id}",
+                    f"{doc_from.doctype.value}: {doc_from.id}",
                     f"{to_doctype}: {link_to.document.id}",
-                    ltype=defs.LinkTypes.Related,
+                    ltype=defs.LinkTypes.Related.value,
                 )
+            elif (
+                link_to.ltype == defs.LinkTypes.LinkedTo
+                or link_to.ltype == defs.LinkTypes.AutomaticallyLinkedTo
+            ):
+                graph.add_edge(
+                    f"{doc_from.doctype.value}: {doc_from.id}",
+                    f"{to_doctype}: {link_to.document.id}",
+                    ltype=link_to.ltype.value,
+                )
+            else:
+                raise ValueError(f"link type {link_to.ltype.value} not recognized")
         else:
             graph.add_edge(
-                f"{doc_from.doctype}: {doc_from.id}",
+                f"{doc_from.doctype.value}: {doc_from.id}",
                 f"{to_doctype}: {link_to.document.id}",
-                ltype=link_to.ltype,
+                ltype=link_to.ltype.value,
             )
         return graph
 
-    @classmethod
-    def __load_cre_graph(cls, documents: List[defs.Document]) -> nx.Graph:
-        graph = cls.graph
-        if not graph:
-            graph = nx.DiGraph()
-
+    def __load_cre_graph(cls, documents: List[defs.Document]):
         for doc in documents:
-            from_doctype = None
             if doc.doctype == defs.Credoctypes.CRE:
-                graph = cls.add_cre(dbcre=doc, graph=graph)
-                from_doctype = defs.Credoctypes.CRE
+                cls.add_cre(cre=doc)
             else:
-                graph = cls.add_dbnode(dbnode=doc, graph=graph)
-                from_doctype = doc.doctype
+                cls.add_dbnode(dbnode=doc)
             for link in doc.links:
                 if link.document.doctype == defs.Credoctypes.CRE:
-                    graph = cls.add_cre(dbcre=link.document, graph=graph)
+                    cls.add_cre(cre=link.document)
                 else:
-                    graph = cls.add_dbnode(dbnode=link.document, graph=graph)
-            graph = cls.add_graph_edge(doc_from=doc, link_to=link, graph=graph)
-        cls.graph = graph
-        return graph
+                    cls.add_dbnode(dbnode=link.document)
+                cls.__add_graph_edge(doc_from=doc, link_to=link, graph=cls.__graph)

--- a/application/database/inmemory_graph.py
+++ b/application/database/inmemory_graph.py
@@ -7,7 +7,7 @@ from application.defs import cre_defs as defs
 class CRE_Graph:
     graph: nx.Graph = None
     __parent_child_subgraph = None
-    __instance = None
+    __instance: "CRE_Graph" = None
 
     @classmethod
     def instance(cls, documents: List[defs.Document] = None) -> "CRE_Graph":
@@ -23,7 +23,7 @@ class CRE_Graph:
     def add_node(self, *args, **kwargs):
         return self.graph.add_node(*args, **kwargs)
 
-    def adds_cycle(self, doc_from: defs.Document, link_to: defs.Link):
+    def introduces_cycle(self, doc_from: defs.Document, link_to: defs.Link):
         try:
             existing_cycle = nx.find_cycle(self.graph)
             if existing_cycle:

--- a/application/defs/cre_defs.py
+++ b/application/defs/cre_defs.py
@@ -190,7 +190,6 @@ class Credoctypes(str, Enum, metaclass=EnumMetaWithContains):
 
 
 class LinkTypes(str, Enum, metaclass=EnumMetaWithContains):
-    Same = "SAME"
     LinkedTo = "Linked To"  # Any standard entry is by default “linked”
     PartOf = "Is Part Of"  # Hierarchy above: “is part of”
     Contains = "Contains"  # Hierarchy below: “Contains”
@@ -205,8 +204,6 @@ class LinkTypes(str, Enum, metaclass=EnumMetaWithContains):
 
     @staticmethod
     def from_str(name: str) -> Any:  # it returns LinkTypes but then it won't run
-        if name.upper().startswith("SAM"):
-            name = "SAME"
         res = [x for x in LinkTypes if x.value == name]
         if not res:
             raise KeyError(
@@ -252,7 +249,7 @@ class ToolTypes(str, Enum, metaclass=EnumMetaWithContains):
 @dataclass
 class Link:
     document: "Document"
-    ltype: LinkTypes = LinkTypes.Same
+    ltype: LinkTypes
     tags: List[str] = field(default_factory=list)
 
     def __post_init__(self):

--- a/application/frontend/src/const.ts
+++ b/application/frontend/src/const.ts
@@ -5,8 +5,6 @@ export const TYPE_LINKED_TO = 'Linked To';
 export const TYPE_LINKED_FROM = 'Linked From';
 export const TYPE_CONTAINS = 'Contains';
 export const TYPE_RELATED = 'Related';
-export const TYPE_SAME = 'SAME';
-export const TYPE_SAM = 'SAM';
 export const TYPE_AUTOLINKED_TO = 'Automatically linked to';
 
 export const DOCUMENT_TYPE_NAMES = {

--- a/application/frontend/src/utils/document.ts
+++ b/application/frontend/src/utils/document.ts
@@ -32,7 +32,7 @@ export const groupLinksByType = (node: Document): LinksByType =>
   node.links ? groupBy(node.links, (link) => link.ltype) : {};
 
 export const orderLinksByType = (lbt: LinksByType): LinksByType => {
-  const order = ['Contains', 'Linked To', 'Automatically linked to', 'SAME', 'SAM', 'Is Part Of', 'Related'];
+  const order = ['Contains', 'Linked To', 'Automatically linked to', 'Is Part Of', 'Related'];
   const res: LinksByType = {};
   for (const itm of order) {
     if (lbt[itm]) {

--- a/application/tests/capec_parser_test.py
+++ b/application/tests/capec_parser_test.py
@@ -45,9 +45,18 @@ class TestCapecParser(unittest.TestCase):
                 name="CAPEC",
                 doctype=defs.Credoctypes.Standard,
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-276", id="276-276"),ltype=defs.LinkTypes.LinkedTo),
-                    defs.Link(document=defs.CRE(name="CRE-285", id="285-285"),ltype=defs.LinkTypes.LinkedTo),
-                    defs.Link(document=defs.CRE(name="CRE-434", id="434-434"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-276", id="276-276"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-285", id="285-285"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-434", id="434-434"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 hyperlink="https://capec.mitre.org/data/definitions/1.html",
                 sectionID="1",

--- a/application/tests/capec_parser_test.py
+++ b/application/tests/capec_parser_test.py
@@ -33,7 +33,9 @@ class TestCapecParser(unittest.TestCase):
             dbnode = self.collection.add_node(defs.Standard(name="CWE", sectionID=cwe))
             cre = defs.CRE(id=f"{cwe}-{cwe}", name=f"CRE-{cwe}")
             dbcre = self.collection.add_cre(cre=cre)
-            self.collection.add_link(cre=dbcre, node=dbnode)
+            self.collection.add_link(
+                cre=dbcre, node=dbnode, ltype=defs.LinkTypes.LinkedTo
+            )
         entries = capec_parser.Capec().parse(
             cache=self.collection,
             ph=prompt_client.PromptHandler(database=self.collection),
@@ -43,9 +45,9 @@ class TestCapecParser(unittest.TestCase):
                 name="CAPEC",
                 doctype=defs.Credoctypes.Standard,
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-276", id="276-276")),
-                    defs.Link(document=defs.CRE(name="CRE-285", id="285-285")),
-                    defs.Link(document=defs.CRE(name="CRE-434", id="434-434")),
+                    defs.Link(document=defs.CRE(name="CRE-276", id="276-276"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(document=defs.CRE(name="CRE-285", id="285-285"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(document=defs.CRE(name="CRE-434", id="434-434"),ltype=defs.LinkTypes.LinkedTo),
                 ],
                 hyperlink="https://capec.mitre.org/data/definitions/1.html",
                 sectionID="1",

--- a/application/tests/cloud_native_security_controls_parser_test.py
+++ b/application/tests/cloud_native_security_controls_parser_test.py
@@ -46,7 +46,7 @@ class TestCloudNativeSecurityControlsParser(unittest.TestCase):
         dbnode = self.collection.add_node(
             defs.Standard(name="fakeNode", sectionID="123-123")
         )
-        self.collection.add_link(dbcre, dbnode)
+        self.collection.add_link(dbcre, dbnode, ltype=defs.LinkTypes.LinkedTo)
 
         mock_requests.return_value = fakeRequest()
         mock_get_text_embeddings.return_value = [0.1, 0.2]
@@ -64,7 +64,10 @@ class TestCloudNativeSecurityControlsParser(unittest.TestCase):
                 "variables or as a file",
                 hyperlink="https://github.com/cloud-native-security-controls/controls-catalog/blob/main/controls/controls_catalog.csv#L2",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123")),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-123", id="123-123"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 name="Cloud Native Security Controls",
                 section="Access",
@@ -78,7 +81,7 @@ class TestCloudNativeSecurityControlsParser(unittest.TestCase):
                 embeddings_text="Secrets are injected at runtime, such as environment variables or as a file",
                 hyperlink="https://github.com/cloud-native-security-controls/controls-catalog/blob/main/controls/controls_catalog.csv#L2",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123")),
+                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123"),ltype=defs.LinkTypes.LinkedTo),
                 ],
                 name="Cloud Native Security Controls",
                 section="Access",

--- a/application/tests/cloud_native_security_controls_parser_test.py
+++ b/application/tests/cloud_native_security_controls_parser_test.py
@@ -81,7 +81,10 @@ class TestCloudNativeSecurityControlsParser(unittest.TestCase):
                 embeddings_text="Secrets are injected at runtime, such as environment variables or as a file",
                 hyperlink="https://github.com/cloud-native-security-controls/controls-catalog/blob/main/controls/controls_catalog.csv#L2",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-123", id="123-123"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 name="Cloud Native Security Controls",
                 section="Access",

--- a/application/tests/cre_main_test.py
+++ b/application/tests/cre_main_test.py
@@ -47,20 +47,23 @@ class TestMain(unittest.TestCase):
                         doctype=defs.Credoctypes.Standard,
                         name="CWE",
                         sectionID="598",
-                    ),ltype=defs.LinkTypes.LinkedTo
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
                 ),
                 defs.Link(
                     document=defs.Code(
                         doctype=defs.Credoctypes.Code,
                         description="print(10)",
                         name="CodemcCodeFace",
-                    ),ltype=defs.LinkTypes.LinkedTo
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
                 ),
                 defs.Link(
                     document=defs.Tool(
                         description="awesome hacking tool",
                         name="ToolmcToolFace",
-                    ),ltype=defs.LinkTypes.LinkedTo
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
                 ),
             ],
         )
@@ -156,20 +159,21 @@ class TestMain(unittest.TestCase):
             description="",
             name="standard_with",
             links=[
-                defs.Link(document=credoc3,ltype=defs.LinkTypes.LinkedTo),
+                defs.Link(document=credoc3, ltype=defs.LinkTypes.LinkedTo),
                 defs.Link(
                     document=defs.Standard(
                         doctype=defs.Credoctypes.Standard, name="CWE", sectionID="598"
                     ),
-                    ltype=defs.LinkTypes.LinkedTo
+                    ltype=defs.LinkTypes.LinkedTo,
                 ),
-                defs.Link(document=credoc2,ltype=defs.LinkTypes.LinkedTo),
+                defs.Link(document=credoc2, ltype=defs.LinkTypes.LinkedTo),
                 defs.Link(
                     document=defs.Standard(
                         doctype=defs.Credoctypes.Standard,
                         name="ASVS",
                         section="SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING",
-                    ),ltype=defs.LinkTypes.LinkedTo
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
                 ),
             ],
             section="Session Management",
@@ -208,7 +212,10 @@ class TestMain(unittest.TestCase):
             id="100-100",
             description="CREdesc",
             name="CREname",
-            links=[defs.Link(document=standard,ltype=defs.LinkTypes.LinkedTo), defs.Link(document=tool,ltype=defs.LinkTypes.LinkedTo)],
+            links=[
+                defs.Link(document=standard, ltype=defs.LinkTypes.LinkedTo),
+                defs.Link(document=tool, ltype=defs.LinkTypes.LinkedTo),
+            ],
             tags=["CREt1", "CREt2"],
             metadata={"tags": ["CREl1", "CREl2"]},
         )
@@ -263,8 +270,8 @@ class TestMain(unittest.TestCase):
         self.assertCountEqual(
             c.links,
             [
-                defs.Link(document=standard,ltype=defs.LinkTypes.LinkedTo),
-                defs.Link(document=tool,ltype=defs.LinkTypes.LinkedTo),
+                defs.Link(document=standard, ltype=defs.LinkTypes.LinkedTo),
+                defs.Link(document=tool, ltype=defs.LinkTypes.LinkedTo),
                 defs.Link(
                     document=c_lower.shallow_copy(), ltype=defs.LinkTypes.Contains
                 ),

--- a/application/tests/cre_main_test.py
+++ b/application/tests/cre_main_test.py
@@ -47,20 +47,20 @@ class TestMain(unittest.TestCase):
                         doctype=defs.Credoctypes.Standard,
                         name="CWE",
                         sectionID="598",
-                    )
+                    ),ltype=defs.LinkTypes.LinkedTo
                 ),
                 defs.Link(
                     document=defs.Code(
                         doctype=defs.Credoctypes.Code,
                         description="print(10)",
                         name="CodemcCodeFace",
-                    )
+                    ),ltype=defs.LinkTypes.LinkedTo
                 ),
                 defs.Link(
                     document=defs.Tool(
                         description="awesome hacking tool",
                         name="ToolmcToolFace",
-                    )
+                    ),ltype=defs.LinkTypes.LinkedTo
                 ),
             ],
         )
@@ -86,7 +86,7 @@ class TestMain(unittest.TestCase):
             name="CWE",
             sectionID="598",
             links=[
-                defs.Link(document=credoc),
+                defs.Link(document=credoc, ltype=defs.LinkTypes.LinkedTo),
             ],
         )
 
@@ -101,15 +101,17 @@ class TestMain(unittest.TestCase):
                         name="zap",
                         section="Rule - 9",
                         sectionID="9",
-                    )
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
                 ),
-                defs.Link(document=credoc),
+                defs.Link(document=credoc, ltype=defs.LinkTypes.LinkedTo),
                 defs.Link(
                     document=defs.Standard(
                         name="CWE",
                         sectionID="598",
                         links=[],
-                    )
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
                 ),
             ],
             section="standard_with_cre",
@@ -154,19 +156,20 @@ class TestMain(unittest.TestCase):
             description="",
             name="standard_with",
             links=[
-                defs.Link(document=credoc3),
+                defs.Link(document=credoc3,ltype=defs.LinkTypes.LinkedTo),
                 defs.Link(
                     document=defs.Standard(
                         doctype=defs.Credoctypes.Standard, name="CWE", sectionID="598"
-                    )
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo
                 ),
-                defs.Link(document=credoc2),
+                defs.Link(document=credoc2,ltype=defs.LinkTypes.LinkedTo),
                 defs.Link(
                     document=defs.Standard(
                         doctype=defs.Credoctypes.Standard,
                         name="ASVS",
                         section="SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING",
-                    )
+                    ),ltype=defs.LinkTypes.LinkedTo
                 ),
             ],
             section="Session Management",
@@ -205,7 +208,7 @@ class TestMain(unittest.TestCase):
             id="100-100",
             description="CREdesc",
             name="CREname",
-            links=[defs.Link(document=standard), defs.Link(document=tool)],
+            links=[defs.Link(document=standard,ltype=defs.LinkTypes.LinkedTo), defs.Link(document=tool,ltype=defs.LinkTypes.LinkedTo)],
             tags=["CREt1", "CREt2"],
             metadata={"tags": ["CREl1", "CREl2"]},
         )
@@ -260,8 +263,8 @@ class TestMain(unittest.TestCase):
         self.assertCountEqual(
             c.links,
             [
-                defs.Link(document=standard),
-                defs.Link(document=tool),
+                defs.Link(document=standard,ltype=defs.LinkTypes.LinkedTo),
+                defs.Link(document=tool,ltype=defs.LinkTypes.LinkedTo),
                 defs.Link(
                     document=c_lower.shallow_copy(), ltype=defs.LinkTypes.Contains
                 ),
@@ -291,21 +294,21 @@ class TestMain(unittest.TestCase):
         file: List[Dict[str, Any]] = [
             {
                 "description": "Verify that approved cryptographic algorithms are used in the generation, seeding, and verification.",
-                "doctype": "CRE",
+                "doctype": defs.Credoctypes.CRE,
                 "id": "157-573",
                 "links": [
                     {
-                        "type": "SAM",
+                        "type": defs.LinkTypes.LinkedTo,
                         "document": {
-                            "doctype": "Standard",
+                            "doctype": defs.Credoctypes.Standard,
                             "name": "TOP10",
                             "section": "https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control",
                         },
                     },
                     {
-                        "type": "SAM",
+                        "type": defs.LinkTypes.LinkedTo,
                         "document": {
-                            "doctype": "Standard",
+                            "doctype": defs.Credoctypes.Standard,
                             "name": "ISO 25010",
                             "section": "Secure data storage",
                         },
@@ -315,7 +318,7 @@ class TestMain(unittest.TestCase):
             },
             {
                 "description": "Desc",
-                "doctype": "CRE",
+                "doctype": defs.Credoctypes.CRE,
                 "id": "141-141",
                 "name": "name",
             },
@@ -332,14 +335,16 @@ class TestMain(unittest.TestCase):
                             doctype=defs.Credoctypes.Standard,
                             name="TOP10",
                             section="https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control",
-                        )
+                        ),
+                        ltype=defs.LinkTypes.LinkedTo,
                     ),
                     defs.Link(
                         document=defs.Standard(
                             doctype=defs.Credoctypes.Standard,
                             name="ISO 25010",
                             section="Secure data storage",
-                        )
+                        ),
+                        ltype=defs.LinkTypes.LinkedTo,
                     ),
                 ],
             ),

--- a/application/tests/cwe_parser_test.py
+++ b/application/tests/cwe_parser_test.py
@@ -65,8 +65,8 @@ class TestCWEParser(unittest.TestCase):
                 name="CWE",
                 doctype=defs.Credoctypes.Standard,
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-732", id="732-732")),
-                    defs.Link(document=defs.CRE(name="CRE-733", id="733-733")),
+                    defs.Link(document=defs.CRE(name="CRE-732", id="732-732"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(document=defs.CRE(name="CRE-733", id="733-733"),ltype=defs.LinkTypes.LinkedTo),
                 ],
                 hyperlink="https://CWE.mitre.org/data/definitions/1004.html",
                 sectionID="1004",
@@ -79,8 +79,8 @@ class TestCWEParser(unittest.TestCase):
                 sectionID="1007",
                 section="Another CWE",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-451", id="451-451")),
-                    defs.Link(document=defs.CRE(name="CRE-632", id="632-632")),
+                    defs.Link(document=defs.CRE(name="CRE-451", id="451-451"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(document=defs.CRE(name="CRE-632", id="632-632"),ltype=defs.LinkTypes.LinkedTo),
                 ],
             ),
         ]

--- a/application/tests/cwe_parser_test.py
+++ b/application/tests/cwe_parser_test.py
@@ -65,8 +65,14 @@ class TestCWEParser(unittest.TestCase):
                 name="CWE",
                 doctype=defs.Credoctypes.Standard,
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-732", id="732-732"),ltype=defs.LinkTypes.LinkedTo),
-                    defs.Link(document=defs.CRE(name="CRE-733", id="733-733"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-732", id="732-732"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-733", id="733-733"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 hyperlink="https://CWE.mitre.org/data/definitions/1004.html",
                 sectionID="1004",
@@ -79,8 +85,14 @@ class TestCWEParser(unittest.TestCase):
                 sectionID="1007",
                 section="Another CWE",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-451", id="451-451"),ltype=defs.LinkTypes.LinkedTo),
-                    defs.Link(document=defs.CRE(name="CRE-632", id="632-632"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-451", id="451-451"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-632", id="632-632"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
             ),
         ]

--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -63,9 +63,9 @@ class TestDB(unittest.TestCase):
         )
 
         collection.session.add(dbcre)
-        collection.add_link(cre=dbcre, node=dbstandard, type=defs.LinkTypes.LinkedTo)
+        collection.add_link(cre=dbcre, node=dbstandard, ltype=defs.LinkTypes.LinkedTo)
         collection.add_internal_link(
-            lower=dbcre, higher=dbgroup, type=defs.LinkTypes.Contains
+            lower=dbcre, higher=dbgroup, ltype=defs.LinkTypes.Contains
         )
 
         self.collection = collection
@@ -190,7 +190,7 @@ class TestDB(unittest.TestCase):
             )
         )
         self.collection.add_link(
-            self.dbcre, self.collection.add_node(code0), type=defs.LinkTypes.LinkedTo
+            self.dbcre, self.collection.add_node(code0), ltype=defs.LinkTypes.LinkedTo
         )
         self.collection.add_node(code1)
         self.collection.add_node(tool0)
@@ -2098,7 +2098,7 @@ class TestDB(unittest.TestCase):
                 defs.Link(document=copy(nodes[i]), ltype=defs.LinkTypes.LinkedTo)
             )
             collection.add_link(
-                cre=dbcres[i], node=dbnodes[i], type=defs.LinkTypes.LinkedTo
+                cre=dbcres[i], node=dbnodes[i], ltype=defs.LinkTypes.LinkedTo
             )
 
         collection.session.commit()
@@ -2136,7 +2136,7 @@ class TestDB(unittest.TestCase):
                 defs.Link(document=copy(nodes[i]), ltype=defs.LinkTypes.LinkedTo)
             )
             collection.add_link(
-                cre=dbcres[i], node=dbnodes[i], type=defs.LinkTypes.LinkedTo
+                cre=dbcres[i], node=dbnodes[i], ltype=defs.LinkTypes.LinkedTo
             )
 
         collection.session.commit()
@@ -2165,21 +2165,21 @@ class TestDB(unittest.TestCase):
                         linked_item = collection.add_cre(link.document)
                         if item.doctype == defs.Credoctypes.CRE:
                             collection.add_internal_link(
-                                dbitem, linked_item, type=link.ltype
+                                dbitem, linked_item, ltype=link.ltype
                             )
                         else:
                             collection.add_link(
-                                node=dbitem, cre=linked_item, type=link.ltype
+                                node=dbitem, cre=linked_item, ltype=link.ltype
                             )
                     else:
                         linked_item = collection.add_node(link.document)
                         if item.doctype == defs.Credoctypes.CRE:
                             collection.add_link(
-                                cre=dbitem, node=linked_item, type=link.ltype
+                                cre=dbitem, node=linked_item, ltype=link.ltype
                             )
                         else:
                             collection.add_internal_link(
-                                cre=linked_item, node=dbitem, type=link.ltype
+                                cre=linked_item, node=dbitem, ltype=link.ltype
                             )
 
         cres = inputDocs[defs.Credoctypes.CRE]

--- a/application/tests/defs_test.py
+++ b/application/tests/defs_test.py
@@ -63,7 +63,10 @@ class TestCreDefs(unittest.TestCase):
             id="500-500",
             description="desc",
             name="name",
-            links=[defs.Link(document=cre,ltype=defs.LinkTypes.Related), defs.Link(document=standard2,ltype=defs.LinkTypes.LinkedTo)],
+            links=[
+                defs.Link(document=cre, ltype=defs.LinkTypes.Related),
+                defs.Link(document=standard2, ltype=defs.LinkTypes.LinkedTo),
+            ],
             tags=["tag1", "t2"],
         )
         group_output = {

--- a/application/tests/defs_test.py
+++ b/application/tests/defs_test.py
@@ -30,19 +30,19 @@ class TestCreDefs(unittest.TestCase):
             id="100-100",
             description="CREdesc",
             name="CREname",
-            links=[defs.Link(document=standard)],
+            links=[defs.Link(document=standard, ltype=defs.LinkTypes.LinkedTo)],
             tags=["CREt1", "CREt2"],
         )
         cre_output = {
             "description": "CREdesc",
-            "doctype": "CRE",
+            "doctype": defs.Credoctypes.CRE,
             "id": "100-100",
             "links": [
                 {
-                    "ltype": "SAME",
+                    "ltype": defs.LinkTypes.LinkedTo,
                     "document": {
                         "id": "ASVS:SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING:3.1.1",
-                        "doctype": "Standard",
+                        "doctype": defs.Credoctypes.Standard,
                         "name": "ASVS",
                         "section": "SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING",
                         "subsection": "3.1.1",
@@ -63,7 +63,7 @@ class TestCreDefs(unittest.TestCase):
             id="500-500",
             description="desc",
             name="name",
-            links=[defs.Link(document=cre), defs.Link(document=standard2)],
+            links=[defs.Link(document=cre,ltype=defs.LinkTypes.Related), defs.Link(document=standard2,ltype=defs.LinkTypes.LinkedTo)],
             tags=["tag1", "t2"],
         )
         group_output = {
@@ -72,17 +72,17 @@ class TestCreDefs(unittest.TestCase):
             "id": "500-500",
             "links": [
                 {
-                    "ltype": "SAME",
+                    "ltype": defs.LinkTypes.Related,
                     "document": {
                         "description": "CREdesc",
-                        "doctype": "CRE",
+                        "doctype": defs.Credoctypes.CRE,
                         "id": "100-100",
                         "links": [
                             {
-                                "ltype": "SAME",
+                                "ltype": defs.LinkTypes.LinkedTo,
                                 "document": {
                                     "id": "ASVS:SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING:3.1.1",
-                                    "doctype": "Standard",
+                                    "doctype": defs.Credoctypes.Standard,
                                     "name": "ASVS",
                                     "section": (
                                         "SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING"
@@ -97,10 +97,10 @@ class TestCreDefs(unittest.TestCase):
                     },
                 },
                 {
-                    "ltype": "SAME",
+                    "ltype": defs.LinkTypes.LinkedTo,
                     "document": {
                         "id": "Standard:StandardSection:3.1.1",
-                        "doctype": "Standard",
+                        "doctype": defs.Credoctypes.Standard,
                         "name": "Standard",
                         "section": "StandardSection",
                         "subsection": "3.1.1",
@@ -117,7 +117,7 @@ class TestCreDefs(unittest.TestCase):
         )
         nested_output = {
             "id": "ASVS:SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING:3.1.1",
-            "doctype": "Standard",
+            "doctype": defs.Credoctypes.Standard,
             "name": "ASVS",
             "section": "SESSION-MGT-TOKEN-DIRECTIVES-DISCRETE-HANDLING",
             "subsection": "3.1.1",
@@ -130,8 +130,6 @@ class TestCreDefs(unittest.TestCase):
 
     def test_linktype_from_str(self) -> None:
         expected = {
-            "SAME": defs.LinkTypes.Same,
-            "SAM": defs.LinkTypes.Same,
             "Linked To": defs.LinkTypes.LinkedTo,
             "Is Part Of": defs.LinkTypes.PartOf,
             "Contains": defs.LinkTypes.Contains,
@@ -173,7 +171,12 @@ class TestCreDefs(unittest.TestCase):
                 vars(code)[v] = [0.001]
                 c.append(code)
             elif v == "links":
-                code.links = [defs.Link(document=defs.CRE(id="123-123", name="asdf"))]
+                code.links = [
+                    defs.Link(
+                        document=defs.CRE(id="123-123", name="asdf"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    )
+                ]
                 c.append(code)
             elif v == "tags":
                 vars(code)[v] = [tag + "_a" for tag in d1.tags]
@@ -199,7 +202,9 @@ class TestCreDefs(unittest.TestCase):
             hyperlink="https://example.com/s2",
             version="v2",
         )
-        s1_with_link = copy.deepcopy(d1).add_link(defs.Link(document=s2))
+        s1_with_link = copy.deepcopy(d1).add_link(
+            defs.Link(document=s2, ltype=defs.LinkTypes.LinkedTo)
+        )
         self.assertNotEqual(s1_with_link, d1)
 
     def test_standards_equality(self) -> None:
@@ -232,7 +237,12 @@ class TestCreDefs(unittest.TestCase):
                 vars(code)[v] = [0.001]
                 s["embeddings"] = code
             elif v == "links":
-                code.links = [defs.Link(document=defs.CRE(id="123-123", name="asdf"))]
+                code.links = [
+                    defs.Link(
+                        document=defs.CRE(id="123-123", name="asdf"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    )
+                ]
                 s["links"] = code
             elif v == "tags":
                 vars(code)[v] = [tag + "_a" for tag in s1.tags]
@@ -262,14 +272,18 @@ class TestCreDefs(unittest.TestCase):
             hyperlink="https://example.com/s2",
             version="v2",
         )
-        s1_with_link = copy.deepcopy(s1).add_link(defs.Link(document=s2))
+        s1_with_link = copy.deepcopy(s1).add_link(
+            defs.Link(document=s2, ltype=defs.LinkTypes.LinkedTo)
+        )
         self.assertNotEqual(s1_with_link, s1)
 
     def test_add_link(self) -> None:
         tool = defs.Tool(name="mctoolface")
         tool2 = defs.Tool(name="mctoolface2")
-        lnk = defs.Link(document=tool2, ltype=defs.LinkTypes.Same)
-        actual = copy.deepcopy(tool).add_link(defs.Link(document=tool2))
+        lnk = defs.Link(document=tool2, ltype=defs.LinkTypes.LinkedTo)
+        actual = copy.deepcopy(tool).add_link(
+            defs.Link(document=tool2, ltype=defs.LinkTypes.LinkedTo)
+        )
         tool.links = [lnk]
         self.assertDictEqual(actual.todict(), tool.todict())
 

--- a/application/tests/dsomm_parser_test.py
+++ b/application/tests/dsomm_parser_test.py
@@ -39,8 +39,12 @@ class TestDSOMM(unittest.TestCase):
             cre = defs.CRE(id=f"123-123", name=f"CRE-{item}")
             cres.append(cre)
             dbcre = self.collection.add_cre(cre=cre)
-            self.collection.add_link(cre=dbcre, node=dbsamm)
-            self.collection.add_link(cre=dbcre, node=dbiso)
+            self.collection.add_link(
+                cre=dbcre, node=dbsamm, ltype=defs.LinkTypes.LinkedTo
+            )
+            self.collection.add_link(
+                cre=dbcre, node=dbiso, ltype=defs.LinkTypes.LinkedTo
+            )
         entries = dsomm.DSOMM().parse(
             cache=self.collection,
             ph=prompt_client.PromptHandler(database=self.collection),
@@ -50,7 +54,10 @@ class TestDSOMM(unittest.TestCase):
                 name=dsomm.DSOMM().name,
                 doctype=defs.Credoctypes.Standard,
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-I-SB-2-A", id="123-123")),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-I-SB-2-A", id="123-123"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 description="Description:While building and testing artifacts, third party "
                 "systems, application frameworks\n"
@@ -76,7 +83,10 @@ class TestDSOMM(unittest.TestCase):
                 name=dsomm.DSOMM().name,
                 doctype=defs.Credoctypes.Standard,
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-5.37", id="537-537")),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-5.37", id="537-537"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 description="Description:Sample evidence as an attribute in the yaml: The "
                 "build process is defined in [REPLACE-ME "

--- a/application/tests/inmemory_graph_test.py
+++ b/application/tests/inmemory_graph_test.py
@@ -1,0 +1,156 @@
+import unittest
+import networkx as nx
+from application.defs import cre_defs as defs
+from application.database.inmemory_graph import CRE_Graph
+
+
+class TestCreDefs(unittest.TestCase):
+    def test_add_edge(self) -> None:
+        cre1 = defs.CRE(name="c1", id="111-111")
+        cre2 = defs.CRE(name="c2", id="111-112")
+        cre3 = defs.CRE(name="c3", id="111-113")
+
+        g = CRE_Graph()
+        g.with_graph(graph=nx.DiGraph(), graph_data=[])
+        g.add_cre(cre1)
+        g.add_cre(cre2)
+        g.add_cre(cre3)
+
+        g.add_link(cre1, defs.Link(document=cre2, ltype=defs.LinkTypes.Contains))
+        g.add_link(cre2, defs.Link(document=cre3, ltype=defs.LinkTypes.Contains))
+        self.maxDiff = None
+        self.assertDictEqual(
+            nx.to_dict_of_dicts(g.get_raw_graph()),
+            {
+                "CRE: 111-111": {
+                    "CRE: 111-112": {"ltype": defs.LinkTypes.Contains.value}
+                },
+                "CRE: 111-112": {
+                    "CRE: 111-113": {"ltype": defs.LinkTypes.Contains.value}
+                },
+                "CRE: 111-113": {},
+            },
+        )
+
+        g.add_link(
+            cre3,
+            defs.Link(
+                document=defs.CRE(name="c4", id="111-114"), ltype=defs.LinkTypes.PartOf
+            ),
+        )
+        g.add_link(
+            cre2,
+            defs.Link(
+                document=defs.CRE(name="c4", id="111-114"), ltype=defs.LinkTypes.PartOf
+            ),
+        )
+
+        self.assertDictEqual(
+            nx.to_dict_of_dicts(g.get_raw_graph()),
+            {
+                "CRE: 111-111": {
+                    "CRE: 111-112": {"ltype": defs.LinkTypes.Contains.value}
+                },
+                "CRE: 111-112": {
+                    "CRE: 111-113": {"ltype": defs.LinkTypes.Contains.value}
+                },
+                "CRE: 111-113": {},
+                "CRE: 111-114": {
+                    "CRE: 111-112": {"ltype": defs.LinkTypes.Contains.value},
+                    "CRE: 111-113": {"ltype": defs.LinkTypes.Contains.value},
+                },
+            },
+        )
+
+        s1 = defs.Standard(name="s1", section="s1 section")
+        g.add_link(
+            cre1,
+            defs.Link(
+                document=s1,
+                ltype=defs.LinkTypes.LinkedTo,
+            ),
+        )
+        s2 = defs.Standard(name="s2", section="s2 section")
+        g.add_link(
+            cre1,
+            defs.Link(
+                document=s2,
+                ltype=defs.LinkTypes.AutomaticallyLinkedTo,
+            ),
+        )
+
+        self.assertDictEqual(
+            nx.to_dict_of_dicts(g.get_raw_graph()),
+            {
+                "CRE: 111-111": {
+                    "CRE: 111-112": {"ltype": defs.LinkTypes.Contains.value},
+                    f"Node: {s2.id}": {
+                        "ltype": defs.LinkTypes.AutomaticallyLinkedTo.value
+                    },
+                    f"Node: {s1.id}": {"ltype": defs.LinkTypes.LinkedTo.value},
+                },
+                "CRE: 111-112": {
+                    "CRE: 111-113": {"ltype": defs.LinkTypes.Contains.value}
+                },
+                "CRE: 111-113": {},
+                "CRE: 111-114": {
+                    "CRE: 111-112": {"ltype": defs.LinkTypes.Contains.value},
+                    "CRE: 111-113": {"ltype": defs.LinkTypes.Contains.value},
+                },
+                "Node: s1:s1 section": {},
+                "Node: s2:s2 section": {},
+            },
+        )
+
+    def test_introduces_cycle(self) -> None:
+        cre1 = defs.CRE(name="c1", id="111-111")
+        cre2 = defs.CRE(name="c2", id="111-112")
+        cre3 = defs.CRE(name="c3", id="111-113")
+
+        g = CRE_Graph()
+        g.with_graph(graph=nx.DiGraph(), graph_data=[])
+        g.add_cre(cre1)
+        g.add_cre(cre2)
+        g.add_cre(cre3)
+
+        g.add_link(cre1, defs.Link(document=cre2, ltype=defs.LinkTypes.Contains))
+        g.add_link(cre2, defs.Link(document=cre3, ltype=defs.LinkTypes.Contains))
+
+        self.assertIsNone(g.has_cycle())
+
+        # cre -> cre cycle tests
+        self.assertTrue(
+            g.introduces_cycle(
+                cre3, defs.Link(document=cre1, ltype=defs.LinkTypes.Contains)
+            )
+        )
+        self.assertFalse(
+            g.introduces_cycle(
+                cre3, defs.Link(document=cre1, ltype=defs.LinkTypes.PartOf)
+            )
+        )
+        self.assertFalse(
+            g.introduces_cycle(
+                cre1, defs.Link(document=cre3, ltype=defs.LinkTypes.Contains)
+            )
+        )
+        self.assertFalse(
+            g.introduces_cycle(
+                cre1, defs.Link(document=cre3, ltype=defs.LinkTypes.Related)
+            )
+        )
+
+        # cre -> node cycle tests, essentially, we cannot have nodes with cycles
+        node1 = defs.Standard(name="s1", section="section1", sectionID="sectionid1")
+        g.add_link(cre2, defs.Link(document=node1, ltype=defs.LinkTypes.LinkedTo))
+        self.assertFalse(
+            g.introduces_cycle(
+                cre1, defs.Link(document=node1, ltype=defs.LinkTypes.LinkedTo)
+            )
+        )
+        self.assertFalse(
+            g.introduces_cycle(
+                cre1,
+                defs.Link(document=node1, ltype=defs.LinkTypes.AutomaticallyLinkedTo),
+            )
+        )

--- a/application/tests/juiceshop_test.py
+++ b/application/tests/juiceshop_test.py
@@ -78,7 +78,10 @@ class TestJuiceshopParser(unittest.TestCase):
                 embeddings_text="Sensitive Data Exposure",
                 hyperlink="https://demo.owasp-juice.shop//#/score-board?searchQuery=Access%20Log",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123"),ltype=defs.LinkTypes.LinkedTo),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-123", id="123-123"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 name="OWASP Juice Shop",
                 section="Access Log",

--- a/application/tests/juiceshop_test.py
+++ b/application/tests/juiceshop_test.py
@@ -42,7 +42,7 @@ class TestJuiceshopParser(unittest.TestCase):
         dbnode = self.collection.add_node(
             defs.Standard(name="fakeNode", sectionID="123")
         )
-        self.collection.add_link(dbcre, dbnode)
+        self.collection.add_link(dbcre, dbnode, ltype=defs.LinkTypes.LinkedTo)
 
         mock_requests.return_value = fakeRequest()
         mock_get_text_embeddings.return_value = [0.1, 0.2]
@@ -60,7 +60,10 @@ class TestJuiceshopParser(unittest.TestCase):
                 embeddings_text="XSS",
                 hyperlink="https://demo.owasp-juice.shop//#/score-board?searchQuery=API-only%20XSS",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123")),
+                    defs.Link(
+                        document=defs.CRE(name="CRE-123", id="123-123"),
+                        ltype=defs.LinkTypes.LinkedTo,
+                    ),
                 ],
                 tags=["XSS"],
                 name="OWASP Juice Shop",
@@ -75,7 +78,7 @@ class TestJuiceshopParser(unittest.TestCase):
                 embeddings_text="Sensitive Data Exposure",
                 hyperlink="https://demo.owasp-juice.shop//#/score-board?searchQuery=Access%20Log",
                 links=[
-                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123")),
+                    defs.Link(document=defs.CRE(name="CRE-123", id="123-123"),ltype=defs.LinkTypes.LinkedTo),
                 ],
                 name="OWASP Juice Shop",
                 section="Access Log",

--- a/application/tests/mdutils_test.py
+++ b/application/tests/mdutils_test.py
@@ -45,13 +45,21 @@ class TestMdutilsParser(unittest.TestCase):
             )
             for s in range(0, 10)
         ]
-        standards[0].add_link(defs.Link(document=cres[2]))
+        standards[0].add_link(
+            defs.Link(document=cres[2], ltype=defs.LinkTypes.LinkedTo)
+        )
         for i in range(0, 10):
-            standards[i].add_link(defs.Link(document=cres[i]))
+            standards[i].add_link(
+                defs.Link(document=cres[i], ltype=defs.LinkTypes.LinkedTo)
+            )
             if not i % 2:
-                standards[i].add_link(defs.Link(document=tools[i]))
+                standards[i].add_link(
+                    defs.Link(document=tools[i], ltype=defs.LinkTypes.LinkedTo)
+                )
             else:
-                standards[i].add_link(defs.Link(document=standards2[i]))
+                standards[i].add_link(
+                    defs.Link(document=standards2[i], ltype=defs.LinkTypes.LinkedTo)
+                )
         self.maxDiff = None
         self.assertEqual(mdutils.cre_to_md(standards), self.result)
 

--- a/application/tests/oscal_utils_test.py
+++ b/application/tests/oscal_utils_test.py
@@ -32,7 +32,8 @@ class TestOSCALUtils(unittest.TestCase):
             if i % 5 == 0:
                 cre.add_link(
                     defs.Link(
-                        document=defs.CRE(name=f"cre-{i}", id=f"{i}{i}{i}-{i}{i}{i}")
+                        document=defs.CRE(name=f"cre-{i}", id=f"{i}{i}{i}-{i}{i}{i}"),
+                        ltype=defs.LinkTypes.LinkedTo,
                     )
                 )
             elif i % 5 == 1:
@@ -42,7 +43,8 @@ class TestOSCALUtils(unittest.TestCase):
                             name=f"standard-{i}",
                             section=f"{i}",
                             hyperlink=f"https://example.com/{i}",
-                        )
+                        
+                        ),ltype=defs.LinkTypes.LinkedTo,
                     )
                 )
             else:
@@ -52,7 +54,7 @@ class TestOSCALUtils(unittest.TestCase):
                             name=f"tool-{i}",
                             sectionID=f"{i}",
                             hyperlink=f"https://example.com/{i}",
-                        )
+                        ),ltype=defs.LinkTypes.LinkedTo,
                     )
                 )
 
@@ -127,7 +129,13 @@ class TestOSCALUtils(unittest.TestCase):
         )
         for i in range(0, 5):
             standard.add_link(
-                defs.Link(document=defs.CRE(name=f"cre-{i}", id=f"{i}{i}{i}-{i}{i}{i}"))
+                defs.Link(
+                    document=defs.CRE(
+                        name=f"cre-{i}",
+                        id=f"{i}{i}{i}-{i}{i}{i}",
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
+                )
             )
 
         expected = {
@@ -300,7 +308,8 @@ class TestOSCALUtils(unittest.TestCase):
             for j in range(0, 5):
                 standard.add_link(
                     defs.Link(
-                        document=defs.CRE(name=f"cre-{j}", id=f"{j}{j}{j}-{j}{j}{j}")
+                        document=defs.CRE(name=f"cre-{j}", id=f"{j}{j}{j}-{j}{j}{j}"),
+                        ltype=defs.LinkTypes.LinkedTo,
                     )
                 )
             standards.append(standard)
@@ -362,7 +371,13 @@ class TestOSCALUtils(unittest.TestCase):
         )
         for i in range(0, 5):
             tool.add_link(
-                defs.Link(document=defs.CRE(name=f"cre-{i}", id=f"{i}{i}{i}-{i}{i}{i}"))
+                defs.Link(
+                    document=defs.CRE(
+                        name=f"cre-{i}",
+                        id=f"{i}{i}{i}-{i}{i}{i}",
+                    ),
+                    ltype=defs.LinkTypes.LinkedTo,
+                )
             )
 
         expected = {

--- a/application/tests/oscal_utils_test.py
+++ b/application/tests/oscal_utils_test.py
@@ -43,8 +43,8 @@ class TestOSCALUtils(unittest.TestCase):
                             name=f"standard-{i}",
                             section=f"{i}",
                             hyperlink=f"https://example.com/{i}",
-                        
-                        ),ltype=defs.LinkTypes.LinkedTo,
+                        ),
+                        ltype=defs.LinkTypes.LinkedTo,
                     )
                 )
             else:
@@ -54,7 +54,8 @@ class TestOSCALUtils(unittest.TestCase):
                             name=f"tool-{i}",
                             sectionID=f"{i}",
                             hyperlink=f"https://example.com/{i}",
-                        ),ltype=defs.LinkTypes.LinkedTo,
+                        ),
+                        ltype=defs.LinkTypes.LinkedTo,
                     )
                 )
 

--- a/application/tests/spreadsheet_test.py
+++ b/application/tests/spreadsheet_test.py
@@ -49,7 +49,7 @@ class TestDB(unittest.TestCase):
         )
 
         collection.add_internal_link(
-            collection.add_cre(cc), collection.add_cre(cd), type=defs.LinkTypes.Contains
+            collection.add_cre(cc), collection.add_cre(cd), ltype=defs.LinkTypes.Contains
         )
         result = ExportSheet().prepare_spreadsheet(storage=collection, docs=[cc, cd])
 
@@ -77,17 +77,17 @@ class TestDB(unittest.TestCase):
                         linked_item = collection.add_cre(link.document)
                         if item.doctype == defs.Credoctypes.CRE:
                             collection.add_internal_link(
-                                dbitem, linked_item, type=link.ltype
+                                dbitem, linked_item, ltype=link.ltype
                             )
                         else:
                             collection.add_link(
-                                node=dbitem, cre=linked_item, type=link.ltype
+                                node=dbitem, cre=linked_item, ltype=link.ltype
                             )
                     else:
                         linked_item = collection.add_node(link.document)
                         if item.doctype == defs.Credoctypes.CRE:
                             collection.add_link(
-                                cre=dbitem, node=linked_item, type=link.ltype
+                                cre=dbitem, node=linked_item, ltype=link.ltype
                             )
                         else:
                             collection.add_internal_link(

--- a/application/tests/spreadsheet_test.py
+++ b/application/tests/spreadsheet_test.py
@@ -49,7 +49,9 @@ class TestDB(unittest.TestCase):
         )
 
         collection.add_internal_link(
-            collection.add_cre(cc), collection.add_cre(cd), ltype=defs.LinkTypes.Contains
+            collection.add_cre(cc),
+            collection.add_cre(cd),
+            ltype=defs.LinkTypes.Contains,
         )
         result = ExportSheet().prepare_spreadsheet(storage=collection, docs=[cc, cd])
 

--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -130,10 +130,10 @@ class TestMain(unittest.TestCase):
         dcd = collection.add_cre(cres["cd"])
 
         collection.add_internal_link(
-            higher=dca, lower=dcd, type=defs.LinkTypes.Contains
+            higher=dca, lower=dcd, ltype=defs.LinkTypes.Contains
         )
         collection.add_internal_link(
-            higher=dcb, lower=dcd, type=defs.LinkTypes.Contains
+            higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
         )
         self.maxDiff = None
         with self.app.test_client() as client:
@@ -177,13 +177,13 @@ class TestMain(unittest.TestCase):
         dcc = collection.add_cre(cres["cc"])
         dcd = collection.add_cre(cres["cd"])
         collection.add_internal_link(
-            higher=dca, lower=dcd, type=defs.LinkTypes.Contains
+            higher=dca, lower=dcd, ltype=defs.LinkTypes.Contains
         )
         collection.add_internal_link(
-            higher=dcb, lower=dcd, type=defs.LinkTypes.Contains
+            higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
         )
         collection.add_internal_link(
-            higher=dcc, lower=dcd, type=defs.LinkTypes.Contains
+            higher=dcc, lower=dcd, ltype=defs.LinkTypes.Contains
         )
 
         self.maxDiff = None
@@ -462,10 +462,10 @@ class TestMain(unittest.TestCase):
             dcb = collection.add_cre(cres["cb"])
             dcd = collection.add_cre(cres["cd"])
             collection.add_internal_link(
-                higher=dca, lower=dcd, type=defs.LinkTypes.Contains
+                higher=dca, lower=dcd, ltype=defs.LinkTypes.Contains
             )
             collection.add_internal_link(
-                higher=dcb, lower=dcd, type=defs.LinkTypes.Contains
+                higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
             )
 
             expected = {"data": [cres["ca"].todict(), cres["cb"].todict()]}
@@ -514,10 +514,10 @@ class TestMain(unittest.TestCase):
             dasvs = collection.add_node(standards["ASVS"])
             dcwe = collection.add_node(standards["cwe0"])
             collection.add_internal_link(
-                higher=dca, lower=dcd, type=defs.LinkTypes.Contains
+                higher=dca, lower=dcd, ltype=defs.LinkTypes.Contains
             )
             collection.add_internal_link(
-                higher=dcb, lower=dcd, type=defs.LinkTypes.Contains
+                higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
             )
 
             collection.add_link(dcb, dasvs)
@@ -716,10 +716,10 @@ class TestMain(unittest.TestCase):
             dasvs = collection.add_node(standards["ASVS"])
             dcwe = collection.add_node(standards["cwe0"])
             collection.add_internal_link(
-                higher=dca, lower=dcd, type=defs.LinkTypes.Contains
+                higher=dca, lower=dcd, ltype=defs.LinkTypes.Contains
             )
             collection.add_internal_link(
-                higher=dcb, lower=dcd, type=defs.LinkTypes.Contains
+                higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
             )
 
             collection.add_link(dcb, dasvs)
@@ -893,7 +893,7 @@ class TestMain(unittest.TestCase):
                 )
                 dbcre = collection.add_cre(c)
                 collection.add_internal_link(
-                    higher=previous_db, lower=dbcre, type=defs.LinkTypes.Contains
+                    higher=previous_db, lower=dbcre, ltype=defs.LinkTypes.Contains
                 )
                 previous_cre.add_link(
                     defs.Link(document=c, ltype=defs.LinkTypes.Contains)

--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -505,8 +505,12 @@ class TestMain(unittest.TestCase):
                     ltype=defs.LinkTypes.Contains, document=cres["cd"].shallow_copy()
                 )
             )
-            cres["cd"].add_link(defs.Link(document=standards["cwe0"]))
-            cres["cb"].add_link(defs.Link(document=standards["ASVS"]))
+            cres["cd"].add_link(
+                defs.Link(document=standards["cwe0"], ltype=defs.LinkTypes.LinkedTo)
+            )
+            cres["cb"].add_link(
+                defs.Link(document=standards["ASVS"], ltype=defs.LinkTypes.LinkedTo)
+            )
 
             dca = collection.add_cre(cres["ca"])
             dcb = collection.add_cre(cres["cb"])
@@ -520,8 +524,8 @@ class TestMain(unittest.TestCase):
                 higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
             )
 
-            collection.add_link(dcb, dasvs)
-            collection.add_link(dcd, dcwe)
+            collection.add_link(dcb, dasvs, ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcd, dcwe, ltype=defs.LinkTypes.LinkedTo)
 
             response = client.get(
                 "/smartlink/standard/CWE/456",
@@ -707,8 +711,8 @@ class TestMain(unittest.TestCase):
                     ltype=defs.LinkTypes.Contains, document=cres["cd"].shallow_copy()
                 )
             )
-            cres["cd"].add_link(defs.Link(document=standards["cwe0"]))
-            cres["cb"].add_link(defs.Link(document=standards["ASVS"]))
+            cres["cd"].add_link(defs.Link(document=standards["cwe0"],ltype=defs.LinkTypes.LinkedTo))
+            cres["cb"].add_link(defs.Link(document=standards["ASVS"],ltype=defs.LinkTypes.LinkedTo))
 
             dca = collection.add_cre(cres["ca"])
             dcb = collection.add_cre(cres["cb"])
@@ -722,8 +726,8 @@ class TestMain(unittest.TestCase):
                 higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
             )
 
-            collection.add_link(dcb, dasvs)
-            collection.add_link(dcd, dcwe)
+            collection.add_link(dcb, dasvs,ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcd, dcwe,ltype=defs.LinkTypes.LinkedTo)
 
             response = client.get("/rest/v1/deeplink/CWE?sectionid=456")
             self.assertEqual(404, response.status_code)

--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import redis
 import rq
 import os
+import networkx as nx
 
 from application import create_app, sqla  # type: ignore
 from application.tests.utils import data_gen
@@ -43,6 +44,11 @@ class TestMain(unittest.TestCase):
         self.app_context.push()
         os.environ["INSECURE_REQUESTS"] = "True"
         sqla.create_all()
+
+        self.collection = db.Node_collection().with_graph()
+        self.collection.graph.with_graph(
+            graph=nx.DiGraph(), graph_data=[]
+        )  # initialize the graph singleton for the tests to be unique
 
     def test_extend_cre_with_tag_links(self) -> None:
         """
@@ -112,11 +118,11 @@ class TestMain(unittest.TestCase):
             self.assertEqual(res, v)
 
     def test_find_by_id(self) -> None:
-        collection = db.Node_collection().with_graph()
+        collection = self.collection
 
         cres = {
             "ca": defs.CRE(id="111-111", description="CA", name="CA", tags=["ta"]),
-            "cd": defs.CRE(id="222-222", description="CD", name="CD", tags=["td"]),
+            "cd": defs.CRE(id="222-223", description="CD", name="CD", tags=["td"]),
             "cb": defs.CRE(id="333-333", description="CB", name="CB", tags=["tb"]),
         }
         cres["ca"].add_link(
@@ -137,9 +143,11 @@ class TestMain(unittest.TestCase):
         )
         self.maxDiff = None
         with self.app.test_client() as client:
+            # id does not exist case
             response = client.get(f"/rest/v1/id/9999999999")
             self.assertEqual(404, response.status_code)
 
+            # single id case
             expected = {"data": cres["ca"].todict()}
             response = client.get(
                 f"/rest/v1/id/{cres['ca'].id}",
@@ -148,7 +156,8 @@ class TestMain(unittest.TestCase):
             self.assertEqual(json.loads(response.data.decode()), expected)
             self.assertEqual(200, response.status_code)
 
-            md_expected = "<pre>CRE---[222-222CD](https://www.opencre.org/cre/222-222),[111-111CA](https://www.opencre.org/cre/111-111),[333-333CB](https://www.opencre.org/cre/333-333)</pre>"
+            # change the format to markdown
+            md_expected = "<pre>CRE---[222-223CD](https://www.opencre.org/cre/222-223),[111-111CA](https://www.opencre.org/cre/111-111),[333-333CB](https://www.opencre.org/cre/333-333)</pre>"
             md_response = client.get(
                 f"/rest/v1/id/{cres['cd'].id}?format=md",
                 headers={"Content-Type": "application/json"},
@@ -159,7 +168,7 @@ class TestMain(unittest.TestCase):
         collection = db.Node_collection().with_graph()
         cres = {
             "ca": defs.CRE(id="111-111", description="CA", name="CA", tags=["ta"]),
-            "cd": defs.CRE(id="222-222", description="CD", name="CD", tags=["td"]),
+            "cd": defs.CRE(id="222-224", description="CD", name="CD", tags=["td"]),
             "cb": defs.CRE(id="333-333", description="CB", name="CB", tags=["tb"]),
             "cc": defs.CRE(id="444-444", description="CC", name="CC", tags=["tc"]),
         }
@@ -199,7 +208,7 @@ class TestMain(unittest.TestCase):
             self.assertEqual(200, response.status_code)
             self.assertEqual(json.loads(response.data.decode()), expected)
 
-            md_expected = "<pre>CRE---[222-222CD](https://www.opencre.org/cre/222-222),[111-111CA](https://www.opencre.org/cre/111-111),[333-333CB](https://www.opencre.org/cre/333-333),[444-444CC](https://www.opencre.org/cre/444-444)</pre>"
+            md_expected = "<pre>CRE---[222-224CD](https://www.opencre.org/cre/222-224),[111-111CA](https://www.opencre.org/cre/111-111),[333-333CB](https://www.opencre.org/cre/333-333),[444-444CC](https://www.opencre.org/cre/444-444)</pre>"
             md_response = client.get(
                 f"/rest/v1/name/{cres['cd'].name}?format=md",
                 headers={"Content-Type": "application/json"},
@@ -444,9 +453,9 @@ class TestMain(unittest.TestCase):
             self.assertEqual(404, response.status_code)
 
             cres = {
-                "ca": defs.CRE(id="111-111", description="CA", name="CA", tags=["ta"]),
-                "cd": defs.CRE(id="222-222", description="CD", name="CD", tags=["td"]),
-                "cb": defs.CRE(id="333-333", description="CB", name="CB", tags=["tb"]),
+                "ca": defs.CRE(id="111-115", description="CA", name="CA", tags=["ta"]),
+                "cd": defs.CRE(id="222-225", description="CD", name="CD", tags=["td"]),
+                "cb": defs.CRE(id="333-335", description="CB", name="CB", tags=["tb"]),
             }
             cres["ca"].add_link(
                 defs.Link(
@@ -711,8 +720,12 @@ class TestMain(unittest.TestCase):
                     ltype=defs.LinkTypes.Contains, document=cres["cd"].shallow_copy()
                 )
             )
-            cres["cd"].add_link(defs.Link(document=standards["cwe0"],ltype=defs.LinkTypes.LinkedTo))
-            cres["cb"].add_link(defs.Link(document=standards["ASVS"],ltype=defs.LinkTypes.LinkedTo))
+            cres["cd"].add_link(
+                defs.Link(document=standards["cwe0"], ltype=defs.LinkTypes.LinkedTo)
+            )
+            cres["cb"].add_link(
+                defs.Link(document=standards["ASVS"], ltype=defs.LinkTypes.LinkedTo)
+            )
 
             dca = collection.add_cre(cres["ca"])
             dcb = collection.add_cre(cres["cb"])
@@ -726,8 +739,8 @@ class TestMain(unittest.TestCase):
                 higher=dcb, lower=dcd, ltype=defs.LinkTypes.Contains
             )
 
-            collection.add_link(dcb, dasvs,ltype=defs.LinkTypes.LinkedTo)
-            collection.add_link(dcd, dcwe,ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcb, dasvs, ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcd, dcwe, ltype=defs.LinkTypes.LinkedTo)
 
             response = client.get("/rest/v1/deeplink/CWE?sectionid=456")
             self.assertEqual(404, response.status_code)

--- a/application/tests/zap_alerts_parser_test.py
+++ b/application/tests/zap_alerts_parser_test.py
@@ -81,21 +81,21 @@ class TestZAPAlertsParser(unittest.TestCase):
         ]
         cre = self.collection.add_cre(defs.CRE(name="foo", id="000-000"))
         [
-            self.collection.add_link(cre, top10)
+            self.collection.add_link(cre, top10, ltype=defs.LinkTypes.LinkedTo)
             for top10 in top10s
             if top10.subsection == "something"
         ]
 
         cre2 = self.collection.add_cre(defs.CRE(name="bar", id="000-001"))
         [
-            self.collection.add_link(cre2, top10)
+            self.collection.add_link(cre2, top10, ltype=defs.LinkTypes.LinkedTo)
             for top10 in top10s
             if top10.subsection == ""
         ]
 
         cre3 = self.collection.add_cre(defs.CRE(name="foobar", id="000-003"))
         [
-            self.collection.add_link(cre, top10)
+            self.collection.add_link(cre, top10, ltype=defs.LinkTypes.LinkedTo)
             for top10 in top10s
             if top10.subsection == "wrong year"
         ]
@@ -183,8 +183,8 @@ class TestZAPAlertsParser(unittest.TestCase):
         dbcre0 = self.collection.add_cre(defs.CRE(name="foo", id="111-110"))
         dbcre1 = self.collection.add_cre(defs.CRE(name="foo1", id="111-111"))
         dbcwe = self.collection.add_node(defs.Standard(name="CWE", sectionID="1021"))
-        self.collection.add_link(cre=dbcre0, node=dbcwe)
-        self.collection.add_link(cre=dbcre1, node=dbcwe)
+        self.collection.add_link(cre=dbcre0, node=dbcwe, ltype=defs.LinkTypes.LinkedTo)
+        self.collection.add_link(cre=dbcre1, node=dbcwe, ltype=defs.LinkTypes.LinkedTo)
 
         entries = zap_alerts_parser.ZAP().parse(
             cache=self.collection, ph=prompt_client.PromptHandler(self.collection)

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -102,7 +102,6 @@ def find_cre(creid: str = None, crename: str = None) -> Any:  # refer
     # opt_osib = request.args.get("osib")
     opt_format = request.args.get("format")
     cres = database.get_CREs(external_id=creid, name=crename, include_only=include_only)
-
     if cres:
         if len(cres) > 1:
             logger.error("get by id returned more than one results? This looks buggy")


### PR DESCRIPTION
fix bug #552  by ensuring that ALL db cre links are from Higher->Lower … and of type either contains or related, no more lower->higher of type partof since this is prone to bugs, part of is now an api construct

also implement feature #555  remove the obsolete SAME relationship