### PR TITLE
fix(parsers): remove duplicated ID from PCI DSS section name (#328)

### DIFF
--- a/application/utils/external_project_parsers/parsers/pci_dss.py
+++ b/application/utils/external_project_parsers/parsers/pci_dss.py
@@ -57,6 +57,13 @@ class PciDss(ParserInterface):
                 ).strip(),
                 version=version,
             )
+            # Fix for Issue #328: Remove ID from Section Name if duplicated
+            if pci_control.section.startswith(pci_control.sectionID):
+                # Remove the ID and any leading whitespace/punctuation left over
+                pci_control.section = pci_control.section[
+                    len(pci_control.sectionID) :
+                ].strip()
+
             existing = cache.get_nodes(
                 name=pci_control.name,
                 section=pci_control.section,


### PR DESCRIPTION
fix(parsers): remove duplicated ID from PCI DSS section name (#328)

## Overview
This PR fixes a bug in the PCI DSS parser where the section ID was being duplicated in the section Name field.
Previously, the parser read "Defined Approach Requirements" from the spreadsheet, which often includes the ID prefix (e.g., "12.1.2 Ensure..."). Since the ID is also read separately, OpenCRE would display duplication (e.g., "12.1.2 12.1.2 Ensure...").

## Changes

### [application/utils/external_project_parsers/parsers/pci_dss.py](cci:7://file:///Users/prateeksingh/OpenCRE/application/utils/external_project_parsers/parsers/pci_dss.py:0:0-0:0)
*   **Logic Updated**: Added a check to see if the parsed `section` name starts with the `sectionID`.
*   **Fix**: If a duplicate prefix is found, it is stripped from the `section` name, leaving only the clean description text (e.g., "Ensure...").

## Verification
Verified locally using a temporary reproduction script to simulate the parsing logic:
*   **Before Fix**: Output confirmed duplications (e.g., `12.1.2 Ensure...`).
*   **After Fix**: Output confirmed clean section names (e.g., `Ensure..`).

Fixes #328