### PR TITLE
feat: add close button to mobile navbar #657

### DIFF
--- a/application/frontend/src/scaffolding/Header/Header.tsx
+++ b/application/frontend/src/scaffolding/Header/Header.tsx
@@ -1,6 +1,6 @@
 import './header.scss';
 
-import { LogOut, Menu, Search, User } from 'lucide-react';
+import { LogOut, Menu, Search, User, X } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { NavLink } from 'react-router-dom';
@@ -134,6 +134,13 @@ export const Header = ({ capabilities }: HeaderProps) => {
       <div className={`navbar__overlay ${isMobileMenuOpen ? 'is-open' : ''}`} onClick={closeMobileMenu}></div>
 
       <div className={`navbar__mobile-menu ${isMobileMenuOpen ? 'is-open' : ''}`}>
+        <button
+          className="navbar__mobile-menu-close"
+          onClick={closeMobileMenu}
+          aria-label="Close mobile menu"
+        >
+          <X className="mobile-close-icon" />
+        </button>
         <div className="mobile-search-container">
           <SearchBar />
         </div>

--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -345,3 +345,22 @@
   border: 0;
 }
 
+.navbar__mobile-menu-close {
+  display: flex;
+  margin-left: auto;
+  margin-bottom: 1rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+
+  .mobile-close-icon {
+    color: #ffffff;
+    width: 28px;
+    height: 28px;
+  }
+
+  &:hover {
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
Added a working 'X' button on top of the mobile navigation drawer that closes the hamburger menu on mobile devices.
<img width="538" height="638" alt="Mobile-navbar-with-'X'-on-top" src="https://github.com/user-attachments/assets/0fe1f095-afc0-4e52-8ed2-e72b8fa2f1a2" />
