### PR TITLE
Fix : resolve navbar alignment on desktop and mobile

### DIFF
--- a/application/frontend/src/pages/Search/components/SearchBar.scss
+++ b/application/frontend/src/pages/Search/components/SearchBar.scss
@@ -1,6 +1,5 @@
 .navbar__search {
   display: none;
-  align-items: center;
 
   @media (min-width: 1024px) {
     display: flex;
@@ -14,8 +13,6 @@
 
   form {
     position: relative;
-    display: flex;
-    align-items: center;
   }
 
   .search-icon {
@@ -41,8 +38,6 @@
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 1px 4px rgba(0, 0, 0, 0.25);
 
     transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-    line-height: normal;
-    height: 2.25rem;
   }
 
   input:hover {
@@ -63,4 +58,17 @@
     font-size: 0.75rem;
     color: #f87171; /* red-400 */
   }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }


### PR DESCRIPTION
**This PR address some recent UI regressions majorly revolving around the navbar** 
Before : 
<img width="1470" height="804" alt="image" src="https://github.com/user-attachments/assets/4d12b77c-f3e7-4238-8ce1-d74c96309101" />
After : 
<img width="2940" height="1608" alt="image" src="https://github.com/user-attachments/assets/ceb2e61d-3ac8-4df2-bbbc-4080a257ed08" />
(Clarification on this screenshot, this doesnt show the "MyOpenCRE" in the top navbar, my guess is due to my backend not running on localhost, but my changes don't touch anything besides search bar itself so I dont think it should affect that, pls feel free to correct me on this if I am wrong) 
Also in the process of fixing this, the searchbar issue on mobie seems to have changed : 
what I mentioned in #766  : 
<img width="753" height="1600" alt="image" src="https://github.com/user-attachments/assets/c40ac235-6a92-4c5f-9716-2a5dc34912f2" />

what the issue is at the time of fixing this: (there is a "Search OpenCRE in between the magnifying glass icon and search bar" and search bar itself is a bit chopped off)
<img width="811" height="1599" alt="image" src="https://github.com/user-attachments/assets/2622ce93-b0f0-4c95-ad8a-17c25e543f27" />

My fix : 
<img width="2940" height="1608" alt="image" src="https://github.com/user-attachments/assets/272290f3-fcf9-482e-bd6b-13861abc188d" />

closes  #766 