### PR TITLE
Collapse linked sources if more than 5 entries (fixes #283)

### DIFF
--- a/application/frontend/src/components/DocumentNode/DocumentNode.tsx
+++ b/application/frontend/src/components/DocumentNode/DocumentNode.tsx
@@ -149,7 +149,6 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({
               const sortedResults = [...links].sort((a, b) =>
                 getDocumentDisplayName(a.document).localeCompare(getDocumentDisplayName(b.document))
               );
-              let lastDocumentName = sortedResults[0].document.name;
               return (
                 <div className="document-node__link-type-container" key={`${type}-${idx}`}>
                   {idx > 0 && <hr style={{ borderColor: 'transparent', margin: '20px 0' }} />}
@@ -159,22 +158,17 @@ export const DocumentNode: FunctionComponent<DocumentNode> = ({
                   </div>
                   <div>
                     <div className="accordion ui fluid styled f0">
-                      {sortedResults.slice(0, showAll[idx] ? sortedResults.length : MAX_LENGTH_FOR_AUTO_EXPAND).map((link, i) => {
-                        const temp = (
-                          <div key={`document-node-container-${type}-${idx}-${i}`}>
-                            {lastDocumentName !== link.document.name && <span style={{ margin: '5px' }} />}
-                            <DocumentNode
-                              node={link.document}
-                              linkType={type}
-                              hasLinktypeRelatedParent={isNestedInRelated as boolean}
-                              key={`document-sub-node-${type}-${idx}-${i}`}
-                            />
-                            <FilterButton document={link.document} />
-                          </div>
-                        );
-                        lastDocumentName = link.document.name;
-                        return temp;
-                      })}
+                      {sortedResults.slice(0, showAll[idx] ? sortedResults.length : MAX_LENGTH_FOR_AUTO_EXPAND).map((link, i) => (
+                        <div key={`document-node-container-${type}-${idx}-${i}`} style={{ marginBottom: '4px' }}>
+                          <DocumentNode
+                            node={link.document}
+                            linkType={type}
+                            hasLinktypeRelatedParent={isNestedInRelated as boolean}
+                            key={`document-sub-node-${type}-${idx}-${i}`}
+                          />
+                          <FilterButton document={link.document} />
+                        </div>
+                      ))}
                     </div>
                     {sortedResults.length > MAX_LENGTH_FOR_AUTO_EXPAND && (
                       <button

--- a/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
+++ b/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
@@ -97,24 +97,18 @@ export const CommonRequirementEnumeration = () => {
                 const sortedResults = links.sort((a, b) =>
                   getDocumentDisplayName(a.document).localeCompare(getDocumentDisplayName(b.document))
                 );
-                let lastDocumentName = sortedResults[0].document.name;
                 return (
                   <div className="cre-page__links" key={type}>
                     <div className="cre-page__links-eader">
                       <b>Which {getDocumentTypeText(type, links[0].document.doctype)}</b>:
                       {/* Risk of mixed doctype in here causing odd output */}
                     </div>
-                    {sortedResults.slice(0, showAll[type] ? sortedResults.length : MAX_LENGTH_FOR_AUTO_EXPAND).map((link, i) => {
-                      const temp = (
-                        <div key={i} className="accordion ui fluid styled cre-page__links-container">
-                          {lastDocumentName !== link.document.name && <span style={{ margin: '5px' }} />}
-                          <DocumentNode node={link.document} linkType={type} />
-                          <FilterButton document={link.document} />
-                        </div>
-                      );
-                      lastDocumentName = link.document.name;
-                      return temp;
-                    })}
+                    {sortedResults.slice(0, showAll[type] ? sortedResults.length : MAX_LENGTH_FOR_AUTO_EXPAND).map((link, i) => (
+                      <div key={i} className="accordion ui fluid styled cre-page__links-container" style={{ marginBottom: '4px' }}>
+                        <DocumentNode node={link.document} linkType={type} />
+                        <FilterButton document={link.document} />
+                      </div>
+                    ))}
                     {sortedResults.length > MAX_LENGTH_FOR_AUTO_EXPAND && (
                       <button
                         onClick={() => setShowAll(prev => ({ ...prev, [type]: !prev[type] }))}


### PR DESCRIPTION
Fixes #283

**Description of Changes:**
Implemented a default collapse behavior for linked sources to avoid clutter when sections contain many entries, as requested in the issue. 

- Added logic to `CommonRequirementEnumeration.tsx` (top-level CRE page) and `DocumentNode.tsx` (nested sub-nodes) to show only 5 entries by default.
- Added a "Show more ▼" / "Show less ▲" toggle button that appears dynamically only if a section exceeds 5 entries.
- Used a configurable constant `MAX_LENGTH_FOR_AUTO_EXPAND` set to 5.
- Sections reset to collapsed state on page navigation to maintain the default-collapsed behavior.

**Testing:**
- Verified on local instance for CREs with many entries (e.g., `636-660`, `503-455`).
- Verified click expansion ("Show more") and contraction ("Show less") works independently for different sections.
- Verified that sections with 5 or fewer entries do not display the toggle button.

Bonus Fix: Removed legacy conditional margins from the lists and added consistent 4px padding so the spacing between all bullet points is uniform across sections.

***Screen Recording***
[showmore+spacing.zip](https://github.com/user-attachments/files/26297003/showmore%2Bspacing.zip)

***Screenshots***
<img width="1915" height="969" alt="image" src="https://github.com/user-attachments/assets/5c7ecc33-857b-4611-9167-1a2e60fe2180" />
<img width="1912" height="971" alt="Screenshot 2026-03-27 124357" src="https://github.com/user-attachments/assets/5983ff1b-cda4-4d22-a831-c6f790c2dd1b" />




