### PR TITLE
Fixed ticket #619 - Changes in Zoomable -Circles (Parth)

### DIFF
--- a/application/frontend/src/pages/Explorer/visuals/circles/circles.scss
+++ b/application/frontend/src/pages/Explorer/visuals/circles/circles.scss
@@ -1,32 +1,61 @@
-
 .node {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .node:hover {
-    stroke: #000;
-    stroke-width: 1.5px;
+  stroke: #000;
+  stroke-width: 1.5px;
 }
 
 .node--leaf {
-    fill: white;
+  fill: white;
 }
 
 .label {
-    font: 11px "Helvetica Neue", Helvetica, Arial, sans-serif;
-    text-anchor: middle;
-    text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff, 0 -1px 0 #fff;
+  font: 11px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  text-anchor: middle;
+  text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff, 0 -1px 0 #fff;
 }
 
 .label,
 .node--root,
-.node--leaf {
-    pointer-events: none;
-}
+// .node--leaf {
+//   pointer-events: none;
+// }
 
 .ui.button.screen-size-button {
-    position: absolute;
-    right: 0;
-    margin: 0;
-    background-color: transparent;
+  /* position: absolute;  */
+  /* right: 0;            */
+  margin: 0;
+  background-color: transparent;
+}
+
+.circle-tooltip {
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  max-width: 300px;
+  word-wrap: break-word;
+}
+.breadcrumb-item {
+  word-break: break-word; // Break long words in breadcrumb items
+  overflow-wrap: anywhere;
+  display: inline; // Or inline-block if you want padding/margin to apply
+  max-width: 100%; // Prevent overflow
+}
+.breadcrumb-container {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  padding: 10px;
+  background-color: #f8f8f8;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+
+  overflow: auto;
+  max-width: 100%;
+
+  line-height: 1.4;
+  white-space: normal; // Allow wrapping
+  word-break: break-word; // Break long words if needed
+  overflow-wrap: anywhere;
 }

--- a/application/frontend/src/pages/Explorer/visuals/circles/circles.tsx
+++ b/application/frontend/src/pages/Explorer/visuals/circles/circles.tsx
@@ -11,12 +11,21 @@ export const ExplorerCircles = () => {
   const { height, width } = useWindowDimensions();
   const [useFullScreen, setUseFullScreen] = useState(false);
   const { dataLoading, dataTree } = useDataStore();
+  const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+  
+
+  const rootRef = React.useRef<any>(null);
+  const zoomRef = React.useRef<any>(null);
+  const updateBreadcrumbRef = React.useRef<any>(null);
+  const viewRef = React.useRef<any>(null);
+  const zoomToRef = React.useRef<any>(null);
+  const margin = 20;
 
   useEffect(() => {
     var svg = d3.select('svg');
     svg.selectAll('*').remove();
-    var margin = 20,
-      diameter = +svg.attr('width'),
+
+    var diameter = +svg.attr('width'),
       g = svg.append('g').attr('transform', 'translate(' + diameter / 2 + ',' + diameter / 2 + ')');
 
     var color = d3
@@ -60,6 +69,42 @@ export const ExplorerCircles = () => {
       nodes = pack(root).descendants(),
       view;
 
+    // Create tooltip div for hover labels
+    const tooltip = d3
+      .select('body')
+      .append('div')
+      .attr('class', 'circle-tooltip')
+      .style('position', 'absolute')
+      .style('visibility', 'hidden')
+      .style('background-color', 'white')
+      .style('padding', '5px')
+      .style('border-radius', '3px')
+      .style('border', '1px solid #ccc')
+      .style('pointer-events', 'none')
+      .style('z-index', '10');
+
+    // Update breadcrumb when focus changes
+    const updateBreadcrumb = (d: any) => {
+      if (d === root) {
+        setBreadcrumb(['Cluster']);
+        return;
+      }
+
+      let path: string[] = [];
+      let current = d;
+
+      while (current && current !== root) {
+        if (current.data.displayName && current.data.displayName !== 'cluster') {
+          // Remove "CRE: " prefix if it exists
+          const displayName = current.data.displayName.replace(/^CRE: /, '');
+          path.unshift(displayName);
+        }
+        current = current.parent;
+      }
+      path.unshift('Cluster');
+      setBreadcrumb(path);
+    };
+
     var circle = g
       .selectAll('circle')
       .data(nodes)
@@ -71,38 +116,130 @@ export const ExplorerCircles = () => {
       .style('fill', function (d: any) {
         return d.children ? color(d.depth) : d.data.color ? d.data.color : null;
       })
-      .on('click', function (event, d: any) {
-        if (focus !== d) zoom(event, d), event.stopPropagation();
-      });
+      // .on('mouseover', function (event, d: any) {
+      //   // console.log('Hovered node:', d.data);  // Log the hovered node data -- Parth (for checking)
+      //   if (d.data.displayName) {
+      //     // Remove "CRE: " prefix if it exists
+      //     const displayName = d.data.displayName.replace(/^CRE: /, '');
 
+      //     // Show full label without truncation
+      //     tooltip
+      //       .html(displayName)
+      //       .style('visibility', 'visible')
+      //       .style('top', event.pageY - 10 + 'px')
+      //       .style('left', event.pageX + 10 + 'px');
+      //   }
+      // })
+      //New mouseover to use id if diaplayName is not present (most likely for white dots )
+      .on('mouseover', function (event, d: any) {
+        // Prefer displayName, fallback to id
+        const label = d.data.displayName
+          ? d.data.displayName.replace(/^CRE: /, '')
+          : d.data.id
+          ? d.data.id
+          : '';
+
+        if (label) {
+          tooltip
+            .html(label)
+            .style('visibility', 'visible')
+            .style('top', event.pageY - 10 + 'px')
+            .style('left', event.pageX + 10 + 'px');
+        }
+      })
+      .on('mousemove', function (event) {
+        tooltip.style('top', event.pageY - 10 + 'px').style('left', event.pageX + 10 + 'px');
+      })
+      .on('mouseout', function () {
+        tooltip.style('visibility', 'hidden');
+      })
+      .on('click', function (event, d: any) {
+        if (focus !== d) {
+          updateBreadcrumb(d);
+          zoom(event, d);
+          event.stopPropagation();
+        }
+      });
+// This is will make sure that no labels are shown at the start
     var text = g
       .selectAll('text')
       .data(nodes)
       .enter()
       .append('text')
       .attr('class', 'label')
-      .style('fill-opacity', function (d: any) {
-        return d.parent === root ? 1 : 0;
-      })
-      .style('display', function (d: any) {
-        return d.parent === root ? 'inline' : 'none';
-      })
+      // .style('fill-opacity', function (d: any) {
+      //   // Show text at all zoom levels
+      //   return d.parent === root || d.parent === focus ? 1 : 0;
+      // })
+      .style('fill-opacity', 0)
+      // .style('display', function (d: any) {
+      //   // Try to display all labels if there's room
+      //   return d.parent === root || d.parent === focus ? 'inline' : 'none';
+      // })
+      .style('display', 'none') // Hide all text initially
       .text(function (d: any) {
         if (!d.data.displayName) return '';
-        let name =
-          d.data.displayName.length > 33 ? d.data.displayName.substr(0, 33) + '...' : d.data.displayName;
-        if (d.data.children && d.data.children.length > 0) name += ' (' + d.data.children.length + ')';
+
+        // Remove "CRE: " prefix
+        let name = d.data.displayName.replace(/^CRE: /, '');
+
+        // Truncate if necessary
+        name = name.length > 33 ? name.substr(0, 33) + '...' : name;
+
+        // Add count of children
+        if (d.data.children && d.data.children.length > 0) {
+          name += ' (' + d.data.children.length + ')';
+        }
+
         return name;
       });
 
     var node = g.selectAll('circle,text');
 
     svg.style('background', color(-1)).on('click', function (event) {
+      updateBreadcrumb(root);
       zoom(event, root);
     });
 
     zoomTo([root.x, root.y, root.r * 2 + margin]);
+    setBreadcrumb(['Cluster']);
 
+    // function zoom(event: any, d: any) {
+    //   var focus0 = focus;
+    //   focus = d;
+
+    //   var transition = d3
+    //     .transition()
+    //     .duration(event.altKey ? 7500 : 750)
+    //     .tween('zoom', function (d) {
+    //       var i = d3.interpolateZoom(view, [focus.x, focus.y, focus.r * 2 + margin]);
+    //       return function (t) {
+    //         zoomTo(i(t));
+    //       };
+    //     });
+
+    //   transition
+    //     .selectAll('text')
+    //     .filter(function (d: any) {
+    //       const el = this as HTMLElement;
+    //       // Show text for all nodes that are children of the current focus
+    //       return (d && d.parent === focus) || el.style.display === 'inline';
+    //     })
+    //     .style('fill-opacity', function (d: any) {
+    //       // Show text at all zoom levels, including deepest
+    //       return d && d.parent === focus ? 1 : 0;
+    //     })
+    //     .on('start', function (d: any) {
+    //       const el = this as HTMLElement;
+    //       if (d && d.parent === focus) el.style.display = 'inline';
+    //     })
+    //     .on('end', function (d: any) {
+    //       const el = this as HTMLElement;
+    //       if (d && d.parent !== focus) el.style.display = 'none';
+    //     });
+    // }
+
+    //Updated the zoom function so that it does not show text at all zoom levels
     function zoom(event: any, d: any) {
       var focus0 = focus;
       focus = d;
@@ -116,29 +253,12 @@ export const ExplorerCircles = () => {
             zoomTo(i(t));
           };
         });
-
-      transition
-        .selectAll('text')
-        .filter(function (d: any) {
-          const el = this as HTMLElement;
-          return (d && d.parent === focus) || el.style.display === 'inline';
-        })
-        .style('fill-opacity', function (d: any) {
-          return d && d.parent === focus ? 1 : 0;
-        })
-        .on('start', function (d: any) {
-          const el = this as HTMLElement;
-          if (d && d.parent === focus) el.style.display = 'inline';
-        })
-        .on('end', function (d: any) {
-          const el = this as HTMLElement;
-          if (d && d.parent !== focus) el.style.display = 'none';
-        });
     }
 
     function zoomTo(v) {
       var k = diameter / v[2];
       view = v;
+      viewRef.current = v;
       node.attr('transform', function (d: any) {
         return 'translate(' + (d.x - v[0]) * k + ',' + (d.y - v[1]) * k + ')';
       });
@@ -146,26 +266,184 @@ export const ExplorerCircles = () => {
         return d.r * k;
       });
     }
-  }, [useFullScreen]);
+    rootRef.current = root;
+    zoomRef.current = zoom;
+    updateBreadcrumbRef.current = updateBreadcrumb;
+    zoomToRef.current = zoomTo;
+
+    // Clean up tooltip when component unmounts
+    return () => {
+      d3.select('.circle-tooltip').remove();
+    };
+  }, [useFullScreen, dataTree]);
+
   const defaultSize = width > height ? height - 100 : width;
   const size = useFullScreen ? width : defaultSize;
+
   return (
-    <div>
-      <LoadingAndErrorIndicator loading={dataLoading} error={null} />
-      <div style={{ display: 'block', margin: 'auto', width: 'fit-content' }}>
-        <div style={{ position: 'relative' }}>
+    <div style={{ position: 'relative', width: '100vw', minHeight: size + 80 }}>
+      {/* Breadcrumb navigation: full width, at the top */}
+      {breadcrumb.length > 0 && (
+        <div
+          className="breadcrumb-container"
+          style={{
+            margin: 0,
+            marginBottom: 0,
+            textAlign: 'center',
+            borderRadius: '8px 8px 0 0',
+            width: '100vw',
+            maxWidth: '100vw',
+            background: '#f8f8f8',
+            boxSizing: 'border-box',
+            position: 'relative',
+            zIndex: 10,
+          }}
+        >
+          {breadcrumb.map((item, index) => (
+            <React.Fragment key={index}>
+              {index > 0 && <span className="separator"> &gt; </span>}
+              <span
+                className="breadcrumb-item"
+                style={{
+                  cursor: index === breadcrumb.length - 1 ? 'default' : 'pointer',
+                  color: index === breadcrumb.length - 1 ? '#333' : '#2185d0',
+                  fontWeight: index === breadcrumb.length - 1 ? 'bold' : 500,
+                  textDecoration: index === breadcrumb.length - 1 ? 'none' : 'underline',
+                }}
+                onClick={() => {
+                  if (index < breadcrumb.length - 1) {
+                    let node = rootRef.current;
+                    for (let i = 1; i <= index; i++) {
+                      if (!node.children) break;
+                      node = node.children.find(
+                        (child) =>
+                          child.data.displayName &&
+                          child.data.displayName.replace(/^CRE: /, '') === breadcrumb[i]
+                      );
+                      if (!node) break;
+                    }
+                    if (node) {
+                      updateBreadcrumbRef.current(node);
+                      zoomRef.current({ altKey: false }, node);
+                    }
+                  }
+                }}
+              >
+                {item}
+              </span>
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+
+      {/* Graph container: absolutely positioned and centered */}
+      <div
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: 60, // adjust if needed to leave space for breadcrumbs
+          transform: 'translateX(-50%)',
+          width: size,
+          height: size,
+          background: 'rgb(163, 245, 207)',
+          borderRadius: 8,
+          zIndex: 1,
+        }}
+      >
+        {/* Top right fullscreen button */}
+        <div
+          style={{
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '5px',
+            zIndex: 21,
+          }}
+        >
           <Button icon onClick={() => setUseFullScreen(!useFullScreen)} className="screen-size-button">
             <Icon name={useFullScreen ? 'compress' : 'expand'} />
           </Button>
         </div>
+        {/* Bottom right zoom controls */}
+        <div
+          style={{
+            position: 'absolute',
+            right: 20,
+            bottom: 20,
+            display: 'flex',
+            // --- FIX 1: Changed to 'row' to make both buttons visible ---
+            flexDirection: 'row',
+            gap: '10px',
+            zIndex: 20,
+          }}
+        >
+          <Button
+            icon
+            className="screen-size-button"
+            onClick={() => {
+              if (!zoomToRef.current || !rootRef.current) return;
+
+              const currentView: [number, number, number] = viewRef.current
+                ? viewRef.current
+                : [rootRef.current.x, rootRef.current.y, rootRef.current.r * 2 + margin];
+
+              // --- FIX 2: SWAPPED LOGIC for ZOOM IN ---
+              // To ZOOM IN, we need a LARGER scale factor, which requires a SMALLER view diameter.
+              const targetView: [number, number, number] = [
+                currentView[0],
+                currentView[1],
+                currentView[2] * 0.8,
+              ];
+              const i = d3.interpolateZoom(currentView, targetView);
+
+              d3.select('svg')
+                .transition()
+                .duration(350)
+                .tween('zoom', () => (t) => zoomToRef.current(i(t)));
+            }}
+          >
+            <Icon name="plus" />
+          </Button>
+          <Button
+            icon
+            className="screen-size-button"
+            onClick={() => {
+              if (!zoomToRef.current || !rootRef.current) return;
+
+              const currentView: [number, number, number] = viewRef.current
+                ? viewRef.current
+                : [rootRef.current.x, rootRef.current.y, rootRef.current.r * 2 + margin];
+
+              // --- FIX 2: SWAPPED LOGIC for ZOOM OUT ---
+              // To ZOOM OUT, we need a SMALLER scale factor, which requires a LARGER view diameter.
+              const targetView: [number, number, number] = [
+                currentView[0],
+                currentView[1],
+                currentView[2] / 0.8,
+              ];
+              const i = d3.interpolateZoom(currentView, targetView);
+
+              d3.select('svg')
+                .transition()
+                .duration(350)
+                .tween('zoom', () => (t) => zoomToRef.current(i(t)));
+            }}
+          >
+            <Icon name="minus" />
+          </Button>
+        </div>
+        `
         <svg
           width={size}
           height={size}
-          style={{ background: 'rgb(163, 245, 207)', display: 'block', margin: 'auto' }}
+          style={{ background: 'transparent', display: 'block', margin: 'auto' }}
         >
-          <g transform="translate(480,480)"></g>
+          <g transform={`translate(${size / 2},${size / 2})`}></g>
         </svg>
       </div>
+      <LoadingAndErrorIndicator loading={dataLoading} error={null} />
     </div>
   );
 };


### PR DESCRIPTION
@robvanderveer @northdpole @paoga87 
As mentioned in the ticket #619 , here the changes made in the Zoomable Circles -- 
1) Changes the name from "Cluster" --> "OpenCRE" 
2) Increased the Zoom-in/out scale from "0.8" --> "2.4" (3 times) 
3) - Solved the resizing problem --> Cause = D3 circles don't resize with the browser window because the drawing logic within the useEffect hook is not re-running when the window dimensions change --> Solution = Moved size  outside the useEffect and added it to dependency 
4) Enabled the labels and made then render at the top of the circle

Demonstrating video - 

https://github.com/user-attachments/assets/75833037-6fa4-4517-a545-1469ae338e14



Extra changes discussed  After this -- 
1)- Removed the child count 
2)- Removed the Prefix "CRE" and also the number 
3)- To show full label , i removed truncate 
4)- Added down-dash and underline
Ex- 
<img width="720" height="128" alt="image" src="https://github.com/user-attachments/assets/65b63f70-5560-4c83-ad8c-9151527d6e32" />
