### PR TITLE
add pagination to tags and text_search endpoints

### DIFF
--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -435,11 +435,62 @@ class TestMain(unittest.TestCase):
             response = client.get(f"/rest/v1/tags?tag=CW")
             self.assertEqual(404, response.status_code)
 
-            expected = {"data": [cres["ca"].todict(), cres["cb"].todict()]}
+            expected = {
+                "data": [cres["ca"].todict(), cres["cb"].todict()],
+                "page": 1,
+                "total_pages": 1,
+            }
 
             response = client.get(f"/rest/v1/tags?tag=ta")
             self.assertEqual(200, response.status_code)
-            self.assertCountEqual(json.loads(response.data.decode()), expected)
+            payload = json.loads(response.data.decode())
+            self.assertEqual(1, payload["page"])
+            self.assertEqual(1, payload["total_pages"])
+            self.assertEqual(
+                sorted(d["id"] for d in payload["data"]),
+                sorted(d["id"] for d in expected["data"]),
+            )
+
+    @patch.object(db, "Node_collection")
+    def test_tags_pagination_and_format_parity(self, db_mock) -> None:
+        docs = [
+            defs.CRE(id="111-111", description="A", name="A", tags=["ta"]),
+            defs.CRE(id="222-222", description="B", name="B", tags=["ta"]),
+            defs.CRE(id="333-333", description="C", name="C", tags=["ta"]),
+        ]
+        db_mock.return_value.get_by_tags.return_value = docs
+
+        with self.app.test_client() as client:
+            json_response = client.get("/rest/v1/tags?tag=ta&page=2&items_per_page=1")
+            payload = json.loads(json_response.data.decode())
+            self.assertEqual(200, json_response.status_code)
+            self.assertEqual(2, payload["page"])
+            self.assertEqual(3, payload["total_pages"])
+            self.assertEqual("222-222", payload["data"][0]["id"])
+
+            md_response = client.get(
+                "/rest/v1/tags?tag=ta&page=2&items_per_page=1&format=md"
+            )
+            self.assertEqual(200, md_response.status_code)
+            self.assertIn("222-222", md_response.data.decode())
+
+            csv_response = client.get(
+                "/rest/v1/tags?tag=ta&page=2&items_per_page=1&format=csv"
+            )
+            self.assertEqual(200, csv_response.status_code)
+            self.assertGreater(len(csv_response.data), 0)
+
+            oscal_response = client.get(
+                "/rest/v1/tags?tag=ta&page=2&items_per_page=1&format=oscal"
+            )
+            oscal_payload = json.loads(oscal_response.data.decode())
+            self.assertEqual(200, oscal_response.status_code)
+            self.assertIn("metadata", oscal_payload)
+
+            out_of_range_response = client.get(
+                "/rest/v1/tags?tag=ta&page=99&items_per_page=1"
+            )
+            self.assertEqual(404, out_of_range_response.status_code)
 
     def test_test_search(self) -> None:
         collection = db.Node_collection()
@@ -469,7 +520,10 @@ class TestMain(unittest.TestCase):
             for r in requests:
                 response = client.get(r)
                 self.assertEqual(200, response.status_code)
-                self.assertCountEqual(response.json, expected)
+                payload = response.json
+                self.assertEqual(1, payload["page"])
+                self.assertEqual(1, payload["total_pages"])
+                self.assertCountEqual(payload["data"], expected)
 
             expected = [docs["sa"].todict()]
             srequests = [
@@ -481,7 +535,51 @@ class TestMain(unittest.TestCase):
             for r in srequests:
                 resp = client.get(r)
                 self.assertEqual(200, resp.status_code)
-                self.assertDictEqual(resp.json[0], expected[0])
+                self.assertDictEqual(resp.json["data"][0], expected[0])
+
+    @patch.object(db, "Node_collection")
+    def test_text_search_pagination_and_format_parity(self, db_mock) -> None:
+        docs = [
+            defs.Standard(name="SB", section="s1", subsection="a"),
+            defs.Standard(name="SB", section="s2", subsection="b"),
+            defs.Standard(name="SB", section="s3", subsection="c"),
+        ]
+        db_mock.return_value.text_search.return_value = docs
+
+        with self.app.test_client() as client:
+            json_response = client.get(
+                "/rest/v1/text_search?text=SB&page=2&items_per_page=1"
+            )
+            payload = json.loads(json_response.data.decode())
+            self.assertEqual(200, json_response.status_code)
+            self.assertEqual(2, payload["page"])
+            self.assertEqual(3, payload["total_pages"])
+            self.assertEqual(1, len(payload["data"]))
+            self.assertEqual("s2", payload["data"][0]["section"])
+
+            md_response = client.get(
+                "/rest/v1/text_search?text=SB&page=2&items_per_page=1&format=md"
+            )
+            self.assertEqual(200, md_response.status_code)
+            self.assertIn("s2", md_response.data.decode())
+
+            csv_response = client.get(
+                "/rest/v1/text_search?text=SB&page=2&items_per_page=1&format=csv"
+            )
+            self.assertEqual(200, csv_response.status_code)
+            self.assertGreater(len(csv_response.data), 0)
+
+            oscal_response = client.get(
+                "/rest/v1/text_search?text=SB&page=2&items_per_page=1&format=oscal"
+            )
+            oscal_payload = json.loads(oscal_response.data.decode())
+            self.assertEqual(200, oscal_response.status_code)
+            self.assertEqual(1, len(oscal_payload["controls"]))
+
+            out_of_range_response = client.get(
+                "/rest/v1/text_search?text=SB&page=99&items_per_page=1"
+            )
+            self.assertEqual(404, out_of_range_response.status_code)
 
     def test_find_root_cres(self) -> None:
         self.maxDiff = None

--- a/application/web/openapi_schemas.py
+++ b/application/web/openapi_schemas.py
@@ -45,6 +45,16 @@ class NodeListResponseSchema(Schema):
 
 class DataListResponseSchema(Schema):
     data = fields.List(fields.Dict(keys=fields.Str(), values=fields.Raw()))
+    page = fields.Int(
+        required=False,
+        metadata={"description": "Current 1-based page (when pagination is applied)"},
+    )
+    total_pages = fields.Int(
+        required=False,
+        metadata={
+            "description": "Total pages for the result set (when pagination is applied)"
+        },
+    )
 
 
 class TagQuerySchema(FormatQuerySchema):
@@ -53,10 +63,26 @@ class TagQuerySchema(FormatQuerySchema):
         required=True,
         metadata={"description": "Tag name(s)"},
     )
+    page = fields.Int(
+        required=False,
+        metadata={"description": "1-based page number for paginated results"},
+    )
+    items_per_page = fields.Int(
+        required=False,
+        metadata={"description": "Number of items per page (capped server-side)"},
+    )
 
 
 class TextSearchQuerySchema(FormatQuerySchema):
     text = fields.Str(required=True, metadata={"description": "Search query"})
+    page = fields.Int(
+        required=False,
+        metadata={"description": "1-based page number for paginated results"},
+    )
+    items_per_page = fields.Int(
+        required=False,
+        metadata={"description": "Number of items per page (capped server-side)"},
+    )
 
 
 class NodeQuerySchema(FormatQuerySchema):

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -5,6 +5,7 @@ import csv
 from functools import wraps
 import json
 import logging
+import math
 import os
 import io
 import pathlib
@@ -97,6 +98,35 @@ class SupportedFormats(Enum):
     JSON = "json"
     YAML = "yaml"
     OSCAL = "oscal"
+
+
+def _parse_positive_int(value: str | None, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+        if parsed > 0:
+            return parsed
+    except (TypeError, ValueError):
+        pass
+    return default
+
+
+def _paginate_documents(
+    documents: list[defs.Document],
+) -> tuple[int, int, list[defs.Document]]:
+    """Slice ``documents`` using ``page`` / ``items_per_page`` query args."""
+    page = _parse_positive_int(request.args.get("page"), 1)
+    items_per_page = min(
+        _parse_positive_int(request.args.get("items_per_page"), ITEMS_PER_PAGE),
+        MAX_ITEMS_PER_PAGE,
+    )
+    total_pages = max(1, math.ceil(len(documents) / items_per_page))
+    if page > total_pages:
+        abort(404, "Page does not exist")
+    start = (page - 1) * items_per_page
+    end = start + items_per_page
+    return page, total_pages, documents[start:end]
 
 
 def extend_cre_with_tag_links(
@@ -296,7 +326,6 @@ def find_node_by_name(
         abort(404, "Node does not exist")
 
 
-# TODO: (spyros) paginate
 @openapi_documented("find_document_by_tag")
 @app.route("/rest/v1/tags", methods=["GET"])
 def find_document_by_tag() -> Any:
@@ -309,15 +338,16 @@ def find_document_by_tag() -> Any:
     opt_format = request.args.get("format")
     documents = database.get_by_tags(tags)
     if documents:
-        res = [doc.todict() for doc in documents]
-        result = {"data": res}
+        page, total_pages, paged_documents = _paginate_documents(documents)
+        res = [doc.todict() for doc in paged_documents]
+        result = {"data": res, "page": page, "total_pages": total_pages}
         # if opt_osib:
         #     result["osib"] = odefs.cre2osib(documents).todict()
         if opt_format == SupportedFormats.Markdown.value:
-            return f"<pre>{mdutils.cre_to_md(documents)}</pre>"
+            return f"<pre>{mdutils.cre_to_md(paged_documents)}</pre>"
         elif opt_format == SupportedFormats.CSV.value:
             docs = sheet_utils.ExportSheet().prepare_spreadsheet(
-                docs=documents, storage=database
+                docs=paged_documents, storage=database
             )
             return write_csv(docs=docs).getvalue().encode("utf-8")
         elif opt_format == SupportedFormats.OSCAL.value:
@@ -330,7 +360,7 @@ def find_document_by_tag() -> Any:
                     "(compliance-trestle not installed).",
                 )
 
-            return jsonify(json.loads(oscal_utils.list_to_oscal(documents)))
+            return jsonify(json.loads(oscal_utils.list_to_oscal(paged_documents)))
 
         return jsonify(result)
     abort(404, "Tag does not exist")
@@ -608,11 +638,12 @@ def text_search() -> Any:
     opt_format = request.args.get("format")
     documents = database.text_search(text)
     if documents:
+        page, total_pages, paged_documents = _paginate_documents(documents)
         if opt_format == SupportedFormats.Markdown.value:
-            return f"<pre>{mdutils.cre_to_md(documents)}</pre>"
+            return f"<pre>{mdutils.cre_to_md(paged_documents)}</pre>"
         elif opt_format == SupportedFormats.CSV.value:
             docs = sheet_utils.ExportSheet().prepare_spreadsheet(
-                docs=documents, storage=database
+                docs=paged_documents, storage=database
             )
             return write_csv(docs=docs).getvalue().encode("utf-8")
         elif opt_format == SupportedFormats.OSCAL.value:
@@ -625,10 +656,10 @@ def text_search() -> Any:
                     "(compliance-trestle not installed).",
                 )
 
-            return jsonify(json.loads(oscal_utils.list_to_oscal(documents)))
+            return jsonify(json.loads(oscal_utils.list_to_oscal(paged_documents)))
 
-        res = [doc.todict() for doc in documents]
-        return jsonify(res)
+        res = [doc.todict() for doc in paged_documents]
+        return jsonify({"data": res, "page": page, "total_pages": total_pages})
     else:
         abort(404, "No object matches the given search terms")
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -451,6 +451,18 @@ paths:
         style: form
         explode: true
         description: Tag name(s)
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+        description: 1-based page number for paginated results
+      - name: items_per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+        description: Number of items per page (capped server-side)
       responses:
         '200':
           description: Success
@@ -483,6 +495,18 @@ paths:
         schema:
           type: string
         description: Search query
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+        description: 1-based page number for paginated results
+      - name: items_per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+        description: Number of items per page (capped server-side)
       responses:
         '200':
           description: Success
@@ -929,6 +953,12 @@ components:
           items:
             type: object
             additionalProperties: {}
+        page:
+          type: integer
+          description: Current 1-based page (when pagination is applied)
+        total_pages:
+          type: integer
+          description: Total pages for the result set (when pagination is applied)
       additionalProperties: false
     MapAnalysisResponseSchema:
       type: object


### PR DESCRIPTION
**Summary**

- Adds pagination and response-format parity to /rest/v1/tags and /rest/v1/text_search so large result sets can be consumed safely and consistently.
- These endpoints previously returned full result sets in one response, which can become heavy for clients and backend resources. This change improves scalability and keeps behavior consistent across output formats.

**Changes**

1. Added pagination support (page, items_per_page) to:

- /rest/v1/tags
- /rest/v1/text_search

2. Introduced shared pagination helpers in the API layer.

3. Applied pagination consistently before rendering all supported formats:

- JSON
- Markdown
- CSV
- OSCAL

4. Added out-of-range page handling (404).

5. Enhanced /rest/v1/tags JSON response with pagination metadata:

- page
- total_pages

6. Updated OpenAPI docs to include new query parameters for both endpoints.

7. Added regression tests for:

- pagination behavior
- format parity across paged responses
- out-of-range requests

**Impact**

- Reduces payload size and improves response performance on large queries.
- Prevents client-side overfetching and timeout-prone calls.
- Makes paged results consistent regardless of selected output format.

**Validation**

- conda run -n opencre python -m unittest application.tests.web_main_test -v ✅
- conda run -n opencre python -m unittest application.tests.cwe_parser_test -v ✅