### PR TITLE
Fix: improve hero search bar layout on small mobile screens

### DIFF
--- a/application/frontend/src/pages/Search/search.scss
+++ b/application/frontend/src/pages/Search/search.scss
@@ -1122,3 +1122,33 @@ body {
     transform: rotate(360deg);
   }
 }
+
+@media (max-width: 396px) {
+  .search-bar {
+    .search-bar__group {
+      .search-bar__wrapper {
+        .search-bar__flex {
+          .search-bar__icon {
+            left: 1rem;
+            height: 1.1rem;
+            width: 1.1rem;
+          }
+
+          .search-bar__input {
+            font-size: 0.9rem;
+            padding-top: 0.9rem;
+            padding-bottom: 0.9rem;
+            padding-left: 3rem;
+            padding-right: 6.5rem;
+          }
+
+          .search-bar__button {
+            padding: 0.45rem 1.2rem;
+            font-size: 0.85rem;
+            border-radius: 0.6rem;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Fixes a UI issue where the hero section search bar appeared cramped or clipped on small mobile screens.

The existing layout worked well on tablet and desktop, but on narrow mobile viewports the input text and button spacing caused visual crowding. This PR scales the search bar proportionally for small screens while preserving the original design.

### What was changed

- Reduced font size, padding, and icon size for the hero search bar
- Changes are limited to SCSS only
- No layout, structure, or logic changes

### Screen sizes tested

- 375 × 667 (iPhone SE)
- ~360px Android devices
- Verified that layouts above ~396px remain unchanged

### Notes

Viewports below ~320px are not explicitly targeted, as they are outside the range of commonly supported mobile devices.  
The update follows standard responsive design practices and is fully backward-compatible.



### Before / After (Chrome DevTools – iPhone SE)

**Before**
<br/>
<img width="920" height="1027" alt="image" src="https://github.com/user-attachments/assets/5260473e-ffca-434b-98e5-2c82002e6035" />


**After**
<br/>
<img width="929" height="1032" alt="image" src="https://github.com/user-attachments/assets/30222b05-32e3-49df-bdbd-a384d68305c5" />
