### PR TITLE
fix(frontend): add missing noopener/noreferrer on external _blank links (closes #690)

### DIFF
--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -89,7 +89,7 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({
     return (
       <>
         <span>Reference:</span>
-        <a href={hyperlink.hyperlink} target="_blank">
+        <a href={hyperlink.hyperlink} target="_blank" rel="noopener noreferrer">
           {' '}
           {hyperlink.hyperlink}
         </a>
@@ -103,7 +103,7 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({
     }
 
     return (
-      <a href={hyperlink.hyperlink} target="_blank">
+      <a href={hyperlink.hyperlink} target="_blank" rel="noopener noreferrer">
         <Icon name="external" />
       </a>
     );

--- a/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
+++ b/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
@@ -63,7 +63,7 @@ export const CommonRequirementEnumeration = () => {
           {display && display.hyperlink && (
             <>
               <span>Reference: </span>
-              <a href={display?.hyperlink} target="_blank">
+              <a href={display?.hyperlink} target="_blank" rel="noopener noreferrer">
                 {' '}
                 {display.hyperlink}
               </a>

--- a/application/frontend/src/pages/Explorer/LinkedStandards.tsx
+++ b/application/frontend/src/pages/Explorer/LinkedStandards.tsx
@@ -53,7 +53,7 @@ export const LinkedStandards = ({ creCode, linkedTo, applyHighlight, filter }) =
         {uniqueLinkedTo.map((x: LinkedTreeDocument) => (
           <Fragment key={x.document.name}>
             {isExternalLink(x, linkedTo) && (
-              <a href={x.document.hyperlink} target="_blank">
+              <a href={x.document.hyperlink} target="_blank" rel="noopener noreferrer">
                 <Label>
                   <Icon name="external" />
                   {applyHighlight(x.document.name, filter)}

--- a/application/frontend/src/pages/Explorer/explorer.tsx
+++ b/application/frontend/src/pages/Explorer/explorer.tsx
@@ -137,7 +137,7 @@ export const Explorer = () => {
         <h1>Open CRE Explorer</h1>
         <p>
           A visual explorer of Open Common Requirement Enumerations (CREs). Originally created by:{' '}
-          <a target="_blank" href="https://zeljkoobrenovic.github.io/opencre-explorer/">
+          <a target="_blank" rel="noopener noreferrer" href="https://zeljkoobrenovic.github.io/opencre-explorer/">
             Zeljko Obrenovic
           </a>
           .
@@ -158,13 +158,13 @@ export const Explorer = () => {
                 <a href="/explorer/circles">Zoomable circles</a>
               </li>
             </ul>
-            {/* <a target="_blank" href="visuals/force-graph-3d-contains.html">
+            {/* <a target="_blank" rel="noopener noreferrer" href="visuals/force-graph-3d-contains.html">
               hierarchy only
             </a>
-            <a target="_blank" href="visuals/force-graph-3d-related.html">
+            <a target="_blank" rel="noopener noreferrer" href="visuals/force-graph-3d-related.html">
               related only
             </a>
-            <a target="_blank" href="visuals/force-graph-3d-linked.html">
+            <a target="_blank" rel="noopener noreferrer" href="visuals/force-graph-3d-linked.html">
               links to external standards
             </a>*/}
           </div>

--- a/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
+++ b/application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx
@@ -59,7 +59,7 @@ const GetResultLine = (path, gapAnalysis, key) => {
   let segmentID = gapAnalysis[key].start.id;
   return (
     <div key={path.end.id} style={{ marginBottom: '.25em', fontWeight: 'bold' }}>
-      <a href={getInternalUrl(path.end)} target="_blank">
+      <a href={getInternalUrl(path.end)} target="_blank" rel="noopener noreferrer">
         <Popup
           wide="very"
           size="large"
@@ -293,7 +293,7 @@ export const GapAnalysis = () => {
                 .map((key) => (
                   <Table.Row key={key}>
                     <Table.Cell textAlign="left" verticalAlign="top" selectable>
-                      <a href={getInternalUrl(gapAnalysis[key].start)} target="_blank">
+                      <a href={getInternalUrl(gapAnalysis[key].start)} target="_blank" rel="noopener noreferrer">
                         <p>
                           <b>{getDocumentDisplayName(gapAnalysis[key].start, true)}</b>
                         </p>

--- a/application/frontend/src/pages/Graph/Graph.tsx
+++ b/application/frontend/src/pages/Graph/Graph.tsx
@@ -39,7 +39,7 @@ const documentToReactFlowNode = (cDoc: Document | any): CREGraph => {
     position: { x: 0, y: 0 },
     data: {
       label: (
-        <a target="_blank" href={cDoc.hyperlink}>
+        <a target="_blank" rel="noopener noreferrer" href={cDoc.hyperlink}>
           {' '}
           {cDoc.id} - {cDoc.name}
         </a>
@@ -60,7 +60,7 @@ const documentToReactFlowNode = (cDoc: Document | any): CREGraph => {
         position: { x: 0, y: 0 },
         data: {
           label: (
-            <a target="_blank" href={hyperlink}>
+            <a target="_blank" rel="noopener noreferrer" href={hyperlink}>
               {' '}
               {node_label}
             </a>

--- a/application/frontend/src/pages/Standard/StandardSection.tsx
+++ b/application/frontend/src/pages/Standard/StandardSection.tsx
@@ -72,7 +72,7 @@ export const StandardSection = () => {
         {document && document.hyperlink && (
           <>
             <span>Reference: </span>
-            <a href={document?.hyperlink} target="_blank">
+            <a href={document?.hyperlink} target="_blank" rel="noopener noreferrer">
               {' '}
               {document.hyperlink}
             </a>

--- a/application/templates/includes/navigation.html
+++ b/application/templates/includes/navigation.html
@@ -51,7 +51,7 @@
                                                     <span class="mr-1"><span class="fas fa-th-large"></span></span>
                                                     UI components
                                                 </a>
-                                                <a href="https://themesberg.com/docs/pixel-bootstrap/getting-started/overview/" target="_blank" class="btn btn-outline-white btn-icon animate-up-2 mb-2 mb-sm-0">
+                                                <a href="https://themesberg.com/docs/pixel-bootstrap/getting-started/overview/" target="_blank" rel="noopener noreferrer" class="btn btn-outline-white btn-icon animate-up-2 mb-2 mb-sm-0">
                                                     <span class="mr-1"><span class="fas fa-book"></span></span>
                                                     UI Docs
                                                 </a>
@@ -67,18 +67,18 @@
                                             <li><a class="dropdown-item" href="/ui-bootstrap-carousels.html">Bootstrap Carousels</a></li>
                                             <li><a class="dropdown-item" href="/ui-breadcrumbs.html">Breadcrumbs</a></li>
                                             <li><a class="dropdown-item" href="/ui-buttons.html">Buttons</a></li>
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/plugins/jquery-counters/" target="_blank">Counters <span class="badge badge-tertiary ml-3">Pro</span></a></li>
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/buttons/#button-dropdown" target="_blank">Dropdowns <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/plugins/jquery-counters/" target="_blank" rel="noopener noreferrer">Counters <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/buttons/#button-dropdown" target="_blank" rel="noopener noreferrer">Dropdowns <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                         </ul>
                                     </div>
                                     <div class="col pl-0">
                                         <ul class="list-style-none">
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/e-commerce/" target="_blank">E-commerce <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/e-commerce/" target="_blank" rel="noopener noreferrer">E-commerce <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                             <li><a class="dropdown-item" href="/ui-forms.html">Forms</a></li>
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/icon-boxes/" target="_blank">Icon Boxes <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/icon-boxes/" target="_blank" rel="noopener noreferrer">Icon Boxes <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                             <li><a class="dropdown-item" href="/ui-modals.html">Modals</a></li>
                                             <li><a class="dropdown-item" href="/ui-navs.html">Navs</a></li>
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/plugins/owl-carousel/" target="_blank">Owl Carousels <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/plugins/owl-carousel/" target="_blank" rel="noopener noreferrer">Owl Carousels <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                             <li><a class="dropdown-item" href="/ui-pagination.html">Pagination</a></li>
                                             <li><a class="dropdown-item" href="/ui-popovers.html">Popovers</a></li>
                                             <li><a class="dropdown-item" href="/ui-progress-bars.html">Progress Bars</a></li>
@@ -87,13 +87,13 @@
                                     </div>
                                     <div class="col pl-0">
                                         <ul class="list-style-none">
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/icon-boxes/#steps" target="_blank">Steps <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/icon-boxes/#steps" target="_blank" rel="noopener noreferrer">Steps <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                             <li><a class="dropdown-item" href="/ui-tabs.html">Tabs</a> </li>
                                             <li><a class="dropdown-item" href="/ui-toasts.html">Toasts</a> </li>
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/timelines/" target="_blank">Timelines <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/components/timelines/" target="_blank" rel="noopener noreferrer">Timelines <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                             <li><a class="dropdown-item" href="/ui-tooltips.html">Tooltips</a></li>
                                             <li><a class="dropdown-item" href="/ui-typography.html">Typography</a></li>
-                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/plugins/chart-js/" target="_blank">Charts <span class="badge badge-tertiary ml-3">Pro</span></a></li>
+                                            <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://themesberg.com/docs/pixel-bootstrap/plugins/chart-js/" target="_blank" rel="noopener noreferrer">Charts <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                             <li><a class="dropdown-item d-flex align-items-center justify-content-between" href="https://demo.themesberg.com/pixel-pro/html/components/widgets.html">Widgets <span class="badge badge-tertiary ml-3">Pro</span></a></li>
                                         </ul>
                                     </div>
@@ -109,14 +109,14 @@
                                 <div class="col-auto px-0" data-dropdown-content>
                                     <div class="list-group list-group-flush">
                                         <a href="https://github.com/app-generator/jinja-template-pixel-uikit" 
-                                           target="_blank" class="list-group-item list-group-item-action d-flex align-items-center p-0 py-3 px-lg-4">
+                                           target="_blank" rel="noopener noreferrer" class="list-group-item list-group-item-action d-flex align-items-center p-0 py-3 px-lg-4">
                                             <span class="icon icon-sm icon-secondary"><span class="fas fa-file-alt"></span></span>
                                             <div class="ml-4">
                                                 <span class="text-dark d-block">Documentation</span>
                                                 <span class="small">Learn how to build the app</span>
                                             </div>
                                         </a>
-                                        <a href="https://appseed.us/support" target="_blank" class="list-group-item list-group-item-action d-flex align-items-center p-0 py-3 px-lg-4">
+                                        <a href="https://appseed.us/support" target="_blank" rel="noopener noreferrer" class="list-group-item list-group-item-action d-flex align-items-center p-0 py-3 px-lg-4">
                                             <span class="icon icon-sm icon-primary"><span class="fas fa-microphone-alt"></span></span>
                                             <div class="ml-4">
                                                 <span class="text-dark d-block">Support</span>
@@ -134,7 +134,7 @@
                 <div class="d-flex align-items-center">
                     <span class="d-none d-md-inline"> 
                       <a href="https://appseed.us/jinja-template/jinja-pixel-uikit-pro" 
-                         target="_blank" class="btn btn-tertiary animate-up-2">
+                         target="_blank" rel="noopener noreferrer" class="btn btn-tertiary animate-up-2">
                          <span class="fas fa-rocket mr-2"></span>PRO Version</a>
                     </span>
                     


### PR DESCRIPTION
## Summary
This PR fixes #690 by ensuring external links opened with `target="_blank"` also include `rel="noopener noreferrer"`.

## Why
Missing `rel="noopener noreferrer"` on `_blank` links can expose `window.opener` and enable reverse-tabnabbing/privacy leaks.

## Changes
Added `rel="noopener noreferrer"` to missing `_blank` anchors in:

- `application/frontend/src/components/DocumentNode/DocumentNode.tsx`
- `application/frontend/src/pages/Standard/StandardSection.tsx`
- `application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx`
- `application/frontend/src/pages/Explorer/LinkedStandards.tsx`
- `application/frontend/src/pages/Graph/Graph.tsx`
- `application/frontend/src/pages/GapAnalysis/GapAnalysis.tsx`
- `application/frontend/src/pages/Explorer/explorer.tsx`
- `application/templates/includes/navigation.html`

## Verification
- Confirmed no remaining `_blank` anchors without `rel`:
  - `rg -nP "<a[^>]*target=\"_blank\"(?![^>]*rel=)" application/frontend/src application/templates`
  - Result: no matches
- Build check:
  - `npm run build`
  - Result: successful build (existing bundle-size warnings only)

## Scope
No functional/UI behavior changes expected; this is a security hardening update for link attributes only.
