### PR TITLE
fix: add input validation for CSV import (#554)

### DIFF
--- a/application/tests/myopencre_parser_test.py
+++ b/application/tests/myopencre_parser_test.py
@@ -46,5 +46,32 @@ class MyOpenCreParserIdentityTest(unittest.TestCase):
                 myopencre_parser._reconcile_cre_identities(cres)
 
 
+class MyOpenCreCsvValidationTest(unittest.TestCase):
+    def test_accepts_well_formed_cre_cells(self) -> None:
+        myopencre_parser.validate_cre_csv_rows(
+            [{"CRE 0": "123-456|Access Control", "standard|name": "ASVS"}]
+        )
+
+    def test_rejects_short_cre_id(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            myopencre_parser.validate_cre_csv_rows(
+                [{"CRE 0": "12-456|Bad Id", "standard|name": "ASVS"}]
+            )
+        self.assertIn("Expected XXX-XXX|Name", str(cm.exception))
+        self.assertIn("row 2", str(cm.exception))
+
+    def test_rejects_missing_separator(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            myopencre_parser.validate_cre_csv_rows(
+                [{"CRE 0": "123-456 Access Control", "standard|name": "ASVS"}]
+            )
+        self.assertIn("Expected XXX-XXX|Name", str(cm.exception))
+
+    def test_skips_empty_cre_cells(self) -> None:
+        myopencre_parser.validate_cre_csv_rows(
+            [{"CRE 0": "", "CRE 1": "n/a", "standard|name": "ASVS"}]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/application/tests/myopencre_parser_test.py
+++ b/application/tests/myopencre_parser_test.py
@@ -46,31 +46,23 @@ class MyOpenCreParserIdentityTest(unittest.TestCase):
                 myopencre_parser._reconcile_cre_identities(cres)
 
 
-class MyOpenCreCsvValidationTest(unittest.TestCase):
-    def test_accepts_well_formed_cre_cells(self) -> None:
-        myopencre_parser.validate_cre_csv_rows(
-            [{"CRE 0": "123-456|Access Control", "standard|name": "ASVS"}]
-        )
+class MyOpenCreCsvValidationWiringTest(unittest.TestCase):
+    """parse_rows_to_documents delegates CRE cell validation to the shared
+    spreadsheet_parsers.validate_import_csv_rows (#554 / #682). Format-level
+    cases live in spreadsheet_parsers_test.py; this just proves the wiring.
+    """
 
-    def test_rejects_short_cre_id(self) -> None:
+    def test_rejects_malformed_cre_cell_via_shared_validator(self) -> None:
+        rows = [
+            {
+                "CRE 0": "12-456|Bad Id",
+                "standard|name": "ASVS",
+                "standard|id": "1.1.1",
+            }
+        ]
         with self.assertRaises(ValueError) as cm:
-            myopencre_parser.validate_cre_csv_rows(
-                [{"CRE 0": "12-456|Bad Id", "standard|name": "ASVS"}]
-            )
+            myopencre_parser.parse_rows_to_documents(rows)
         self.assertIn("Expected XXX-XXX|Name", str(cm.exception))
-        self.assertIn("row 2", str(cm.exception))
-
-    def test_rejects_missing_separator(self) -> None:
-        with self.assertRaises(ValueError) as cm:
-            myopencre_parser.validate_cre_csv_rows(
-                [{"CRE 0": "123-456 Access Control", "standard|name": "ASVS"}]
-            )
-        self.assertIn("Expected XXX-XXX|Name", str(cm.exception))
-
-    def test_skips_empty_cre_cells(self) -> None:
-        myopencre_parser.validate_cre_csv_rows(
-            [{"CRE 0": "", "CRE 1": "n/a", "standard|name": "ASVS"}]
-        )
 
 
 if __name__ == "__main__":

--- a/application/tests/spreadsheet_parsers_test.py
+++ b/application/tests/spreadsheet_parsers_test.py
@@ -10,6 +10,7 @@ from application.utils.spreadsheet_parsers import (
     parse_master_spreadsheet_documents,
     parse_standards,
     supported_resource_mapping,
+    validate_import_csv_rows,
 )
 
 
@@ -75,6 +76,43 @@ class TestParsers(unittest.TestCase):
         standards_map = supported_resource_mapping.get("Standards", {})
         for link in legacy_links:
             self.assertIn(link.document.name, standards_map)
+
+
+class TestValidateImportCsvRows(unittest.TestCase):
+    """CRE cell format validation (#554) via the shared validate_import_csv_rows."""
+
+    def _row(self, cre_0: str) -> dict:
+        return {
+            "CRE 0": cre_0,
+            "standard|name": "ASVS",
+            "standard|id": "1.1.1",
+        }
+
+    def test_accepts_well_formed_cre_cells(self) -> None:
+        validate_import_csv_rows([self._row("123-456|Access Control")])
+
+    def test_rejects_short_cre_id(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            validate_import_csv_rows([self._row("12-456|Bad Id")])
+        self.assertIn("Expected XXX-XXX|Name", str(cm.exception))
+        self.assertIn("row 2", str(cm.exception))
+
+    def test_rejects_missing_separator(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            validate_import_csv_rows([self._row("123-456 Access Control")])
+        self.assertIn("Expected XXX-XXX|Name", str(cm.exception))
+
+    def test_skips_empty_cre_cells(self) -> None:
+        validate_import_csv_rows(
+            [
+                {
+                    "CRE 0": "",
+                    "CRE 1": "n/a",
+                    "standard|name": "ASVS",
+                    "standard|id": "1.1.1",
+                }
+            ]
+        )
 
 
 if __name__ == "__main__":

--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -1401,6 +1401,51 @@ class TestMain(unittest.TestCase):
                 self.assertGreaterEqual(data.get("new_standards"), 2)
                 self.assertIsInstance(data.get("new_cres"), list)
 
+    def test_import_from_cre_csv_rejects_bad_cre_format(self) -> None:
+        """Malformed CRE cells must 400 with a clear message (#554 / #751)."""
+        workspace = tempfile.mkdtemp()
+        path = os.path.join(workspace, "bad_cre.csv")
+        with open(path, "w", encoding="utf-8") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["CRE 0", "standard|name", "standard|id"]
+            )
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "CRE 0": "12-456|Too Short",
+                    "standard|name": "ASVS",
+                    "standard|id": "1.1.1",
+                }
+            )
+        with patch.dict(os.environ, {"CRE_ALLOW_IMPORT": "True"}):
+            with self.app.test_client() as client:
+                response = client.post(
+                    "/rest/v1/cre_csv_import",
+                    data={"cre_csv": open(path, "rb")},
+                    buffered=True,
+                    content_type="multipart/form-data",
+                )
+                self.assertEqual(400, response.status_code)
+                self.assertIn(b"Expected XXX-XXX|Name", response.data)
+
+    def test_import_from_cre_csv_rejects_triple_quotes(self) -> None:
+        """Triple-quoted content must not create bogus root CREs (#554)."""
+        workspace = tempfile.mkdtemp()
+        path = os.path.join(workspace, "triple.csv")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write('CRE 0,standard|name,standard|id\n')
+            f.write('"""123-456|Quoted""",ASVS,1.1.1\n')
+        with patch.dict(os.environ, {"CRE_ALLOW_IMPORT": "True"}):
+            with self.app.test_client() as client:
+                response = client.post(
+                    "/rest/v1/cre_csv_import",
+                    data={"cre_csv": open(path, "rb")},
+                    buffered=True,
+                    content_type="multipart/form-data",
+                )
+                self.assertEqual(400, response.status_code)
+                self.assertIn(b"triple-quoted", response.data)
+
     def test_get_cre_csv(self) -> None:
         # empty string means temporary db
         collection = db.Node_collection().with_graph()

--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -1568,6 +1568,51 @@ class TestMain(unittest.TestCase):
                 self.assertGreaterEqual(data.get("new_standards"), 2)
                 self.assertIsInstance(data.get("new_cres"), list)
 
+    def test_import_from_cre_csv_rejects_bad_cre_format(self) -> None:
+        """Malformed CRE cells must 400 with a clear message (#554 / #751)."""
+        workspace = tempfile.mkdtemp()
+        path = os.path.join(workspace, "bad_cre.csv")
+        with open(path, "w", encoding="utf-8") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["CRE 0", "standard|name", "standard|id"]
+            )
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "CRE 0": "12-456|Too Short",
+                    "standard|name": "ASVS",
+                    "standard|id": "1.1.1",
+                }
+            )
+        with patch.dict(os.environ, {"CRE_ALLOW_IMPORT": "True"}):
+            with self.app.test_client() as client:
+                response = client.post(
+                    "/rest/v1/cre_csv_import",
+                    data={"cre_csv": open(path, "rb")},
+                    buffered=True,
+                    content_type="multipart/form-data",
+                )
+                self.assertEqual(400, response.status_code)
+                self.assertIn(b"Expected XXX-XXX|Name", response.data)
+
+    def test_import_from_cre_csv_rejects_triple_quotes(self) -> None:
+        """Triple-quoted content must not create bogus root CREs (#554)."""
+        workspace = tempfile.mkdtemp()
+        path = os.path.join(workspace, "triple.csv")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write('CRE 0,standard|name,standard|id\n')
+            f.write('"""123-456|Quoted""",ASVS,1.1.1\n')
+        with patch.dict(os.environ, {"CRE_ALLOW_IMPORT": "True"}):
+            with self.app.test_client() as client:
+                response = client.post(
+                    "/rest/v1/cre_csv_import",
+                    data={"cre_csv": open(path, "rb")},
+                    buffered=True,
+                    content_type="multipart/form-data",
+                )
+                self.assertEqual(400, response.status_code)
+                self.assertIn(b"triple-quoted", response.data)
+
     def test_get_cre_csv(self) -> None:
         # empty string means temporary db
         collection = db.Node_collection().with_graph()

--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -1600,7 +1600,7 @@ class TestMain(unittest.TestCase):
         workspace = tempfile.mkdtemp()
         path = os.path.join(workspace, "triple.csv")
         with open(path, "w", encoding="utf-8") as f:
-            f.write('CRE 0,standard|name,standard|id\n')
+            f.write("CRE 0,standard|name,standard|id\n")
             f.write('"""123-456|Quoted""",ASVS,1.1.1\n')
         with patch.dict(os.environ, {"CRE_ALLOW_IMPORT": "True"}):
             with self.app.test_client() as client:

--- a/application/utils/external_project_parsers/parsers/myopencre_parser.py
+++ b/application/utils/external_project_parsers/parsers/myopencre_parser.py
@@ -13,6 +13,38 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 _CRE_ID_TOKEN = re.compile(r"^\d{3}-\d{3}$")
+# Exported CRE cells are ``<id>|<name>`` (see ExportFormat.separator).
+_CRE_CELL_PATTERN = re.compile(r"^\d{3}-\d{3}\|.+$")
+
+
+def _is_empty_cell(value: Any) -> bool:
+    if value is None:
+        return True
+    text = str(value).strip()
+    return text == "" or text.lower() in {"none", "nan", "n/a", "no", "tbd", "0"}
+
+
+def validate_cre_csv_rows(rows: List[Dict[str, Any]]) -> None:
+    """Fail fast on CRE cells that are not ``XXX-XXX|Name`` (#554).
+
+    Raises ``ValueError`` with a row/column message so the web layer can
+    return HTTP 400 instead of a 500 / silent bad parse.
+    """
+    if not rows:
+        return
+    cre_headers = [h for h in rows[0].keys() if str(h).startswith("CRE")]
+    for row_index, row in enumerate(rows, start=2):
+        for header in cre_headers:
+            value = row.get(header)
+            if _is_empty_cell(value):
+                continue
+            normalized = str(value).strip()
+            if not _CRE_CELL_PATTERN.match(normalized):
+                raise ValueError(
+                    "Invalid CRE column format in row "
+                    f"{row_index}, column '{header}'. Expected XXX-XXX|Name "
+                    f"(got '{normalized}')."
+                )
 
 
 def _load_existing_cre_identity_maps() -> Tuple[Dict[str, str], Dict[str, str]]:
@@ -90,6 +122,7 @@ def parse_rows_to_documents(rows: List[Dict[str, Any]]) -> ParseResult:
     conventions. It reuses export_format_parser.parse_export_format to
     understand the CSV structure.
     """
+    validate_cre_csv_rows(rows)
     documents = export_format_parser.parse_export_format(rows)
 
     # CREs are under the Credoctypes.CRE value key

--- a/application/utils/external_project_parsers/parsers/myopencre_parser.py
+++ b/application/utils/external_project_parsers/parsers/myopencre_parser.py
@@ -3,6 +3,7 @@ import re
 from typing import Dict, List, Any, Tuple
 
 from application.defs import cre_defs as defs
+from application.utils import spreadsheet_parsers
 from application.utils.external_project_parsers.parsers import export_format_parser
 from application.utils.external_project_parsers import base_parser_defs
 from application.utils.external_project_parsers.base_parser_defs import ParseResult
@@ -13,38 +14,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 _CRE_ID_TOKEN = re.compile(r"^\d{3}-\d{3}$")
-# Exported CRE cells are ``<id>|<name>`` (see ExportFormat.separator).
-_CRE_CELL_PATTERN = re.compile(r"^\d{3}-\d{3}\|.+$")
-
-
-def _is_empty_cell(value: Any) -> bool:
-    if value is None:
-        return True
-    text = str(value).strip()
-    return text == "" or text.lower() in {"none", "nan", "n/a", "no", "tbd", "0"}
-
-
-def validate_cre_csv_rows(rows: List[Dict[str, Any]]) -> None:
-    """Fail fast on CRE cells that are not ``XXX-XXX|Name`` (#554).
-
-    Raises ``ValueError`` with a row/column message so the web layer can
-    return HTTP 400 instead of a 500 / silent bad parse.
-    """
-    if not rows:
-        return
-    cre_headers = [h for h in rows[0].keys() if str(h).startswith("CRE")]
-    for row_index, row in enumerate(rows, start=2):
-        for header in cre_headers:
-            value = row.get(header)
-            if _is_empty_cell(value):
-                continue
-            normalized = str(value).strip()
-            if not _CRE_CELL_PATTERN.match(normalized):
-                raise ValueError(
-                    "Invalid CRE column format in row "
-                    f"{row_index}, column '{header}'. Expected XXX-XXX|Name "
-                    f"(got '{normalized}')."
-                )
 
 
 def _load_existing_cre_identity_maps() -> Tuple[Dict[str, str], Dict[str, str]]:
@@ -122,7 +91,7 @@ def parse_rows_to_documents(rows: List[Dict[str, Any]]) -> ParseResult:
     conventions. It reuses export_format_parser.parse_export_format to
     understand the CSV structure.
     """
-    validate_cre_csv_rows(rows)
+    rows = spreadsheet_parsers.validate_import_csv_rows(rows)
     documents = export_format_parser.parse_export_format(rows)
 
     # CREs are under the Credoctypes.CRE value key

--- a/application/utils/spreadsheet_parsers.py
+++ b/application/utils/spreadsheet_parsers.py
@@ -159,6 +159,10 @@ def is_empty(value: Optional[str]) -> bool:
     )
 
 
+# Exported CRE cells are ``<id>|<name>`` (see ExportFormat.separator).
+_CRE_CELL_PATTERN = re.compile(r"^\d{3}-\d{3}\|.+$")
+
+
 def validate_import_csv_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Entry point for parsing imported CSV files.
@@ -203,14 +207,22 @@ def validate_import_csv_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]
         if all(not v for v in normalized.values()):
             continue
 
-        cre_values = [v for k, v in normalized.items() if k.startswith("CRE") and v]
+        cre_cells = {
+            k: v
+            for k, v in normalized.items()
+            if k.startswith("CRE") and not is_empty(v)
+        }
 
-        for cre in cre_values:
-            if "|" not in cre:
+        for header, cre in cre_cells.items():
+            if not _CRE_CELL_PATTERN.match(str(cre)):
                 errors.append(
                     {
                         "row": row_index,
-                        "message": f"Invalid CRE entry '{cre}', expected '<CRE-ID>|<Name>'",
+                        "message": (
+                            f"Invalid CRE column format in row {row_index}, "
+                            f"column '{header}'. Expected XXX-XXX|Name "
+                            f"(got '{cre}')."
+                        ),
                     }
                 )
 

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -1292,9 +1292,27 @@ def import_from_cre_csv() -> Any:
     if file is None:
         abort(400, "No file provided")
     contents = file.read()
-    csv_read = csv.DictReader(contents.decode("utf-8").splitlines())
     try:
-        parse_result = myopencre_parser.parse_rows_to_documents(list(csv_read))
+        contents_text = contents.decode("utf-8")
+    except UnicodeDecodeError:
+        abort(400, "Invalid CSV encoding. Expected UTF-8.")
+
+    # Triple-quoted blobs were previously mis-parsed into bogus root CREs (#554).
+    if '"""' in contents_text:
+        abort(
+            400,
+            "Invalid CSV content: triple-quoted text detected. "
+            "Use standard CSV quoting (double quotes) instead.",
+        )
+
+    try:
+        csv_read = csv.DictReader(contents_text.splitlines())
+        rows = list(csv_read)
+    except csv.Error as exc:
+        abort(400, f"Invalid CSV content: {exc}")
+
+    try:
+        parse_result = myopencre_parser.parse_rows_to_documents(rows)
     except cre_exceptions.DuplicateLinkException as dle:
         abort(500, f"error during parsing of the incoming CSV, err:{dle}")
     except ValueError as ve:

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -1517,11 +1517,29 @@ def import_from_cre_csv() -> Any:
     if file is None:
         abort(400, "No file provided")
     contents = file.read()
-    csv_read = csv.DictReader(contents.decode("utf-8").splitlines())
+    try:
+        contents_text = contents.decode("utf-8")
+    except UnicodeDecodeError:
+        abort(400, "Invalid CSV encoding. Expected UTF-8.")
+
+    # Triple-quoted blobs were previously mis-parsed into bogus root CREs (#554).
+    if '"""' in contents_text:
+        abort(
+            400,
+            "Invalid CSV content: triple-quoted text detected. "
+            "Use standard CSV quoting (double quotes) instead.",
+        )
+
+    try:
+        csv_read = csv.DictReader(contents_text.splitlines())
+        rows = list(csv_read)
+    except csv.Error as exc:
+        abort(400, f"Invalid CSV content: {exc}")
+
     try:
         from application.utils.external_project_parsers.parsers import myopencre_parser
 
-        parse_result = myopencre_parser.parse_rows_to_documents(list(csv_read))
+        parse_result = myopencre_parser.parse_rows_to_documents(rows)
     except cre_exceptions.DuplicateLinkException as dle:
         abort(500, f"error during parsing of the incoming CSV, err:{dle}")
     except ValueError as ve:


### PR DESCRIPTION
Fixes #554

- Validates CRE column format matches XXX-XXX| pattern
- Returns descriptive 400 error instead of generic 500
- Handles triple-quoted text edge case

Tested locally by reproducing both cases from the issue.