### PR TITLE
fix(header): close mobile menu when switching to desktop view

### DIFF
--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -1,7 +1,7 @@
 import './header.scss';
 
 import { Menu, Search } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { Button } from 'semantic-ui-react';
 
@@ -19,7 +19,21 @@ export const Header = () => {
   const { showFilter } = useLocationFromOutsideRoute();
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
 
+    const handleBreakpointChange = (e: MediaQueryListEvent) => {
+      if (e.matches) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleBreakpointChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleBreakpointChange);
+    };
+  }, []);
   const closeMobileMenu = () => {
     setIsMobileMenuOpen(false);
   };


### PR DESCRIPTION
### What this PR does

Fixes an edge-case where the **mobile navigation sidebar remains open** when switching
from mobile to desktop viewport sizes during responsive testing.

The mobile menu now **automatically closes** when the viewport crosses the desktop
breakpoint, ensuring the UI state always matches the active layout.

---

### Changes included

- Automatically closes the mobile navigation menu when switching to desktop view
- Prevents stale mobile UI from persisting during responsive resizing
- Visual / UX behavior fix only

---

### Why this is needed

While testing responsive behavior on desktop (using browser resize / DevTools),
the mobile sidebar could remain visible even after entering desktop view.
This creates a confusing UI state where both desktop navigation and mobile
sidebar are visible at the same time.

Although this usually resolves on a full page refresh, developers commonly
test responsive layouts without refreshing — making this a **real usability
and testing bug**.

This change aligns behavior with production-grade applications, where
mobile navigation state is reset automatically on breakpoint changes.

---

### Screenshots

**Issue observed during responsive testing**

Mobile navigation remains open after switching to desktop viewport:
<img width="1575" height="820" alt="image" src="https://github.com/user-attachments/assets/36169b07-d77a-4551-a890-f38d5a1bb3c0" />



---

### Technical notes

- Uses a `matchMedia('(min-width: 768px)')` listener to detect breakpoint changes
- Closes mobile menu state when entering desktop view
- No routing, styling, or dependency changes
- No impact on existing mobile navigation behavior

---

### Scope

- Header component only
- No logic changes outside responsive state handling