### PR TITLE
Fix: fixed repeated graph reload

### DIFF
--- a/application/database/db.py
+++ b/application/database/db.py
@@ -680,6 +680,10 @@ class Node_collection:
         self.session = sqla.session
 
     def with_graph(self) -> "Node_collection":
+        if self.graph is not None:
+            logger.debug("CRE graph already loaded, skipping reload")
+            return self
+
         logger.info("Loading CRE graph in memory, memory-heavy operation!")
         self.graph = inmemory_graph.CRE_Graph()
         graph_singleton = inmemory_graph.Singleton_Graph_Storage.instance()


### PR DESCRIPTION
Fixes #711  
## Changes made

Prevented redundant in-memory CRE graph reloads, reducing CPU usage from ~99% to ~15% of graph-dependent operations by reusing a single initialized graph per runtime.

Before change:-
<img width="1892" height="66" alt="image" src="https://github.com/user-attachments/assets/8a568b0f-08a2-4377-9e8e-d65fb2b13cc4" />

After change:-
<img width="1884" height="72" alt="image" src="https://github.com/user-attachments/assets/d0673d47-3918-42d3-86fd-bbd8fd193f88" />

