### PR TITLE
Update DSOMM's hyperlink query parameter from action to uuid

### DIFF
--- a/application/utils/external_project_parsers/parsers/dsomm.py
+++ b/application/utils/external_project_parsers/parsers/dsomm.py
@@ -115,7 +115,7 @@ class DSOMM(ParserInterface):
                             section=sname,
                             subsection=aname,
                             sectionID=activity.get("uuid"),
-                            hyperlink=f"https://dsomm.owasp.org/activity-description?action={activity.get('uuid')}",
+                            hyperlink=f"https://dsomm.owasp.org/activity-description?uuid={activity.get('uuid')}",
                             description=f"Description:{activity.get('description')}\n Risk:{activity.get('risk')}\n Measure:{activity.get('measure')}",
                         )
                     else:


### PR DESCRIPTION
This update fixes #598 by updating DSOMM's hyperlink query parameter from `action` to `uuid.`