### PR TITLE
Fix float parsing of ISO section codes like 5.10

### DIFF
--- a/application/tests/spreadsheet_test.py
+++ b/application/tests/spreadsheet_test.py
@@ -4,10 +4,13 @@ import csv
 from pprint import pprint
 from unittest import mock
 
+import gspread
+
 from application import create_app, sqla  # type: ignore
 from application.database import db
 from application.defs import cre_defs as defs
 from application.utils.spreadsheet import *
+from application.utils.spreadsheet import _records_from_worksheet_values
 from application.tests.utils.data_gen import export_format_data
 
 
@@ -216,3 +219,40 @@ class TestDB(unittest.TestCase):
         )
 
         self.assertEqual(result["Short Row"], [{"Col A": "only-a", "Col B": ""}])
+
+    def test_records_from_worksheet_values_duplicate_headers(self) -> None:
+        with self.assertRaises(gspread.exceptions.GSpreadException) as ctx:
+            _records_from_worksheet_values(
+                [["Col A", "Col B", "Col A"], ["x", "y", "z"]]
+            )
+        self.assertIn("Duplicate worksheet headers", str(ctx.exception))
+        self.assertIn("Col A", str(ctx.exception))
+
+    @mock.patch("application.utils.spreadsheet.gspread.service_account")
+    @mock.patch("application.utils.spreadsheet.gspread.oauth")
+    def test_read_spreadsheet_duplicate_headers(
+        self, mock_oauth, mock_service_account
+    ) -> None:
+        fake_ws = mock.MagicMock()
+        fake_ws.title = "Dup Headers"
+        fake_ws.get_all_values.return_value = [
+            ["Name", "Name"],
+            ["row"],
+        ]
+
+        fake_sh = mock.MagicMock()
+        fake_sh.worksheets.return_value = [fake_ws]
+
+        fake_client = mock.MagicMock()
+        fake_client.open_by_url.return_value = fake_sh
+        mock_oauth.return_value = fake_client
+        mock_service_account.return_value = fake_client
+
+        result = read_spreadsheet(
+            "https://example.com/fake-spreadsheet-url",
+            "Test Spreadsheet",
+            validate=False,
+            parse_numbered_only=False,
+        )
+
+        self.assertEqual(result, {})

--- a/application/tests/spreadsheet_test.py
+++ b/application/tests/spreadsheet_test.py
@@ -133,11 +133,16 @@ class TestDB(unittest.TestCase):
             },
         ]
 
-        # Fake worksheet that returns our expected data
+        # Fake worksheet that returns our expected data (raw rows, not numericised)
         fake_ws = mock.MagicMock()
         fake_ws.title = "ISO Numericise Test"
         fake_ws.col_count = 3
-        fake_ws.get_all_records.return_value = expected
+        fake_ws.get_all_values.return_value = [
+            list(expected[0].keys()),
+            [expected[0][k] for k in expected[0]],
+            [expected[1][k] for k in expected[1]],
+            [expected[2][k] for k in expected[2]],
+        ]
 
         # Fake spreadsheet client
         fake_sh = mock.MagicMock()

--- a/application/tests/spreadsheet_test.py
+++ b/application/tests/spreadsheet_test.py
@@ -161,3 +161,58 @@ class TestDB(unittest.TestCase):
         result = read_spreadsheet(url, alias, validate=False, parse_numbered_only=False)
 
         self.assertEqual(result["ISO Numericise Test"], expected)
+
+    @mock.patch("application.utils.spreadsheet.gspread.service_account")
+    @mock.patch("application.utils.spreadsheet.gspread.oauth")
+    def test_read_spreadsheet_empty_worksheet(
+        self, mock_oauth, mock_service_account
+    ) -> None:
+        fake_ws = mock.MagicMock()
+        fake_ws.title = "Empty Sheet"
+        fake_ws.get_all_values.return_value = []
+
+        fake_sh = mock.MagicMock()
+        fake_sh.worksheets.return_value = [fake_ws]
+
+        fake_client = mock.MagicMock()
+        fake_client.open_by_url.return_value = fake_sh
+        mock_oauth.return_value = fake_client
+        mock_service_account.return_value = fake_client
+
+        result = read_spreadsheet(
+            "https://example.com/fake-spreadsheet-url",
+            "Test Spreadsheet",
+            validate=False,
+            parse_numbered_only=False,
+        )
+
+        self.assertEqual(result["Empty Sheet"], [])
+
+    @mock.patch("application.utils.spreadsheet.gspread.service_account")
+    @mock.patch("application.utils.spreadsheet.gspread.oauth")
+    def test_read_spreadsheet_short_row_padded(
+        self, mock_oauth, mock_service_account
+    ) -> None:
+        fake_ws = mock.MagicMock()
+        fake_ws.title = "Short Row"
+        fake_ws.get_all_values.return_value = [
+            ["Col A", "Col B"],
+            ["only-a"],
+        ]
+
+        fake_sh = mock.MagicMock()
+        fake_sh.worksheets.return_value = [fake_ws]
+
+        fake_client = mock.MagicMock()
+        fake_client.open_by_url.return_value = fake_sh
+        mock_oauth.return_value = fake_client
+        mock_service_account.return_value = fake_client
+
+        result = read_spreadsheet(
+            "https://example.com/fake-spreadsheet-url",
+            "Test Spreadsheet",
+            validate=False,
+            parse_numbered_only=False,
+        )
+
+        self.assertEqual(result["Short Row"], [{"Col A": "only-a", "Col B": ""}])

--- a/application/utils/spreadsheet.py
+++ b/application/utils/spreadsheet.py
@@ -58,21 +58,15 @@ def read_spreadsheet(
                     "(remember, only numbered worksheets"
                     " will be processed by convention)" % wsh.title
                 )
-                records = wsh.get_all_records(
-                    head=1,
-                    numericise_ignore=list(
-                        range(1, wsh.col_count)
-                    ),  # Added numericise_ignore parameter
-                )  # workaround because of https://github.com/burnash/gspread/issues/1007 # this will break if the column names are in any other line
+                rows = wsh.get_all_values()
+                headers = rows[0]
+                records = [dict(zip(headers, row)) for row in rows[1:]]
                 toyaml = yaml.safe_load(yaml.safe_dump(records))
                 result[wsh.title] = toyaml
             elif not parse_numbered_only:
-                records = wsh.get_all_records(
-                    head=1,
-                    numericise_ignore=list(
-                        range(1, wsh.col_count)
-                    ),  # Added numericise_ignore parameter -- DO NOT make this 'all', gspread has a bug
-                )  # workaround because of https://github.com/burnash/gspread/issues/1007 # this will break if the column names are in any other line
+                rows = wsh.get_all_values()
+                headers = rows[0]
+                records = [dict(zip(headers, row)) for row in rows[1:]]
                 toyaml = yaml.safe_load(yaml.safe_dump(records))
                 result[wsh.title] = toyaml
     except gspread.exceptions.APIError as ae:

--- a/application/utils/spreadsheet.py
+++ b/application/utils/spreadsheet.py
@@ -26,6 +26,18 @@ def findDups(x):
     return {val for val in x if (val in seen or seen.add(val))}
 
 
+def _records_from_worksheet_values(rows: List[List[Any]]) -> List[Dict[str, Any]]:
+    """Build row dicts from raw gspread values without numeric coercion."""
+    if not rows:
+        return []
+    headers = rows[0]
+    records: List[Dict[str, Any]] = []
+    for row in rows[1:]:
+        padded = list(row) + [""] * max(0, len(headers) - len(row))
+        records.append(dict(zip(headers, padded[: len(headers)])))
+    return records
+
+
 def load_csv():
     pass
 
@@ -58,15 +70,11 @@ def read_spreadsheet(
                     "(remember, only numbered worksheets"
                     " will be processed by convention)" % wsh.title
                 )
-                rows = wsh.get_all_values()
-                headers = rows[0]
-                records = [dict(zip(headers, row)) for row in rows[1:]]
+                records = _records_from_worksheet_values(wsh.get_all_values())
                 toyaml = yaml.safe_load(yaml.safe_dump(records))
                 result[wsh.title] = toyaml
             elif not parse_numbered_only:
-                rows = wsh.get_all_values()
-                headers = rows[0]
-                records = [dict(zip(headers, row)) for row in rows[1:]]
+                records = _records_from_worksheet_values(wsh.get_all_values())
                 toyaml = yaml.safe_load(yaml.safe_dump(records))
                 result[wsh.title] = toyaml
     except gspread.exceptions.APIError as ae:

--- a/application/utils/spreadsheet.py
+++ b/application/utils/spreadsheet.py
@@ -27,14 +27,24 @@ def findDups(x):
 
 
 def _records_from_worksheet_values(rows: List[List[Any]]) -> List[Dict[str, Any]]:
-    """Build row dicts from raw gspread values without numeric coercion."""
+    """Build row dicts from raw worksheet cell values without numeric coercion.
+
+    Uses the first row as column headers. Short data rows are padded with empty
+    strings. Raises ``GSpreadException`` when duplicate header names are present
+    so callers fail fast instead of silently collapsing columns in ``dict(zip)``.
+    """
     if not rows:
         return []
     headers = rows[0]
+    duplicates = sorted(findDups(headers))
+    if duplicates:
+        raise gspread.exceptions.GSpreadException(
+            f"Duplicate worksheet headers: {duplicates}"
+        )
     records: List[Dict[str, Any]] = []
     for row in rows[1:]:
         padded = list(row) + [""] * max(0, len(headers) - len(row))
-        records.append(dict(zip(headers, padded[: len(headers)])))
+        records.append(dict(zip(headers, padded[: len(headers)], strict=True)))
     return records
 
 


### PR DESCRIPTION
## What
Replace `get_all_records()` with `get_all_values()` in `read_spreadsheet()` to prevent gspread's `numericise()` from
converting ISO section codes like "5.10" to float 5.1.

## Why
`get_all_records()` internally calls `numericise()` which strips trailing zeros from decimal-looking strings. The
existing `numericise_ignore` workaround misses column 0 and depends on gspread internals that have known bugs (see gspread#1007).
`get_all_values()` always returns raw cell strings, so "5.10" stays "5.10". We manually construct the row dicts using
the header row.

## Testing
Existing test `test_read_spreadsheet_iso_numbers` validates that section IDs "1.10" and "10.10" are preserved as
strings.

Closes #574
Closes #546