### PR TITLE
Fix Map Analysis hover popup overlapping adjacent standards

### DIFF
--- a/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
+++ b/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
@@ -65,6 +65,7 @@ const GetResultLine = (path, gapAnalysis, key) => {
           size="large"
           style={{ textAlign: 'center' }}
           hoverable
+          position="right center"
           trigger={<span>{getDocumentDisplayName(path.end, true)} </span>}
         >
           <Popup.Content>
@@ -81,6 +82,7 @@ const GetResultLine = (path, gapAnalysis, key) => {
           size="large"
           style={{ textAlign: 'center' }}
           hoverable
+          position="right center"
           trigger={
             <b style={{ color: GetStrengthColor(path.score) }}>
               ({GetStrength(path.score)}:{path.score})


### PR DESCRIPTION
## Summary

When browsing Map Analysis results, hovering over a mapped standard currently displays a popup that overlaps adjacent entries in the list. This makes it difficult to quickly scan or compare multiple standards within the same section, as the popup must be dismissed before interacting with the next item.

This behavior is visible on the current production site and is described in Issue #456.

## Changes

- Explicitly position the Semantic UI `Popup` components used in Map Analysis to appear to the side (`right center`)
- Prevent hover popups from covering neighboring standards while browsing
- Keep the change limited to UI behavior with no impact on logic, data, or layout structure

## Impact

- UI-only change
- No backend or API changes
- Uses Semantic UI’s supported positioning API
- Improves scanability and usability when navigating long Map Analysis result lists

## Result

Hovering over standards now reveals additional context without obscuring adjacent items, resulting in a smoother and less clunky browsing experience.

Fixes #456