### PR TITLE
fix(homepage): correct typo in CRE linking instructions

### DIFF
--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -231,8 +231,8 @@ export const SearchPage = () => {
               </div>
               <h3 className="htu-card__title">Link from your document / tool</h3>
               <p className="htu-card__text">
-                Llink with the CRE ID: <a href="https://opencre.org/cre/764-507">opencre.org/cre/764-507</a>{' '}
-                or use a familiar standard such as CWE:{' '}
+                Link with the CRE ID: <a href="https://opencre.org/cre/764-507">opencre.org/cre/764-507</a> or
+                use a familiar standard such as CWE:{' '}
                 <a href="https://opencre.org/smartlink/standard/CWE/611">
                   opencre.org/smartlink/standard/CWE/611
                 </a>
@@ -281,8 +281,11 @@ export const SearchPage = () => {
                 <a href="https://www.opencre.org/map_analysis">MAP ANALYSIS</a>
               </h3>
               <p className="feature-block__text">
-                Utilize <strong><a href="/map_analysis">Map Analysis</a></strong> as a tool to explore and understand the connections
-                between two standards.
+                Utilize{' '}
+                <strong>
+                  <a href="/map_analysis">Map Analysis</a>
+                </strong>{' '}
+                as a tool to explore and understand the connections between two standards.
               </p>
               <p className="feature-block__text">
                 See how <strong>any two standards connect</strong> with each other, providing valuable


### PR DESCRIPTION
### Summary
Fixes a minor typo in the homepage **How to use** section (`Llink` → `Link`).

### Why
- The text is user-facing and part of the onboarding flow.
- Correcting the typo improves clarity and first-impression quality without changing behavior.

### Scope
- Text-only change
- No functional or layout impact

### Screenshots

**Before**
<img width="485" height="275" alt="Before typo fix" src="https://github.com/user-attachments/assets/70c4c348-e2ac-49b6-9e15-9f7913ce7d0d" />

**After**
<img width="480" height="278" alt="After typo fix" src="https://github.com/user-attachments/assets/7b25106c-fa3a-4407-8412-2f9af15f334d" />