### PR TITLE
Fix: improved caching efficiency to increase rebuild speed

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,9 +1,12 @@
 FROM node:lts AS build
 
 WORKDIR /code
-COPY . /code
-
 RUN apt-get update && apt-get install -y chromium
+COPY package.json yarn.lock ./
+RUN yarn install
+
+COPY . .
+
 RUN make install-deps-typescript && make install-typescript && make frontend
 
 FROM python:3.11.0 AS run


### PR DESCRIPTION
Fixes #695 
## Changes made

The Dockerfile has been restructured to copy dependency files first and run `yarn install` before copying the rest of the source code, allowing Docker to reuse cached layers when dependencies have not changed thereby reducing rebuild time from ~550 seconds to ~300 seconds.

Before change:-
<img width="935" height="426" alt="Image" src="https://github.com/user-attachments/assets/b0038106-545c-47af-99ab-684f4d0e84d5" />

After change:-
<img width="934" height="462" alt="Image" src="https://github.com/user-attachments/assets/f7d39c5b-89a5-4029-8952-2994b41841e2" />

- Copied package.json and yarn.lock before the rest of the source code.
- Executed yarn install immediately after copying dependency files.
- Preserved existing build logic and behavior.
