### PR TITLE
fix(frontend): correct state mutation in GapAnalysis

### DIFF
--- a/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
+++ b/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
@@ -216,9 +216,16 @@ export const GapAnalysis = () => {
         `${apiUrl}/map_analysis_weak_links?standard=${BaseStandard}&standard=${CompareStandard}&key=${key}`
       );
       if (result.data.result) {
-        gapAnalysis[key].weakLinks = result.data.result.paths;
-        setGapAnalysis(undefined); //THIS HAS TO BE THE WRONG WAY OF DOING THIS
-        setGapAnalysis(gapAnalysis);
+        setGapAnalysis((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            [key]: {
+              ...prev[key],
+              weakLinks: result.data.result.paths,
+            },
+          };
+        });
       }
     },
     [gapAnalysis, setGapAnalysis]


### PR DESCRIPTION
## Summary

The Map Analysis page currently updates `gapAnalysis` state by mutating the existing object and forcing a re-render via a temporary `undefined` state. This pattern breaks React’s immutability guarantees and relies on a workaround that can lead to unnecessary renders and harder-to-reason-about behavior.

## What Changed

This PR replaces the direct state mutation with an immutable update using the functional `setState` pattern. The new approach creates a fresh state object when weak links are loaded, allowing React to re-render correctly without forcing intermediate state resets.

## Why This Matters

*   **Removes a known React anti-pattern** (explicitly called out in the code comment)
*   **Avoids forced re-renders** and potential race conditions
*   **Improves maintainability and correctness** without changing user-visible behavior
*   **Keeps the change tightly scoped** to state management only

## Scope

*   UI-only change
*   No backend or API changes
*   No behavior or layout changes beyond the internal state update

