### PR TITLE
docs: add AI/ML development setup and knowledge graph overview to CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -226,3 +226,38 @@ Then in a separate terminal
 <pre>cd application/frontend</pre>
 and finally start the frontend in a debug session:
 <pre>yarn start</pre>
+
+## Setting Up for AI/ML Development
+
+If you are working on the AI mapping or RAG chatbot components:
+
+```bash
+pip install sentence-transformers
+pip install neo4j
+pip install openai
+```
+
+### Running the Mapping Pipeline Locally
+```bash
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=your_password
+python manage.py import_cre --help
+```
+### Running the Mapping Pipeline Locally
+```bash
+# Set environment variables
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=your_password
+
+# Run the CRE importer
+python manage.py import_cre --help
+```
+### Understanding the Knowledge Graph
+The OpenCRE graph consists of:
+- **CRE nodes**: Common Requirements Enumeration entries
+- **Standard nodes**: External standards (OWASP Top 10, NIST, CWE etc.)
+- **Links**: Relationships between CREs and standards (LINKED_TO, CONTAINS, RELATED)
+
+Use Neo4j Browser at http://localhost:7474 to explore the graph visually.


### PR DESCRIPTION
Description:
## What does this PR do?
Adds a new "Setting Up for AI/ML Development" section to CONTRIBUTING.md covering: additional Python dependencies for AI/embedding components, environment variable setup for Neo4j, how to run the CRE importer locally, and a brief explanation of the OpenCRE graph schema (CRE nodes, Standard nodes, Link types).

## Why?
While preparing my GSoC 2026 proposal for the AI-Driven Knowledge Graph Enhancement project, I found this information missing from the contributor guide. New contributors working on AI/embedding components have to piece this together from multiple files.

## Testing
Followed all steps on Ubuntu 22.04, Python 3.11. All commands verified working.