### PR TITLE
fix(gap-analysis): handle empty result dictionary correctly

### DIFF
--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -277,7 +277,7 @@ def map_analysis() -> Any:
     database = db.Node_collection()
     standards = request.args.getlist("standard")
     gap_analysis_dict = gap_analysis.schedule(standards, database)
-    if gap_analysis_dict.get("result"):
+    if "result" in gap_analysis_dict:
         return jsonify(gap_analysis_dict)
     if gap_analysis_dict.get("error"):
         abort(404)
@@ -297,7 +297,7 @@ def map_analysis_weak_links() -> Any:
     gap_analysis_results = database.get_gap_analysis_result(cache_key=cache_key)
     if gap_analysis_results:
         gap_analysis_dict = json.loads(gap_analysis_results)
-        if gap_analysis_dict.get("result"):
+        if "result" in gap_analysis_dict:
             return jsonify({"result": gap_analysis_dict.get("result")})
 
     # if conn.exists(cache_key):
@@ -352,7 +352,7 @@ def fetch_job() -> Any:
                 if ga:
                     # logger.__delattr__("and results in cache")
                     ga = flask_json.loads(ga)
-                    if ga.get("result"):
+                    if "result" in ga:
                         return jsonify(ga)
                     else:
                         logger.error(


### PR DESCRIPTION
# Fix GAP analysis job result handling for empty-but-valid results

## Description
This PR fixes an issue where successful GAP analysis background jobs could incorrectly return a 500 error when the computed result was empty.

The RQ worker correctly completes the job and stores a result in the cache, but the web layer previously treated empty results as invalid and raised an internal error.

## Problem
When fetching GAP analysis results via `/rest/v1/ma_job_results`, the web layer checked the result using a truthiness check:

```python
if ga.get("result"):
If the GAP analysis produced zero paths, the stored payload looked like:
```

```json
{"result": {}}
```

Since an empty dictionary evaluates to `False`, the API incorrectly entered the error branch and raised:

> Finished job does not have a result object, this is a bug!

This occurred even though:

*   The RQ worker completed successfully
*   The result was valid and intentionally empty
*   The data was correctly stored in the database cache

### Root Cause
The API was conflating:

*   “result does not exist” with
*   “result exists but is empty”

An empty GAP analysis is a valid outcome (e.g. no paths found between two standards).

### Solution
The API now checks for presence of the result key, not its truthiness:

The API now checks for presence of the result key, not its truthiness:

```python
if "result" in ga:
```
This allows empty-but-valid results to be returned to the frontend instead of triggering a 500 error.

The same logic is applied consistently across:

*   `/rest/v1/map_analysis`
*   `/rest/v1/map_analysis_weak_links`
*   `/rest/v1/ma_job_results`

### Behavior After This Change
*   ✅ Successful GAP jobs always return a response
*   ✅ Empty GAP results are returned as `{ "result": {} }`
*   ❌ Genuine failures (missing cache, failed jobs, invalid payloads) still return errors
*   ❌ No worker-side behavior is altered

### Related Issue
Fixes #583 – Running a GAP background job does not return a result

