### PR TITLE
Fix viewport meta tag and remove shrink-to-fit

### DIFF
--- a/application/frontend/src/index.html
+++ b/application/frontend/src/index.html
@@ -4,7 +4,11 @@
   <meta charset="utf-8" />
   <meta
     name="viewport"
-    content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no shrink-to-fit=no"
+    content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no"
+  />
+  <meta
+    name="description"
+    content="Open CRE - Open Cybersecurity Requirement Expression: Link security requirements across standards and frameworks."
   />
   <title>Open CRE</title>
   <link rel="icon" type="image/svg+xml" href="/logo.svg" />


### PR DESCRIPTION
This PR fixes two small issues in index.html

Changes: 

- Updates the viewport meta tag to remove `shrink-to-fit` , which is no longer used in browsers
- Adds a descriptive <meta name = "description"> explaining what OpenCRE is

Fixes #688 , #689 