### PR TITLE
Fix variable shadowing crash in get_by_tags and code quality improvements

### DIFF
--- a/application/database/db.py
+++ b/application/database/db.py
@@ -1175,23 +1175,23 @@ class Node_collection:
             cre_where_clause.append(sqla.and_(CRE.tags.like("%{}%".format(tag))))
 
         nodes = Node.query.filter(*nodes_where_clause).all() or []
-        for node in nodes:
-            node = self.get_nodes(
-                name=node.name,
-                section=node.section,
-                subsection=node.subsection,
-                version=node.version,
-                link=node.link,
-                ntype=node.ntype,
-                sectionID=node.section_id,
+        for db_node in nodes:
+            resolved = self.get_nodes(
+                name=db_node.name,
+                section=db_node.section,
+                subsection=db_node.subsection,
+                version=db_node.version,
+                link=db_node.link,
+                ntype=db_node.ntype,
+                sectionID=db_node.section_id,
             )
-            if node:
-                documents.extend(node)
+            if resolved:
+                documents.extend(resolved)
             else:
                 logger.fatal(
-                    "db.get_node returned None for"
+                    "db.get_node returned None for "
                     "Node %s:%s:%s that exists, BUG!"
-                    % (node.name, node.section, node.section_id)
+                    % (db_node.name, db_node.section, db_node.section_id)
                 )
 
         cres = CRE.query.filter(*cre_where_clause).all() or []

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -1189,7 +1189,7 @@ class Node_collection:
                 documents.extend(resolved)
             else:
                 logger.fatal(
-                    "db.get_node returned None for "
+                    "get_nodes() returned no documents for "
                     "Node %s:%s:%s that exists, BUG!"
                     % (db_node.name, db_node.section, db_node.section_id)
                 )

--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -125,6 +125,26 @@ class TestDB(unittest.TestCase):
         self.assertEqual(self.collection.get_by_tags([]), [])
         self.assertEqual(self.collection.get_by_tags(["this should not be a tag"]), [])
 
+    @patch("application.database.db.logger")
+    def test_get_by_tags_empty_nodes_regression(self, mock_logger) -> None:
+        """
+        Simulate get_nodes returning an empty list to test the error path in get_by_tags.
+        See PR #837 regression fix.
+        """
+        dbstandard = db.Node(
+            section="regression_section",
+            name="regression_name",
+            tags="regression_tag",
+            ntype=defs.Standard.__name__,
+        )
+        self.collection.session.add(dbstandard)
+        self.collection.session.commit()
+
+        with patch.object(self.collection, "get_nodes", return_value=[]):
+            res = self.collection.get_by_tags(["regression_tag"])
+            self.assertEqual(res, [])
+            mock_logger.fatal.assert_called_once()
+
     def test_get_standards_names(self) -> None:
         result = self.collection.get_node_names()
         expected = [("Standard", "BarStand"), ("Standard", "Unlinked")]

--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -140,10 +140,24 @@ class TestDB(unittest.TestCase):
         self.collection.session.add(dbstandard)
         self.collection.session.commit()
 
-        with patch.object(self.collection, "get_nodes", return_value=[]):
+        with patch.object(self.collection, "get_nodes", return_value=[]) as mock_get_nodes:
             res = self.collection.get_by_tags(["regression_tag"])
             self.assertEqual(res, [])
-            mock_logger.fatal.assert_called_once()
+            
+            mock_get_nodes.assert_called_once_with(
+                name=dbstandard.name,
+                section=dbstandard.section,
+                subsection=dbstandard.subsection,
+                version=dbstandard.version,
+                link=dbstandard.link,
+                ntype=dbstandard.ntype,
+                sectionID=dbstandard.section_id,
+            )
+            
+            mock_logger.fatal.assert_called_once_with(
+                "db.get_node returned None for Node %s:%s:%s that exists, BUG!"
+                % (dbstandard.name, dbstandard.section, dbstandard.section_id)
+            )
 
     def test_get_standards_names(self) -> None:
         result = self.collection.get_node_names()

--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -140,10 +140,12 @@ class TestDB(unittest.TestCase):
         self.collection.session.add(dbstandard)
         self.collection.session.commit()
 
-        with patch.object(self.collection, "get_nodes", return_value=[]) as mock_get_nodes:
+        with patch.object(
+            self.collection, "get_nodes", return_value=[]
+        ) as mock_get_nodes:
             res = self.collection.get_by_tags(["regression_tag"])
             self.assertEqual(res, [])
-            
+
             mock_get_nodes.assert_called_once_with(
                 name=dbstandard.name,
                 section=dbstandard.section,
@@ -153,9 +155,9 @@ class TestDB(unittest.TestCase):
                 ntype=dbstandard.ntype,
                 sectionID=dbstandard.section_id,
             )
-            
+
             mock_logger.fatal.assert_called_once_with(
-                "db.get_node returned None for Node %s:%s:%s that exists, BUG!"
+                "get_nodes() returned no documents for Node %s:%s:%s that exists, BUG!"
                 % (dbstandard.name, dbstandard.section, dbstandard.section_id)
             )
 


### PR DESCRIPTION
## Summary
Fixes a crash bug and several code quality issues found during codebase review for GSoC 2026 Module B proposal.

Closes #836 
## Changes

### Bug Fix: Variable shadowing crash in get_by_tags() (application/database/db.py)
The loop variable node was overwritten by the return value of self.get_nodes(). When get_nodes() returned [] (empty list), the error handler tried to access node.name on the empty list, causing AttributeError. Renamed to db_node and resolved to preserve the original DB node reference for error logging.

### Code Quality Fixes
- Unreachable code in add_node() (db.py:1585): Removed dead return None after raise ValueError
- - Duplicate import (web_main.py:15,20): Removed redundant from application.utils import oscal_utils, redis
- - Variable typo (gap_analysis.py:44-46): Renamed pentalty to penalty
- - Variable typo (cre_main.py:280): Renamed pending_stadards to pending_standards (4 occurrences)
## Testing
- All changes are localized and do not alter behavior
- - The variable shadowing fix preserves the original node reference for correct error logging
- 