### PR TITLE
fix(navbar): hide "Toggle menu" text visually but keep it screen-reader accessible(#631)

### DIFF
--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -301,3 +301,16 @@
     display: block;
   }
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
This PR fixes Issue #631.

- Added a proper .sr-only class to hide the "Toggle menu" text visually.
- The text remains available to assistive technologies for accessibility.
- Ensures the mobile navbar hamburger button no longer displays the label in UI.
- Follows WCAG and standard sr-only implementation patterns.

Fixes #631.
