### PR TITLE
Change in requirement.txt and Makefile for Linux installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ install-deps-typescript:
 install-deps: install-deps-python install-deps-typescript
 
 install-python:
-	virtualenv -p python3 --system-site-packages venv
+	virtualenv -p python3  venv
 	. ./venv/bin/activate &&\
 	make install-deps-python &&\
 	playwright install

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,7 +103,6 @@ threadpoolctl
 toml
 tomli
 tqdm
-typed-ast
 types-PyYAML
 typing-inspect
 typing_extensions


### PR DESCRIPTION
During the OpenCRE installation over Linux , I encountered some errors which after discussing with the maintainer @northdpole  were solved ,below is the detailed explanation about each error and how I solved it :

Documentation Used : [developmentSetup](https://github.com/OWASP/OpenCRE/blob/37d5db34ee1434421b968982dce8474c1cf047c0/docs/developmentSetup.md)

1. After cloning the forked repo , when I entered the `make install` command ,it showed me the error - Building wheel for typed_ast failed.
![image](https://github.com/user-attachments/assets/4eaddee3-f5dd-4a26-886a-ba49cf3c2ba5)
Then to solved this I removed the typed_ast from requirement.txt file {As this file is of no importance in current versions}
2. Now , after solving the above error a new error came related to system-site-packages -
![image](https://github.com/user-attachments/assets/282dff05-b37a-46c2-9170-63e454362416)
The above error was solved by removing the system-site-packages line from "install python" function in Make file -
![image](https://github.com/user-attachments/assets/d495c6f8-0dea-4251-9913-1b859da8214a)
