### PR TITLE
fix: reduce navbar logo clickable area #644

### DIFF
--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -41,8 +41,9 @@
   gap: 0.5rem;
   margin-left: 4rem;
   img {
-    height: 10rem;
+    height: 4rem;
     width: 10rem;
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Description
Fixes an issue where the navbar logo link extended beyond the visible logo, causing clicks on empty space below the logo to trigger navigation to the home page.

This behavior was caused by an oversized height being applied to the logo container, which unintentionally expanded the clickable area.

#### solves issue #644
## Changes
- Reduced logo height from `10rem` to `4rem`
- Added `display: block` to remove inline spacing
- Ensured the clickable area aligns with the visible logo (image and accompanying text)

## Before & After
**Before**: Logo had 10rem x 10rem clickable area with empty space
**After**: Clickable area is limited to the visible logo content only

## Demo (Video)
https://github.com/user-attachments/assets/4bbc4ee2-ecf5-495a-b662-a2f6f08b20aa

## Testing
- Verified clicking on empty space below the logo no longer triggers navigation
- Confirmed clicking on the logo (image and text) still navigates correctly
- Checked layout consistency across desktop and mobile breakpoints