### PR TITLE
docs: add macOS local development setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,52 @@
 # OpenCRE
 
 Go to [https://www.opencre.org](https://www.opencre.org) to see OpenCRE working and more explanation.
-
-OpenCRE stands for **Open Common Requirement Enumeration**. It is an interactive content linking platform for uniting security standards and guidelines. It offers easy and robust access to relevant information when designing, developing, testing and procuring secure software.
-
----
-
-## What is OpenCRE?
+OpenCRE stands for Open Common Requirement enumeration. It is an interactive content linking platform for uniting security standards and guidelines. It offers easy and robust access to relevant information when designing, developing, testing and procuring secure software.
 
 OpenCRE consists of:
 
-* **The application**: a Python web and CLI application to access the data, running publicly at opencre.org
-* **The catalog data**: a catalog of Common Requirements (CREs)
-* **The mapping data**: links from each CRE to relevant sections in a range of standards
-* **Tools and guidelines** to contribute to the data and to run the application locally
+* The application: a python web and cli application to access the data, running publicly at opencre.org
+* The catalog data: a catalog of Common Requirements (CREs)
+* The mapping data: links from each CRE to relevant sections in a range of standards
+* Tools and guidelines to contribute to the data and to run the application locally
 
----
+# Contribute code or mappings
 
-## Contribute Code or Mappings
-
-To see how you can contribute to the application or to the data (catalog or standard mappings), see **Contributing**.
-
+To see how you can contribute to the application or to the data (catalog or standard mappings), see [Contributing](docs/CONTRIBUTING.md).
 We really welcome you!
 
----
+# Roadmap
 
-## Roadmap
+For a roadmap please see the [issues](https://github.com/OWASP/OpenCRE/issues).
 
-For a roadmap please see the **Issues**.
+# Running your own OpenCRE
 
----
+You are free to use the public opencre application at opencre.org. Apart from that, you can run your own if you want to include your own security standards and guidelines for example. We call that myOpenCRE.
 
-## Running Your Own OpenCRE
+## Locally
 
-You are free to use the public OpenCRE application at [https://www.opencre.org](https://www.opencre.org).
-You can also run your own instance if you want to include your own security standards and guidelines. We call that **myOpenCRE**.
+### Docker
 
----
-
-## Running OpenCRE Locally
-
-### Docker (Recommended)
-
-The easiest way to run OpenCRE locally is by using Docker:
+The easiest way to run OpenCRE locally is by running the published docker container.
+You can do so by running:
 
 ```bash
 docker run -p 5000:5000 ghcr.io/owasp/opencre/opencre:latest
 ```
 
-After the container has finished downloading the remote information, you can access the application at:
+After the container has finished downloading the remote information you can access it in [http://127.0.0.1:5000](http://127.0.0.1:5000).
 
-```
-http://localhost:5000
-```
+If you want to develop on OpenCRE or docker is not available in your environment, you can alternatively run it via CLI.
 
-If you want to develop OpenCRE or Docker is not available in your environment, you can run it via the command line.
+### Command Line
 
----
-
-## Command Line Setup
-
-To run OpenCRE outside Docker you need:
-
-* Python 3
-* Yarn
-* virtualenv
+To run outside of Docker you need to install OpenCRE.
+To install this application you need python3, yarn and virtualenv.
 
 Clone the repository:
 
 ```bash
-git clone https://github.com/OWASP/OpenCRE.git
-cd OpenCRE
+git clone https://github.com/OWASP/common-requirement-enumeration
 ```
 
 (Recommended) Create and activate a Python virtual environment:
@@ -86,131 +62,39 @@ Install dependencies:
 make install
 ```
 
-Download the latest CRE graph from upstream:
+Download the latest CRE graph from upstream by running:
 
 ```bash
 make upstream-sync
 ```
 
-> ⚠️ Until Issue #534 is fixed, Gap Analysis results may not be available locally.
+Keep in mind that until [Issue #534](https://github.com/OWASP/OpenCRE/issues/534) is fixed you won't have access to gap analysis results locally.
 
-Run OpenCRE locally:
-
-```bash
-make dev-flask
-```
-
----
-
-## macOS Local Development Setup
-
-This section documents common issues and solutions when setting up OpenCRE locally on **macOS**, based on contributor experience.
-
-### Tested Environment
-
-* macOS (Intel & Apple Silicon)
-* Python 3.10 – 3.13
-* Node.js 18+
-* Yarn 1.x
-
----
-
-### 1. Virtual Environment Setup
-
-We recommend using Python’s built-in `venv`:
-
-```bash
-python3 -m venv venv
-source venv/bin/activate
-```
-
-> **Important Note**
-> The Makefile currently invokes `virtualenv` internally.
-> On macOS, this can cause setup failures even when `venv` is used.
->
-> To avoid this, install `virtualenv` inside the active virtual environment:
-
-```bash
-pip install virtualenv
-```
-
----
-
-### 2. Installing Dependencies
-
-```bash
-make install
-```
-
-If you encounter the error:
-
-```text
-make: virtualenv: No such file or directory
-```
-
-Ensure that:
-
-* the virtual environment is activated
-* `virtualenv` is installed inside the environment
-
----
-
-### 3. Syncing Upstream Data (Known Limitation)
-
-```bash
-make upstream-sync
-```
-
-> **Known Issue**
-> On macOS, this command may fail with:
->
-> ```text
-> sqlite3.OperationalError: no such table: cre
-> ```
->
-> This is a known upstream limitation (see Issue #534).
-> The application can still be run locally for development even if this step fails.
-
----
-
-### 4. Running the Development Server
+To run CRE locally then you can do:
 
 ```bash
 make dev-flask
 ```
 
-Then open:
-
-```
-http://127.0.0.1:5000
-```
-
----
-
-### Notes
-
-* Webpack and Yarn peer-dependency warnings during installation are expected and can be safely ignored.
-* Some features (such as Gap Analysis) require Neo4j and may not function fully in local development environments.
-
----
-
-## CLI Usage
+To run the CLI application, you can run:
 
 ```bash
 python cre.py --help
 ```
 
-```bash
-python cre.py --review --from_spreadsheet <google_sheets_url>
-```
+To download a remote CRE spreadsheet locally you can run:
 
 ```bash
-python cre.py --add --from_spreadsheet <google_sheets_url>
+python cre.py --review --from_spreadsheet <google sheets url>
 ```
 
----
+To add a remote spreadsheet to your local database you can run:
 
-## Running the Web Application for Development
+```bash
+python cre.py --add --from_spreadsheet <google sheets url>
+```
+
+To run the web application for development you can run:
 
 ```bash
 make start-containers
@@ -220,45 +104,169 @@ make start-worker
 make dev-flask
 ```
 
-Alternatively:
+Alternatively, you can use the dockerfile with:
 
 ```bash
-make docker
-make docker-run
+make docker && make docker-run
 ```
 
----
-
-## Neo4j (Optional)
+Some features like Gap Analysis require a neo4j DB running, you can start this with:
 
 ```bash
 make docker-neo4j
 ```
 
-```
-NEO4J_URL=neo4j://neo4j:password@localhost:7687
+Environment variables for app to connect to neo4jDB (default):
+
+* `NEO4J_URL` (neo4j//neo4j:password@localhost:7687)
+
+To run the web application for production you need gunicorn and you can run from within the cre_sync dir:
+
+```bash
+make prod-run
 ```
 
 ---
 
+### macOS Notes (Apple Silicon & Intel)
+
+OpenCRE is fully supported on macOS. The following notes are optional and intended to help contributors running OpenCRE locally on macOS systems.
+
+#### Prerequisites
+
+Install required tools using Homebrew:
+
+```bash
+brew install python@3.11 yarn make
+```
+
+> Note: Python 3.11 is recommended. Newer Python versions may cause dependency incompatibilities.
+
+Verify Python version:
+
+```bash
+python3 --version
+```
+
+#### Virtual Environment Setup
+
+Create and activate a virtual environment explicitly using Python 3:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Upgrade pip:
+
+```bash
+pip install --upgrade pip
+```
+
+#### Dependency Installation
+
+Install dependencies using the standard workflow:
+
+```bash
+make install
+```
+
+If you encounter build issues, ensure Xcode Command Line Tools are installed:
+
+```bash
+xcode-select --install
+```
+
+#### Running Locally
+
+Sync upstream CRE data (requires internet access):
+
+```bash
+make upstream-sync
+```
+
+Then start the local server:
+
+```bash
+make dev-flask
+```
+
+The application will be available at:
+
+```
+http://127.0.0.1:5000
+```
+
+> Tip: For most macOS users, running via Docker is the simplest and most reliable approach.
+
+---
+
+## Using the OpenCRE API
+
+See [the myOpenCRE user guide](docs/my-opencre-user-guide.md) on using the OpenCRE API to, for example, add your own security guidelines and standards.
+
+## Docker building and running
+
+You can build the production or the development docker images with:
+
+```bash
+make docker-prod
+make docker-dev
+```
+
+The environment variables used by OpenCRE are:
+
+```
+- NEO4J_URL
+- NO_GEN_EMBEDDINGS
+- FLASK_CONFIG
+- DEV_DATABASE_URL
+- INSECURE_REQUESTS
+- REDIS_HOST
+- REDIS_PORT
+- REDIS_NO_SSL
+- REDIS_URL
+- GCP_NATIVE
+- GOOGLE_SECRET_JSON
+- GOOGLE_CLIENT_ID
+- GOOGLE_CLIENT_SECRET
+- LOGIN_ALLOWED_DOMAINS
+- OpenCRE_gspread_Auth
+```
+
+You can run the containers with:
+
+```bash
+make docker-prod-run
+make docker-dev-run
+```
+
 ## Developing
+
+You can run backend tests with:
 
 ```bash
 make test
 ```
 
+You can get a coverage report with:
+
 ```bash
 make cover
 ```
 
-Try to keep coverage above **70%**.
-
-Code style is enforced using **Black** and **GitHub Super-Linter**.
+Try to keep the coverage above 70%.
 
 ---
 
-## License
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![GitHub Super-Linter](https://github.com/OWASP/common-requirement-enumeration/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+[![Main Branch Build](https://github.com/OWASP/common-requirement-enumeration/workflows/Test/badge.svg?branch=main)](https://github.com/OWASP/common-requirement-enumeration/workflows/Test)
 
-This project is licensed under **CC0-1.0**.
+[![Issues](https://img.shields.io/github/issues/owasp/common-requirement-enumeration)](https://github.com/OWASP/common-requirement-enumeration/issues)
+[![PR's Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
+![GitHub contributors](https://img.shields.io/github/contributors/owasp/common-requirement-enumeration)
+![GitHub last commit](https://img.shields.io/github/last-commit/owasp/common-requirement-enumeration)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/y/owasp/common-requirement-enumeration)
 
-PRs welcome ❤️
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=400297709&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestEurope)


### PR DESCRIPTION
### Summary
Adds a macOS-specific local development setup section to the README.

### Motivation
During local setup on macOS (Python 3.13), several non-obvious issues were encountered:
- `virtualenv` required by the Makefile despite using `venv`
- `make install` failing without clear guidance
- `make upstream-sync` failing due to a known upstream limitation

This PR documents these issues to reduce onboarding friction for new contributors.

### Scope
- Documentation only
- No code or behavior changes

