### PR TITLE
Fix: Zoomable circles responsive resize, label toggle, and zoom steps (#619)

### DIFF
--- a/application/frontend/src/pages/Explorer/visuals/circles/circles.scss
+++ b/application/frontend/src/pages/Explorer/visuals/circles/circles.scss
@@ -16,9 +16,9 @@
     font: 11px "Helvetica Neue", Helvetica, Arial, sans-serif;
     text-anchor: middle;
     text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff, 0 -1px 0 #fff;
+    pointer-events: none;
 }
 
-.label,
 .node--root,
 .node--leaf {
     pointer-events: none;
@@ -29,4 +29,8 @@
     right: 0;
     margin: 0;
     background-color: transparent;
+}
+
+.ui.toggle.checkbox {
+    margin-right: 10px;
 }


### PR DESCRIPTION
🔧 Summary of Fixes for Issue #619
This PR addresses the zoomable circle visualization issues and improves overall responsiveness and usability.

✅ Fixes Implemented:
Responsive Resize: Circles now correctly resize with browser window changes by adding width and height to the dependency array in the useEffect.

Label Toggle: Added a checkbox to toggle labels (enabled by default) for better visibility and cleaner UI.

Label Positioning: Moved labels to the top of each circle using the dy attribute for better clarity (instead of center).

Zoom Improvement: Made zoom steps 3x larger for a more noticeable zoom effect by adjusting the margin calculation logic.

Renaming: Renamed the root node label from 'Cluster' to 'OpenCRE' for consistency with project terminology.

