### PR TITLE
fix(search): hide scroll-to-next arrow when mobile navbar is open

### DIFF
--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -18,6 +18,18 @@ export const SearchPage = () => {
   const [search, setSearch] = useState({ term: '', error: '' });
 
   useEffect(() => {
+    const mobileMenu = document.querySelector('.navbar__mobile-menu');
+    const observer = new MutationObserver(() => {
+      if (mobileMenu?.classList.contains('is-open')){
+        setIsArrowVisible(false);
+      }else{
+        setIsArrowVisible(true);
+      }
+    });
+    if (mobileMenu){
+      observer.observe(mobileMenu, {attributes: true, attributeFilter: ['class']})
+    }
+
     const handleScroll = () => {
       const footer = document.getElementById('page-footer');
       if (footer) {
@@ -33,6 +45,7 @@ export const SearchPage = () => {
     window.addEventListener('scroll', handleScroll);
     return () => {
       window.removeEventListener('scroll', handleScroll);
+      observer.disconnect();
     };
   }, []);
 


### PR DESCRIPTION
### Summary

On mobile view, the scroll-to-next arrow remains visible when the navbar menu is open. Although functional, the arrow becomes redundant since the mobile menu covers most of the viewport.

This PR hides the scroll-to-next arrow while the mobile navbar menu is open to improve visual clarity and prevent overlapping UI elements.

Files changed : 
- `search.tsx`

### Testing : 
- mobile viewport (chrome devtools)

**Screen Recording below:**


https://github.com/user-attachments/assets/e9952b71-5012-4400-9950-b5dbaeeeb423

