### PR TITLE
Small Changes to the frontpage

### DIFF
--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -11,7 +11,7 @@ export const SearchPage = () => {
   const { toast } = useToast();
 
   const [isArrowVisible, setIsArrowVisible] = useState(true);
-  const [loading, setLoading] = useState(true);
+  // const [loading, setLoading] = useState(false);
 
   //Search Functionality
   const history = useHistory();
@@ -70,25 +70,25 @@ export const SearchPage = () => {
     }
   };
 
-  useEffect(() => {
-    // Simulate data fetching or API call
-    const timer = setTimeout(() => {
-      setLoading(false); // ✅ stop loading after 2s
-    }, 2000);
+  // useEffect(() => {
+  //   // Simulate data fetching or API call
+  //   const timer = setTimeout(() => {
+  //     setLoading(false); // ✅ stop loading after 2s
+  //   }, 1000);
 
-    return () => clearTimeout(timer); // cleanup
-  }, []);
+  //   return () => clearTimeout(timer); // cleanup
+  // }, []);
 
-  if (loading) {
-    return (
-      <div className="loading-screen">
-        <div className="loading-container">
-          <div className="spinner"></div>
-          <p className="loading-text">Loading...</p>
-        </div>
-      </div>
-    );
-  }
+  // if (loading) {
+  //   return (
+  //     <div className="loading-screen">
+  //       <div className="loading-container">
+  //         <div className="spinner"></div>
+  //         <p className="loading-text">Loading...</p>
+  //       </div>
+  //     </div>
+  //   );
+  // }
 
   return (
     <div className="main-container">
@@ -206,7 +206,9 @@ export const SearchPage = () => {
                 <p>
                   Use the{' '}
                   <strong>
-                    <a href="#search-bar">search bar</a>
+                    {/* Scroll to hero on purpose, the searchbar is covered by the header so we need to scroll to the hero section first */}
+                    <a href="#hero">search bar</a> 
+
                   </strong>
                   ,{' '}
                   <strong>
@@ -262,7 +264,11 @@ export const SearchPage = () => {
               </div>
               <h3 className="feature-block__title">OPENCRE CHAT</h3>
               <p className="feature-block__text">
-                Use <strong>OpenCRE Chat</strong> to ask any security question. In collaboration with{' '}
+                Use <strong>
+                  <a href="https://www.opencre.org/chatbot">
+                    OpenCRE Chat</a>
+                </strong>
+                to ask any security question. In collaboration with{' '}
                 <strong>Google</strong>, we injected all the standards in OpenCRE into an AI model to create
                 the most comprehensive security chatbot. This ensures you get a more{' '}
                 <strong>reliable answer</strong>, and also a reference to a <strong>reputable source</strong>.
@@ -272,7 +278,9 @@ export const SearchPage = () => {
               <div className="feature-block__icon-wrapper">
                 <Network className="icon" />
               </div>
-              <h3 className="feature-block__title">MAP ANALYSIS</h3>
+              <h3 className="feature-block__title">
+                <a href="https://www.opencre.org/map_analysis">
+                  MAP ANALYSIS</a></h3>
               <p className="feature-block__text">
                 Utilize <strong>Map Analysis</strong> as a tool to explore and understand the connections
                 between two standards.

--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -405,7 +405,7 @@ body {
   border-radius: 0.75rem;
   padding: 1.5rem;
   transition: all 0.3s;
-  cursor: pointer;
+  // cursor: pointer;
   font-size: 1.25rem;
 
   &:hover {
@@ -499,7 +499,7 @@ body {
   padding: 2rem;
   text-align: center;
   transition: all 0.3s;
-  cursor: pointer;
+  // cursor: pointer;
 
   &:hover {
     transform: translateY(-0.5rem);
@@ -632,7 +632,7 @@ body {
   border-radius: 0.75rem;
   padding: 2rem;
   transition: all 0.3s;
-  cursor: pointer;
+  // cursor: pointer;
 
   &:hover {
     transform: translateY(-0.5rem);
@@ -735,7 +735,7 @@ body {
         height: 8rem;
         margin: 0 auto 1rem;
         transition: transform 0.3s;
-        cursor: pointer;
+        // cursor: pointer;
         &:hover {
           transform: scale(1.1);
         }
@@ -774,7 +774,7 @@ body {
     border-radius: 0.75rem;
     padding: 1.5rem;
     transition: all 0.3s;
-    cursor: pointer;
+    // cursor: pointer;
     &:hover {
       transform: translateY(-0.5rem);
       border-color: rgba(156, 163, 175, 0.5);
@@ -807,7 +807,7 @@ body {
     padding: 2rem;
     text-align: center;
     transition: all 0.3s;
-    cursor: pointer;
+    // cursor: pointer;
 
     &:hover {
       transform: translateY(-0.5rem);
@@ -898,7 +898,7 @@ body {
   padding: 2rem;
   text-align: center;
   transition: all 0.3s;
-  cursor: pointer;
+  // cursor: pointer;
 
   &:hover {
     transform: translateY(-0.5rem);

--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -2,7 +2,8 @@
 
 .navbar {
   // Positioning and background
-  position: sticky;
+  position: fixed;
+  width: 100%;
   top: 0;
   z-index: 50;
   background-color: rgba(var(--background-rgb), 0.8);


### PR DESCRIPTION
This commit includes the following changes:

Should have:
Make sure the tiles don't change the mousepointer if the tiles are not clickable. The links or buttons in them are clickable. Make OpenCRE chat in the text of the OpenCRE chat tile becomes a clickable link. And/or make the whole tile ckickable and go to that link (in that case the mouse does have to change on the tile). Make Map analysis in the text of the Map analysis tile becomes a clickable link.  And/or make the whole tile ckickable and go to that link (in that case the mouse does have to change on the tile). The page takes a bit to load, which seems a bit silly. It's good that there is a timer, but can't this be made quicker? The sticky header stays in the page below, but at some point disappears. I think that is not intended. Make sure the page scrolls to the "search bar" when people click 'search bar' in the "lookup information" tile. Now it scrolls somewhere else.