### PR TITLE
docs : update GitHub repository link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To install this application you need python3, yarn and virtualenv.
 Clone the repository:
 
 ```bash
-git clone https://github.com/OWASP/common-requirement-enumeration
+git clone https://github.com/OWASP/OpenCRE.git
 ```
 
 (Recommended) Create and activate a Python virtual environment:


### PR DESCRIPTION
This PR changes the GitHub repo link in the README from git clone https://github.com/OWASP/common-requirement-enumeration to https://github.com/OWASP/OpenCRE.git
