### PR TITLE
chore: fix PYTHON_BLACK CI failure by formatting spreadsheet_parsers.py

### DIFF
--- a/application/utils/spreadsheet_parsers.py
+++ b/application/utils/spreadsheet_parsers.py
@@ -333,7 +333,7 @@ def update_cre_in_links(
 
 
 def parse_hierarchical_export_format(
-    cre_file: List[Dict[str, str]]
+    cre_file: List[Dict[str, str]],
 ) -> Dict[str, List[defs.Document]]:
     """parses the main OpenCRE csv and creates a list of standards in it
 


### PR DESCRIPTION
### Summary
This PR applies Black formatting to a Python file that was failing the `PYTHON_BLACK` check in CI.

### Details
- Reformatted `application/utils/spreadsheet_parsers.py` using Black
- No functional or behavioral changes
- Resolves CI failures caused by Black formatting differences

### Why this change
Recent PRs were failing CI due to Black detecting formatting issues in this file.
Running Black locally and committing the result ensures consistent formatting and unblocks CI.

### Scope
- Formatting only
- No logic changes