### PR TITLE
fix: redirect smartlink directly to CRE when only one is linked

### DIFF
--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -569,6 +569,7 @@ class TestMain(unittest.TestCase):
             collection.add_link(dcb, dasvs, ltype=defs.LinkTypes.LinkedTo)
             collection.add_link(dcd, dcwe, ltype=defs.LinkTypes.LinkedTo)
 
+            # Single CRE linked to CWE/456 — should redirect directly to the CRE
             response = client.get(
                 "/smartlink/standard/CWE/456",
                 headers={"Content-Type": "application/json"},
@@ -577,9 +578,10 @@ class TestMain(unittest.TestCase):
             for head in response.headers:
                 if head[0] == "Location":
                     location = head[1]
-            self.assertEqual(location, "/node/standard/CWE/sectionid/456")
+            self.assertEqual(location, "/cre/222-222")
             self.assertEqual(302, response.status_code)
 
+            # Single CRE linked to ASVS/v0.1.2 — should redirect directly to the CRE
             response = client.get(
                 "/smartlink/standard/ASVS/v0.1.2",
                 headers={"Content-Type": "application/json"},
@@ -588,7 +590,24 @@ class TestMain(unittest.TestCase):
             for head in response.headers:
                 if head[0] == "Location":
                     location = head[1]
-            self.assertEqual(location, "/node/standard/ASVS/section/v0.1.2")
+            self.assertEqual(location, "/cre/333-333")
+            self.assertEqual(302, response.status_code)
+
+            # Multiple CREs linked — should redirect to the node page, not a single CRE
+            multi_std = defs.Standard(name="MultiCRE", section="s1")
+            dmulti = collection.add_node(multi_std)
+            collection.add_link(dcd, dmulti, ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcb, dmulti, ltype=defs.LinkTypes.LinkedTo)
+
+            response = client.get(
+                "/smartlink/standard/MultiCRE/s1",
+                headers={"Content-Type": "application/json"},
+            )
+            location = ""
+            for head in response.headers:
+                if head[0] == "Location":
+                    location = head[1]
+            self.assertEqual(location, "/node/standard/MultiCRE/section/s1")
             self.assertEqual(302, response.status_code)
 
             # negative test, this cwe does not exist, therefore we redirect to Mitre!

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -580,6 +580,13 @@ def smartlink(
         )
         found_section_id = True
     if nodes and len(nodes[0].links):
+        if len(nodes[0].links) == 1:
+            cre_doc = nodes[0].links[0].document
+            logger.info(
+                f"found node of type {ntype}, name {name} and section {section}, "
+                f"single CRE linked, redirecting directly to CRE {cre_doc.id}"
+            )
+            return redirect(f"/cre/{cre_doc.id}")
         logger.info(
             f"found node of type {ntype}, name {name} and section {section}, redirecting to opencre"
         )


### PR DESCRIPTION
Fixes #486

## Problem

When a smartlinked standard (e.g., `/smartlink/standard/CWE/611`) resolves to only one connected CRE, the user is taken to an intermediate standard page that just shows the single CRE link. This adds an unnecessary click — the user has to click through to reach the CRE page they actually want.

## Changes

1. **`application/web/web_main.py`** — Modified the `smartlink()` function to check the number of linked CREs. When exactly one CRE is linked, it now redirects directly to `/cre/{id}` instead of the intermediate `/node/...` page. When multiple CREs are linked, the existing behavior is preserved.

2. **`application/tests/web_main_test.py`** — Updated existing test expectations for single-CRE cases (CWE/456 → `/cre/222-222`, ASVS/v0.1.2 → `/cre/333-333`) and added a new test case verifying that standards with multiple CRE links still redirect to the standard page.

## Testing

- Ran `test_smartlink` — all assertions pass
- Single CRE case: redirects to `/cre/{id}` ✅
- Multiple CRE case: redirects to `/node/standard/...` (unchanged) ✅
- Non-existent standard: redirects to external (e.g., Mitre) ✅
- Unknown standard: returns 404 ✅

## AI Disclosure

I used Claude AI to help plan my approach and explore the codebase structure. All implementation, testing, and debugging was done by me.