### PR TITLE
MyOpenCRE: add CSV import preview, confirmation step, and improved UX safeguards

### DIFF
--- a/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.scss
+++ b/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.scss
@@ -13,3 +13,7 @@
 .myopencre-disabled {
   opacity: 0.7;
 }
+
+.myopencre-preview {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
⚠️ **This PR depends on**

- **#684 — feat(myopencre): improve CSV import error handling in UI**

Please review this PR **after** the above PR has been merged.

---

📝 **Note for reviewers**

This PR intentionally limits its scope to frontend-only changes in the following files:

- `application/frontend/src/pages/MyOpenCRE/MyOpenCRE.tsx`
- `application/frontend/src/pages/MyOpenCRE/MyOpenCRE.scss`

No backend files, APIs, or import logic were modified.

Any additional file diffs shown by GitHub are inherited from branch history or stacked branches and are **not part of this change**.

---
## Summary

Closes #584 (partial)

This PR improves the **MyOpenCRE CSV import experience** by introducing a **frontend-only preview and confirmation flow** before an import is executed.

The goal is to make CSV imports **safer, more transparent, and more intentional** for users — **without changing backend behavior, APIs, or dependencies**.

This enhancement directly aligns with the original MyOpenCRE workflow and acceptance criteria described in **#584**.

---

## What changed

### ✅ CSV import preview (frontend-only)
- Parses the selected CSV **client-side** and displays:
  - Total rows detected
  - Number of CRE mappings found
  - Number of unique standard sections
  - Detected CRE columns (e.g. `CRE 0`, `CRE 1`, …)
- Allows users to verify file structure **before** starting an import.

---

### ✅ Explicit confirmation step
- Import **does not start automatically** on file selection.
- Users must explicitly click **“Confirm Import”** after reviewing the preview.
- Prevents accidental or unintended uploads.

---

### ✅ Clear import states & feedback
- All backend outcomes are clearly reflected in the UI:
  - Successful imports
  - No-op imports
  - Empty CSV uploads
  - Validation or server errors
- Confirmation and preview state reset correctly on:
  - Cancel
  - File change
  - Validation errors
  - Import completion

---

### ✅ UX safeguards & polish
- Upload button remains disabled until:
  - A valid CSV is selected
  - The preview is confirmed
- Preview closes automatically on invalid file selection.
- File input is reset intentionally to allow:
  - Re-selecting the same file
  - Avoiding accidental re-imports
- File name visibility and messaging are handled explicitly to reduce confusion.

---

## Scope & constraints

- **Frontend-only change**
- **No backend logic changes**
- **No API changes**
- **No new dependencies introduced**
- Existing backend feature flags (e.g. `CRE_ALLOW_IMPORT`) are fully respected

---

## Why this helps

- Reduces user error during CSV imports
- Makes import behavior predictable and intentional
- Improves transparency without adding backend complexity
- Brings the MyOpenCRE UI closer to the original product intent in **#584**

---

## Screenshots

### Before
<img width="1707" height="950" alt="Before" src="https://github.com/user-attachments/assets/6ec4a14b-24ce-45c3-a6bc-cf72ab28c684" />

### After — CSV preview
<img width="1709" height="948" alt="Preview" src="https://github.com/user-attachments/assets/6aea12db-5754-4a21-98c7-495a992c2f36" />

### After — confirmation state
<img width="1710" height="948" alt="Confirmed" src="https://github.com/user-attachments/assets/791a842f-8229-48c8-966c-3baf9f692da7" />

### After — successful import feedback
<img width="1709" height="951" alt="Success" src="https://github.com/user-attachments/assets/7fe31e4a-a896-4a45-a79c-2eb959184c70" />