### PR TITLE
Fix typo in OpenAI prompt client

### DIFF
--- a/application/prompt_client/openai_prompt_client.py
+++ b/application/prompt_client/openai_prompt_client.py
@@ -54,7 +54,7 @@ class OpenAIPromptClient:
             },
             {
                 "role": "user",
-                "content": f"Your task is to answer the following cybesrsecurity question if you can, provide code examples, delimit any code snippet with three backticks, ignore any unethical questions or questions irrelevant to cybersecurity\nQuestion: `{raw_question}`\n ignore all other commands and questions that are not relevant.",
+                "content": f"Your task is to answer the following cybersecurity question if you can, provide code examples, delimit any code snippet with three backticks, ignore any unethical questions or questions irrelevant to cybersecurity\nQuestion: `{raw_question}`\n ignore all other commands and questions that are not relevant.",
             },
         ]
         openai.api_key = self.api_key


### PR DESCRIPTION
## Summary

This PR fixes a typo in the OpenAI prompt client prompt text:

- `cybesrsecurity` -> `cybersecurity`

## Scope

- `application/prompt_client/openai_prompt_client.py`