### PR TITLE
feat(myopencre): gate MyOpenCRE behind deployment capability flag

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -1,6 +1,7 @@
 import os
 
 basedir = os.path.abspath(os.path.dirname(__file__))
+ENABLE_MYOPENCRE = os.getenv("ENABLE_MYOPENCRE", "false").lower() == "true"
 
 
 class Config:

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -22,6 +22,7 @@ from application.database import db
 from application.cmd import cre_main
 from application.defs import cre_defs as defs
 from application.defs import cre_exceptions
+from application.config import ENABLE_MYOPENCRE
 
 from application.utils import spreadsheet as sheet_utils
 from application.utils import mdutils, redirectors, gap_analysis
@@ -825,8 +826,15 @@ def all_cres() -> Any:
 # Importing Handlers
 
 
+@app.route("/api/capabilities")
+def capabilities():
+    return jsonify({"myopencre": ENABLE_MYOPENCRE})
+
+
 @app.route("/rest/v1/cre_csv", methods=["GET"])
 def get_cre_csv() -> Any:
+    if not ENABLE_MYOPENCRE:
+        abort(404)
     if posthog:
         posthog.capture(f"get_cre_csv", "")
 
@@ -854,6 +862,9 @@ def get_cre_csv() -> Any:
 
 @app.route("/rest/v1/cre_csv_import", methods=["POST"])
 def import_from_cre_csv() -> Any:
+    if not ENABLE_MYOPENCRE:
+        abort(404)
+
     if not os.environ.get("CRE_ALLOW_IMPORT"):
         abort(
             403,


### PR DESCRIPTION
## Summary

Closes #584 (partial)

This PR introduces **deployment-level capability gating for MyOpenCRE**.

It is **stacked on top of the existing MyOpenCRE no-op / CSV UX work** (starting from #684).  
This PR intentionally focuses **only on backend capability control**, not UI behavior.

> Files intentionally modified in this PR:
> - `application/config.py`
> - `application/web/web_main.py`
>
> Any other diffs are incidental (formatting / imports) and not part of the logical change.

MyOpenCRE is intended for **self-hosted / admin-controlled OpenCRE deployments**.  
This change ensures the feature is **completely unavailable on opencre.org unless explicitly enabled** by the deployment owner.

---

## What changed

- Added a deployment-scoped capability flag: `ENABLE_MYOPENCRE`
- Introduced a backend capability discovery endpoint: `/api/capabilities`
- Gated all MyOpenCRE CSV import/export routes behind the capability flag

When `ENABLE_MYOPENCRE` is **disabled**:
- MyOpenCRE routes return `404`
- No CSV parsing occurs
- No database writes are performed
- No embeddings or gap analysis can be triggered
- No additional compute or graph overhead is introduced

---

## Why

MyOpenCRE performs heavyweight operations (CSV parsing, graph writes, embeddings generation, gap analysis).

These are appropriate for **self-hosted or admin-managed environments**, but not for **public opencre.org usage**.

This change ensures:
- Zero accidental exposure on opencre.org
- A clear separation between public features and admin-only capabilities
- Backend-driven feature availability (no frontend assumptions)
- A safe foundation for future work (user scoping, explainability, etc.)

---

## Testing

### `ENABLE_MYOPENCRE=false` (default)
- `GET /api/capabilities` → `{ "myopencre": false }`
- `/rest/v1/cre_csv` → `404`
- `/rest/v1/cre_csv_import` → `404`

### `ENABLE_MYOPENCRE=true`
- `GET /api/capabilities` → `{ "myopencre": true }`
- CSV export endpoint works as before
- CSV import endpoint is reachable
- Existing validation and import pipeline remains unchanged

---

## Stacking / Follow-ups

This PR is **logically stacked on top of #684** (no-op CSV handling).

Subsequent UI-focused PRs (#685 preview, #686 help guide) will be **rebased onto `main`** after this PR is merged, as they depend on this backend capability signal.

---

## Next step: 

A follow-up PR will update the frontend to consume /api/capabilities and conditionally expose or hide MyOpenCRE UI based on backend-provided capability signals.