### PR TITLE
feat(myopencre): implement MyOpenCRE frontend functionality behind backend capability flag

### DIFF
--- a/application/frontend/src/hooks/index.ts
+++ b/application/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useEnvironment } from './useEnvironment';
 export { useLocationFromOutsideRoute } from './useLocationFromOutsideRoute';
+export { useCapabilities } from './useCapabilities';

--- a/application/frontend/src/hooks/useCapabilities.ts
+++ b/application/frontend/src/hooks/useCapabilities.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+import { useEnvironment } from './useEnvironment';
+
+export type Capabilities = {
+    myopencre: boolean;
+};
+
+export const useCapabilities = () => {
+    const { apiUrl } = useEnvironment();
+    const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const baseUrl = apiUrl.replace('/rest/v1', '');
+
+        fetch(`${baseUrl}/api/capabilities`)
+            .then((res) => res.json())
+            .then(setCapabilities)
+            .catch(() => setCapabilities({ myopencre: false }))
+            .finally(() => setLoading(false));
+    }, [apiUrl]);
+
+    return { capabilities, loading };
+};

--- a/application/frontend/src/hooks/useLocationFromOutsideRoute.tsx
+++ b/application/frontend/src/hooks/useLocationFromOutsideRoute.tsx
@@ -1,7 +1,7 @@
 import { matchPath } from 'react-router';
 import { useLocation } from 'react-router-dom';
 
-import { ROUTES } from '../routes';
+import { IRoute } from '../routes';
 
 interface UseLocationFromOutsideRouteReturn {
   params: Record<string, string>;
@@ -9,14 +9,28 @@ interface UseLocationFromOutsideRouteReturn {
   showFilter: boolean;
 }
 
-export const useLocationFromOutsideRoute = (): UseLocationFromOutsideRouteReturn => {
-  // The current URL
+/**
+ * Determines route metadata (params, url, showFilter)
+ * based on the currently active route.
+ *
+ * NOTE:
+ * - This hook no longer imports ROUTES directly
+ * - Routes must be passed in (already capability-resolved)
+ */
+export const useLocationFromOutsideRoute = (routes: IRoute[]): UseLocationFromOutsideRouteReturn => {
   const { pathname } = useLocation();
-  // The current ROUTE, from our URL
-  const currentRoute = ROUTES.map(({ path, showFilter }) => ({
-    ...matchPath(pathname, path),
-    showFilter,
-  })).find((matchedPath) => matchedPath?.isExact);
+
+  const currentRoute = routes
+    .map(({ path, showFilter }) => ({
+      ...matchPath(pathname, {
+        path,
+        exact: true,
+        strict: false,
+      }),
+      showFilter,
+    }))
+    .find((matchedPath) => matchedPath?.isExact);
+
   return {
     params: currentRoute?.params || {},
     url: currentRoute?.url || '',

--- a/application/frontend/src/routes.tsx
+++ b/application/frontend/src/routes.tsx
@@ -30,13 +30,19 @@ export interface IRoute {
   component: ReactNode | ReactNode[];
   showFilter: boolean;
 }
-
-export const ROUTES: IRoute[] = [
-  {
-    path: '/myopencre',
-    component: MyOpenCRE,
-    showFilter: false,
-  },
+export interface Capabilities {
+  myopencre: boolean;
+}
+export const ROUTES = (capabilities: Capabilities): IRoute[] => [
+  ...(capabilities.myopencre
+    ? [
+      {
+        path: '/myopencre',
+        component: MyOpenCRE,
+        showFilter: false,
+      },
+    ]
+    : []),
 
   {
     path: INDEX,

--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -7,18 +7,24 @@ import { NavLink } from 'react-router-dom';
 import { Button } from 'semantic-ui-react';
 
 import { ClearFilterButton } from '../../components/FilterButton/FilterButton';
+import { Capabilities } from '../../hooks/useCapabilities';
 import { useLocationFromOutsideRoute } from '../../hooks/useLocationFromOutsideRoute';
-import { MyOpenCRE } from '../../pages/MyOpenCRE/MyOpenCRE';
 import { SearchBar } from '../../pages/Search/components/SearchBar';
+import { ROUTES } from '../../routes';
 
-export const Header = () => {
+interface HeaderProps {
+  capabilities: Capabilities;
+}
+export const Header = ({ capabilities }: HeaderProps) => {
+  const routes = ROUTES(capabilities);
+
   let currentUrlParams = new URLSearchParams(window.location.search);
   const history = useHistory();
   const HandleDoFilter = () => {
     currentUrlParams.set('applyFilters', 'true');
     history.push(window.location.pathname + '?' + currentUrlParams.toString());
   };
-  const { showFilter } = useLocationFromOutsideRoute();
+  const { showFilter } = useLocationFromOutsideRoute(routes);
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   useEffect(() => {
@@ -69,9 +75,11 @@ export const Header = () => {
               <NavLink to="/explorer" className="nav-link" activeClassName="nav-link--active">
                 Explorer
               </NavLink>
-              <NavLink to="/myopencre" className="nav-link" activeClassName="nav-link--active">
-                MyOpenCRE
-              </NavLink>
+              {capabilities.myopencre && (
+                <NavLink to="/myopencre" className="nav-link" activeClassName="nav-link--active">
+                  MyOpenCRE
+                </NavLink>
+              )}
             </div>
 
             <div>
@@ -190,14 +198,16 @@ export const Header = () => {
           >
             Explorer
           </NavLink>
-          <NavLink
-            to="/myopencre"
-            className="nav-link"
-            activeClassName="nav-link--active"
-            onClick={closeMobileMenu}
-          >
-            MyOpenCRE
-          </NavLink>
+          {capabilities.myopencre && (
+            <NavLink
+              to="/myopencre"
+              className="nav-link"
+              activeClassName="nav-link--active"
+              onClick={closeMobileMenu}
+            >
+              MyOpenCRE
+            </NavLink>
+          )}
         </div>
 
         <div className="mobile-auth">

--- a/application/frontend/src/scaffolding/MainContentArea/MainContentArea.tsx
+++ b/application/frontend/src/scaffolding/MainContentArea/MainContentArea.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 
+import { useCapabilities } from '../../hooks/useCapabilities';
 import { Header, Router } from '../index';
 
 export const MainContentArea = () => {
+  const { capabilities, loading } = useCapabilities();
+
+  if (loading || !capabilities) {
+    return null; // or spinner
+  }
+
   return (
     <>
-      <Header />
-      <Router />
+      <Header capabilities={capabilities} />
+      <Router capabilities={capabilities} />
     </>
   );
 };

--- a/application/frontend/src/scaffolding/Router/Router.tsx
+++ b/application/frontend/src/scaffolding/Router/Router.tsx
@@ -1,19 +1,27 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { Capabilities } from '../../hooks/useCapabilities';
 import { ROUTES } from '../../routes';
 import { NoRoute } from '../index';
 
-export const Router = () => (
-  <Switch>
-    {ROUTES.map(({ path, component: Component }) => {
-      if (!Component) {
-        return null;
-      }
-      const TypedComponent = Component as React.ElementType;
+interface RouterProps {
+  capabilities: Capabilities;
+}
 
-      return <Route key={path} path={path} exact={path === '/'} render={() => <TypedComponent />} />;
-    })}
-    <Route component={NoRoute} />
-  </Switch>
-);
+export const Router = ({ capabilities }: RouterProps) => {
+  const routes = ROUTES(capabilities);
+
+  return (
+    <Switch>
+      {routes.map(({ path, component: Component }) => {
+        if (!Component) return null;
+
+        const TypedComponent = Component as React.ElementType;
+
+        return <Route key={path} path={path} exact={path === '/'} render={() => <TypedComponent />} />;
+      })}
+      <Route component={NoRoute} />
+    </Switch>
+  );
+};


### PR DESCRIPTION
## Summary

Closes #584 (partial)

This PR introduces the **MyOpenCRE** frontend functionality, enabling the MyOpenCRE feature to be conditionally displayed based on the **ENABLE_MYOPENCRE** runtime flag. This feature ensures that MyOpenCRE functionality is only available when the flag is enabled, in alignment with the backend capability gating.

This PR depends on #700, which implements the backend for **MyOpenCRE**. With this PR, we have connected the frontend to the backend, allowing MyOpenCRE UI elements to appear and function only when the backend provides the capability signal.

## Files Modified
The following files were modified as part of this PR:

- **application/frontend/src/hooks/index.ts**
- **application/frontend/src/hooks/useCapabilities.ts** (New file)
- **application/frontend/src/hooks/useLocationFromOutsideRoute.tsx**
- **application/frontend/src/routes.tsx**
- **application/frontend/src/scaffolding/Header/Header.tsx**
- **application/frontend/src/scaffolding/MainContentArea/MainContentArea.tsx**
- **application/frontend/src/scaffolding/Router/Router.tsx**

Other changes are incidental (formatting, imports) and do not affect the logical behavior of the application.

## What Changed
- **Frontend capability hook**: The **useCapabilities** hook was added to fetch the **myopencre** capability from the backend and conditionally render the MyOpenCRE UI.
- **Dynamic MyOpenCRE display**: The MyOpenCRE UI elements (like CSV import/export buttons) are now shown only if the **ENABLE_MYOPENCRE** flag is enabled (i.e., if **myopencre** is `true`).
- **Integration with backend capability signal**: The frontend is now connected to the `/api/capabilities` endpoint, which informs whether MyOpenCRE should be displayed based on the current deployment configuration.

## Why This Change Was Introduced
The **MyOpenCRE** feature requires administrative control for self-hosted deployments. By gating the feature behind a runtime flag, it prevents accidental exposure on public platforms and ensures that it’s only accessible when explicitly enabled. This PR ensures that the frontend only shows the **MyOpenCRE** features when they are actually available, preventing user confusion.

This change:
- Ensures that MyOpenCRE UI elements are hidden unless **ENABLE_MYOPENCRE=true** is set.
- Provides the necessary frontend changes to work with the backend capability signal.
- Lays the groundwork for future user role-based gating once user authentication and roles are implemented.

## Testing
- **ENABLE_MYOPENCRE=false** (default): 
  - The MyOpenCRE UI elements are not displayed.
  
- **ENABLE_MYOPENCRE=true**:
  - The MyOpenCRE UI elements appear and are fully functional.

## Stacking / Follow-ups
This PR depends on #700 for the backend functionality (capability gating). 
- Future UI-focused PRs (such as #685 for preview and #686 for help guide) will be rebased onto the main branch after this PR is merged, as they rely on this frontend functionality.

### Next Steps
- A follow-up PR will integrate feature flagging for user roles (once #586 is completed), allowing us to expose or hide MyOpenCRE based on the user’s role (e.g., admin vs non-admin). 

## Conclusion
This PR provides the frontend functionality for MyOpenCRE based on the backend **ENABLE_MYOPENCRE** flag. It ensures that MyOpenCRE is only available when the backend allows it and is ready to be used in self-hosted deployments. Future work will refine user role-based controls and feature flagging for even finer control.