### PR TITLE
fix(navbar): hide 'Toggle Menu' text in mobile view, only visible to sr-only (#631)

### DIFF
--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -14,7 +14,7 @@
   &__container {
     max-width: 112rem; // max-w-7xl
     margin: 0 auto;
-    padding: 0 1rem;
+    padding: 0 2rem;
     @media (min-width: 640px) {
       padding: 0 1.5rem;
     }
@@ -37,7 +37,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-left: 4rem;
+  margin-left: 2rem;
   img {
     height: 10rem;
     width: 10rem;
@@ -135,8 +135,8 @@
   border-radius: var(--radius);
 
   .icon {
-    height: 1.25rem;
-    width: 1.25rem;
+    height: 2rem;
+    width: 2rem;
     color: var(--foreground);
   }
 
@@ -144,6 +144,18 @@
     // md:hidden
     display: none;
   }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .navbar__mobile-menu {


### PR DESCRIPTION
## Description 
This PR fixes Issue #631  — `Toggle Menu` text appearing in the navbar on mobile view.

- Added `.sr-only` class to `Header` Component
- Fix logo padding and icon size, for better UI 


## Update
<img width="1081" height="440" alt="fix-opencre" src="https://github.com/user-attachments/assets/81822644-b0da-45ba-9a3a-456da476c627" />
