### PR TITLE
fix(frontend): replace 'CREs' with 'Requirements' in user-facing text

### DIFF
--- a/application/frontend/src/const.ts
+++ b/application/frontend/src/const.ts
@@ -10,10 +10,10 @@ export const TYPE_AUTOLINKED_TO = 'Automatically linked to';
 export const DOCUMENT_TYPE_NAMES = {
   [TYPE_AUTOLINKED_TO]: ' has been automatically mapped to',
   [TYPE_LINKED_TO]: ' is linked to sources',
-  [TYPE_IS_PART_OF]: ' is part of CREs',
-  [TYPE_LINKED_FROM]: 'is linked from CREs',
-  [TYPE_CONTAINS]: ' contains CREs',
-  [TYPE_RELATED]: ' is related to CREs',
+  [TYPE_IS_PART_OF]: ' is part of Requirements',
+  [TYPE_LINKED_FROM]: 'is linked from Requirements',
+  [TYPE_CONTAINS]: ' contains Requirements',
+  [TYPE_RELATED]: ' is related to Requirements',
 };
 
 export const DOCUMENT_TYPES = {


### PR DESCRIPTION
Fixes #453

## Problem
New visitors to OpenCRE don't know what a "CRE" is, making the UI 
confusing for first-time users.

## Changes
Updated user-facing display strings in `application/frontend/src/const.ts`:
- "is part of CREs" → "is part of Requirements"
- "is linked from CREs" → "is linked from Requirements"  
- "contains CREs" → "contains Requirements"
- "is related to CREs" → "is related to Requirements"

Note: `bundle.js` is auto-generated and will update automatically on rebuild.
Please let me know if changes to `docs/implementation.md` or any other 
files are also required and I'll update the PR.