### PR TITLE
GSoC 2026: Add sample dataset for noise filtering (Module B)

### DIFF
--- a/dataset/sample_noise_filter.json
+++ b/dataset/sample_noise_filter.json
@@ -1,10 +1,14 @@
 [
     {
-        "message": "Fix use-after-free in SSL module",
-        "label": "Relevant"
+        "message": "gh-144833: Fix use-after-free in SSL module when SSL_new() fails (GH-144843)",
+        "label": "Relevant",
+        "score": 10,
+        "reason": "memory vulnerability, ssl/tls context, critical failure, high confidence"
     },
     {
-        "message": "Update documentation for SSL",
-        "label": "Noise"
+        "message": "gh-140795: Remove 'exc' field in SSLObject (gh-143491)",
+        "label": "Noise",
+        "score": 2,
+        "reason": "ssl/tls context, llm rejected"
     }
 ]

--- a/dataset/sample_noise_filter.json
+++ b/dataset/sample_noise_filter.json
@@ -1,0 +1,10 @@
+[
+    {
+        "message": "Fix use-after-free in SSL module",
+        "label": "Relevant"
+    },
+    {
+        "message": "Update documentation for SSL",
+        "label": "Noise"
+    }
+]


### PR DESCRIPTION
This PR adds a sample dataset for OpenCRE Module B (Noise/Relevance Filter).

It includes examples of:
- Security-relevant commits
- Noise commits

This helps demonstrate filtering logic and dataset structure.

Looking forward to feedback.