### PR TITLE
Fix(searchBar): icon layout fix

### DIFF
--- a/application/frontend/src/pages/Search/components/SearchBar.scss
+++ b/application/frontend/src/pages/Search/components/SearchBar.scss
@@ -16,8 +16,8 @@
   }
 
   .search-icon {
-    position: absolute;
-    left: 0.75rem;
+    position: relative;
+    left: 1rem;
     top: 50%;
     transform: translateY(-50%);
     color: var(--muted-foreground);

--- a/application/frontend/src/pages/Search/components/SearchBar.tsx
+++ b/application/frontend/src/pages/Search/components/SearchBar.tsx
@@ -41,6 +41,8 @@ export const SearchBar = () => {
           Search OpenCRE
         </label>
 
+        <div className="search-container flex items-center">
+
         <Search className="search-icon" aria-hidden="true" />
 
         <input
@@ -58,6 +60,7 @@ export const SearchBar = () => {
             })
           }
         />
+        </div>
       </form>
       {/* Error text */}
       {search.error && (


### PR DESCRIPTION
fixes #770

<img width="1440" height="900" alt="Screenshot 2026-03-01 at 1 41 49 AM" src="https://github.com/user-attachments/assets/af7280df-c19f-49fa-ab09-2b6df755f98f" />


icon layout is fixed no overlapping with the input box.
