### PR TITLE
It's better to link mapanalysis from the text, because there it is cl…

### DIFF
--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -280,7 +280,7 @@ export const SearchPage = () => {
               </div>
               <h3 className="feature-block__title">MAP ANALYSIS</h3>
               <p className="feature-block__text">
-                Utilize <strong><a href="https://www.opencre.org/map_analysis">Map Analysis</a></strong> as a tool to explore and understand the connections
+                Utilize <strong><a href="/map_analysis">Map Analysis</a></strong> as a tool to explore and understand the connections
                 between two standards.
               </p>
               <p className="feature-block__text">


### PR DESCRIPTION
…ick it is a clickable link, instead of the title.