### PR TITLE
feat(api): add source query support for CRE integration metrics

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -27,6 +27,12 @@ paths:
           schema:
             type: string
             enum: [json, md, csv, oscal]
+        - name: source
+          in: query
+          required: false
+          description: Optional integration source identifier (for metrics), e.g. wstg
+          schema:
+            type: string
         - name: include_only
           in: query
           required: false
@@ -65,6 +71,12 @@ paths:
           schema:
             type: string
             enum: [json, md, csv, oscal]
+        - name: source
+          in: query
+          required: false
+          description: Optional integration source identifier (for metrics), e.g. wstg
+          schema:
+            type: string
       responses:
         '200':
           description: CRE found


### PR DESCRIPTION
## Related Issue
Closes #455

## Summary
This PR adds support for a `source` query argument on CRE lookups to improve standard integration metrics.

When external standards (for example WSTG) link to OpenCRE pages with `?source=<name>`, OpenCRE now preserves that source and includes it in CRE lookup analytics.

## Problem
Issue #455 requested support for integration source tracking.  
Before this fix, opening a CRE page with `?source=...` did not forward `source` to the backend CRE API call, so source-based metrics were lost.

## What This PR Changes
1. Backend (`/rest/v1/id/<creid>` and `/rest/v1/name/<crename>`)
- Accepts optional `source` query parameter.
- Normalizes source value for stable metrics aggregation.
- Includes normalized source in CRE lookup analytics event payload.

2. Frontend (`/cre/:id`)
- Reads `source` from page URL query params.
- Forwards `source` to backend request (`/rest/v1/id/:id`).

3. API documentation
- Adds optional `source` query parameter to:
  - `/rest/v1/id/{creid}`
  - `/rest/v1/name/{crename}`

## Before vs After (Verified)
### Before (production)
On production (`opencre.org`), opening `/cre/546-564?source=wstg` triggered:
- `/rest/v1/id/546-564`
- `source` query param was missing

### After (fixed branch, local)
On local fixed branch, opening `/cre/546-564?source=wstg` triggers:
- `/rest/v1/id/546-564?source=wstg`
- `source` is forwarded correctly

This proves:
1. Issue exists on current production/main.
2. Fix resolves the issue locally.

## How to Test
1. Production behavior (issue reproduction)
- Open: `https://www.opencre.org/cre/546-564?source=wstg`
- In browser DevTools → Network, inspect request to `/rest/v1/id/546-564`
- Confirm request URL does **not** include `source=wstg`

2. Local behavior (fix verification)
- Run backend (`:5000`) and frontend dev server (`:9001`)
- Open: `http://localhost:9001/cre/546-564?source=wstg`
- In DevTools → Network, inspect request to backend
- Confirm request URL includes `?source=wstg`

3. Automated checks
- `./venv/bin/pytest application/tests/web_main_test.py -q`
- `yarn build`

## Screenshots
- Before (production: source missing in API request):  
  <img width="1704" height="795" alt="image" src="https://github.com/user-attachments/assets/d9de0806-cb5d-4331-b84b-25082bdc3a11" />
- After (local: source forwarded in API request):  
  <img width="1702" height="801" alt="image" src="https://github.com/user-attachments/assets/17240bc8-f59d-4dd6-8a8c-6f2abdc545a4" />

## Backward Compatibility
- No breaking API change.
- `source` is optional.
- Existing clients without `source` continue to behave exactly as before.
