### PR TITLE
chore(tsconfig): remove deprecated keyofStringsOnly option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "lib": ["esnext", "dom"],
     "outDir": "dist",
     "moduleResolution": "node",
-    "keyofStringsOnly": true,
     "skipLibCheck": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
Removes the deprecated `keyofStringsOnly` compiler option from `tsconfig.json`.

This option has been removed in recent TypeScript versions and currently triggers a compiler error during local development and builds.

The change does not affect runtime behavior or type semantics — it simply aligns the configuration with modern TypeScript defaults and improves developer experience.