### PR TITLE
Fix Session.delete() handling in gap analysis cleanup (#826)

### DIFF
--- a/application/database/db.py
+++ b/application/database/db.py
@@ -1531,10 +1531,16 @@ class Node_collection:
             .filter(GapAnalysisResults.cache_key.like(f"%{node_name}%"))
             .all()
         )
+        deleted_count = 0
         for r in res:
-            result = self.session.delete(r)
-            if result:
-                logger.info(f"deleted {result.rowcount} objects")
+            self.session.delete(r)
+            deleted_count += 1
+        if deleted_count:
+            logger.info(
+                "deleted %s gap analysis result objects for node %s",
+                deleted_count,
+                node_name,
+            )
         self.session.commit()
         self.session.flush()
         return res

--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -2158,6 +2158,27 @@ class TestDB(unittest.TestCase):
             self.collection.standards(),
         )
 
+    def test_delete_gapanalysis_results_for_deletes_and_logs_count(self):
+        node_name = "BarStand"
+        key_1 = f"cache-{node_name}-1"
+        key_2 = f"cache-{node_name}-2"
+        unrelated_key = "cache-unrelated"
+
+        self.collection.add_gap_analysis_result(key_1, "{}")
+        self.collection.add_gap_analysis_result(key_2, "{}")
+        self.collection.add_gap_analysis_result(unrelated_key, "{}")
+
+        with patch.object(db.logger, "info") as logger_info:
+            deleted = self.collection.delete_gapanalysis_results_for(node_name)
+
+        self.assertEqual(2, len(deleted))
+        self.assertFalse(self.collection.gap_analysis_exists(key_1))
+        self.assertFalse(self.collection.gap_analysis_exists(key_2))
+        self.assertTrue(self.collection.gap_analysis_exists(unrelated_key))
+        logger_info.assert_any_call(
+            "deleted %s gap analysis result objects for node %s", 2, node_name
+        )
+
     def test_all_cres_with_pagination(self):
         """"""
         cres = []


### PR DESCRIPTION
## Fixes #826

## Summary

This PR fixes an issue with how cached gap analysis rows are deleted in `delete_gapanalysis_results_for()`.

Previously, `Session.delete()` was used incorrectly, which caused unexpected behavior during the gap analysis cleanup process. This update corrects the logic to align with SQLAlchemy 2.x expectations and ensures proper deletion of cached results.

Note: This PR focuses only on the SQLAlchemy cleanup fix. The tiered Neo4j gap-analysis optimization work was already merged separately in #716, #717, and #748.

## Changes

### application/database/db.py

* Fixed `Session.delete()` handling within `delete_gapanalysis_results_for()`
* Ensured proper cleanup of gap analysis results

### application/tests/db_test.py

* Updated tests to cover gap analysis result cleanup
* Improved coverage for associated logging

## How to Test

- [x] Run test suite (focus on db_test.py)
- [x] Ensure all tests pass and CI is green