### PR TITLE
Changes in Explorer and Visual Graphs

### DIFF
--- a/application/frontend/src/pages/Explorer/visuals/circles/circles.tsx
+++ b/application/frontend/src/pages/Explorer/visuals/circles/circles.tsx
@@ -88,6 +88,7 @@ export const ExplorerCircles = () => {
         return d.parent === root ? 'inline' : 'none';
       })
       .text(function (d: any) {
+        if (!d.data.displayName) return '';
         let name =
           d.data.displayName.length > 33 ? d.data.displayName.substr(0, 33) + '...' : d.data.displayName;
         if (d.data.children && d.data.children.length > 0) name += ' (' + d.data.children.length + ')';

--- a/application/frontend/src/pages/Explorer/visuals/force-graph/forceGraph.tsx
+++ b/application/frontend/src/pages/Explorer/visuals/force-graph/forceGraph.tsx
@@ -55,15 +55,15 @@ export const ExplorerForceGraph = () => {
       addNode(link.source);
       addNode(link.target);
     });
-
-    setMaxNodeSize(gData.nodes.map((n) => n.size).reduce((a, b) => Math.max(a, b)));
-    setMaxCount(gData.links.map((l) => l.count).reduce((a, b) => Math.max(a, b)));
+    //Added inital value to reduce array
+    setMaxNodeSize(gData.nodes.map((n) => n.size).reduce((a, b) => Math.max(a, b), 0));
+    setMaxCount(gData.links.map((l) => l.count).reduce((a, b) => Math.max(a, b), 0));
 
     gData.links = gData.links.map((l) => {
       return { source: l.target, target: l.source, count: l.count, type: l.type };
     });
     setGraphData(gData);
-  }, [ignoreTypes]);
+  }, [ignoreTypes, dataTree]);
 
   const getLinkColor = (ltype) => {
     switch (ltype.toLowerCase()) {

--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -25,10 +25,10 @@ const getLinks = (): { to: string; name: string }[] => [
     to: `/map_analysis`,
     name: 'Map Analysis',
   },
-  // {
-  //   to: `/explorer`,
-  //   name: 'OpenCRE Explorer',
-  // },
+  {
+    to: `/explorer`,
+    name: 'OpenCRE Explorer',
+  },
 ];
 
 export const Header = () => {


### PR DESCRIPTION
This PR is related to ticket #514  
1- In explorer , I have checked and Made sure that all CREs and Standards are rendered correctly on the frontend . - See the solution through the last commit by @dlicheva (https://github.com/OWASP/OpenCRE/pull/542) 
2- For Circular Graph , I have added an edge condition for displayName -
Genrated Graph - 
![image](https://github.com/user-attachments/assets/603cab0d-23a0-4127-9f3c-c69125c1d0c7)
3- Similairy here for Force_graph I have added an edge condition for `reduce()` array.