### PR TITLE
MyOpenCRE: add inline help for CSV preparation

### DIFF
--- a/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.scss
+++ b/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.scss
@@ -17,3 +17,13 @@
 .myopencre-preview {
   margin-top: 1rem;
 }
+
+.myopencre-intro {
+  font-size: 1.05rem;
+  font-weight: 400;
+  margin-bottom: 0.5rem;
+}
+
+.cursor-pointer summary {
+  cursor: pointer;
+}

--- a/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.tsx
+++ b/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.tsx
@@ -256,8 +256,29 @@ export const MyOpenCRE = () => {
 
       <div className="myopencre-section myopencre-upload">
         <Header as="h3">Upload Mapping CSV</Header>
+        <Message info className="cursor-pointer">
+          <details>
+            <summary>
+              <strong>How to prepare your CSV</strong>
+            </summary>
 
-        <p>Upload your completed mapping spreadsheet to import your standard into OpenCRE.</p>
+            <ul>
+              <li>Start from the downloaded CRE Catalogue CSV.</li>
+              <li>
+                Fill <code>standard|name</code> and <code>standard|id</code> for your standard.
+              </li>
+              <li>
+                Map your controls using CRE columns (<code>CRE 0</code>, <code>CRE 1</code>, …).
+              </li>
+
+              <li>
+                CRE values must be in the format <code>&lt;CRE-ID&gt;|&lt;Name&gt;</code>
+                <br />
+                <em>Example:</em> <code>616-305|Development processes for security</code>
+              </li>
+            </ul>
+          </details>
+        </Message>
 
         {!isUploadEnabled && (
           <Message info className="myopencre-disabled">


### PR DESCRIPTION
⚠️ **This PR depends on**

- **#685**

Please review this PR **after** the above PR has been merged.

---

📝 **Note for reviewers**

This PR intentionally limits its scope to frontend-only changes in the following files:

- `application/frontend/src/pages/MyOpenCRE/MyOpenCRE.tsx`
- `application/frontend/src/pages/MyOpenCRE/MyOpenCRE.scss`

No backend files, APIs, or import logic were modified.

Any additional file diffs shown by GitHub are inherited from branch history or stacked branches and are **not part of this change**.

---
## Summary

Closes #584 (partial)

This PR improves the MyOpenCRE upload experience by adding lightweight,
inline guidance for users preparing a CSV mapping file.

The goal is to clarify *what MyOpenCRE is* and *how to prepare a valid CSV*
without changing behavior or adding complexity.

---

## What changed

- Restored and clarified the **“What is MyOpenCRE”** description
- Added a collapsible **“How to prepare your CSV”** help section
- Uses native `<details>` / `<summary>` for a minimal, accessible UI
- Cursor indicates interactivity on hover
- No changes to import logic or validation

---

## Scope

- **Frontend only**
- **No backend changes**
- **No API changes**
- **No dependency changes**

---
## Screenshots
<img width="1536" height="846" alt="image" src="https://github.com/user-attachments/assets/f0fecd75-ab37-446d-b9ec-34cb321dded9" />

<img width="1708" height="945" alt="image" src="https://github.com/user-attachments/assets/40dad1bc-b015-4aeb-8e3d-6f116d5d7a0b" />

---
## Why this helps

- Reduces confusion for first-time users
- Keeps the interface clean while making guidance discoverable
- Aligns with the original MyOpenCRE user journey described in #584