### PR TITLE
fix: typo in function name donwload_graph_from_upstream → download_graph_from_upstream

### DIFF
--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -461,7 +461,7 @@ def review_from_spreadsheet(cache: str, spreadsheet_url: str, share_with: str) -
     # logger.info("A spreadsheet view is at %s" % sheet_url)
 
 
-def donwload_graph_from_upstream(cache: str) -> None:
+def download_graph_from_upstream(cache: str) -> None:
     imported_cres = {}
     collection = db_connect(path=cache).with_graph()
 
@@ -667,7 +667,7 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
     if args.preload_map_analysis_target_url:
         gap_analysis.preload(target_url=args.preload_map_analysis_target_url)
     if args.upstream_sync:
-        donwload_graph_from_upstream(args.cache_file)
+        download_graph_from_upstream(args.cache_file)
 
 
 def ai_client_init(database: db.Node_collection):


### PR DESCRIPTION
Was going through the upstream sync code to understand how it works for #534, and spotted this typo in the function name - `donwload_graph_from_upstream` should be [download_graph_from_upstream](cci:1://file:///Users/prateeksingh/OpenCRE/application/cmd/cre_main.py:463:0-503:60).

Fixed both occurrences:
- Function definition at line 464
- Function call at line 670

No functional changes, just correcting the spelling.