### PR TITLE
Add centralized structured logging, remove per-module basicConfig calls

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -8,6 +8,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_caching import Cache
 from flask_compress import Compress
 from application.config import config
+from application.utils.logging_config import configure_logging
 import os
 import random
 
@@ -26,6 +27,7 @@ cache = Cache()
 
 
 def create_app(mode: str = "production", conf: any = None) -> Any:
+    configure_logging()
     app = Flask(__name__)
     if not conf:
         app.config.from_object(config[mode])

--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -25,10 +25,10 @@ from application.utils import spreadsheet_parsers
 from alive_progress import alive_bar
 from application.prompt_client import prompt_client as prompt_client
 from application.utils import gap_analysis
+from application.utils.logging_config import configure_logging
 
-logging.basicConfig()
+configure_logging()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 app = None
 

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -47,9 +47,7 @@ from application.utils.gap_analysis import (
 
 from .. import sqla  # type: ignore
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 BaseModel: DefaultMeta = sqla.Model

--- a/application/database/inmemory_graph.py
+++ b/application/database/inmemory_graph.py
@@ -5,9 +5,7 @@ from typing import List, Tuple
 from application.defs import cre_defs as defs
 
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class CycleDetectedError(Exception):

--- a/application/defs/osib_defs.py
+++ b/application/defs/osib_defs.py
@@ -22,9 +22,7 @@ from dacite import (
     from_dict,
 )
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 # used for serialising and deserialising yaml OSIB documents

--- a/application/prompt_client/openai_prompt_client.py
+++ b/application/prompt_client/openai_prompt_client.py
@@ -1,9 +1,7 @@
 import openai
 import logging
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class OpenAIPromptClient:

--- a/application/prompt_client/prompt_client.py
+++ b/application/prompt_client/prompt_client.py
@@ -17,9 +17,7 @@ import os
 import re
 import requests
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 SIMILARITY_THRESHOLD = float(os.environ.get("CHATBOT_SIMILARITY_THRESHOLD", "0.7"))
 

--- a/application/prompt_client/vertex_prompt_client.py
+++ b/application/prompt_client/vertex_prompt_client.py
@@ -21,9 +21,7 @@ import grpc
 import grpc_status
 import time
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 MAX_OUTPUT_TOKENS = 1024
 

--- a/application/tests/logging_config_test.py
+++ b/application/tests/logging_config_test.py
@@ -1,0 +1,121 @@
+import json
+import logging
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from application.utils.logging_config import JSONFormatter, configure_logging
+
+
+class TestJSONFormatter(unittest.TestCase):
+    def _make_record(self, msg="hello", level=logging.INFO, name="test"):
+        record = logging.LogRecord(
+            name=name,
+            level=level,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+        return record
+
+    def test_output_is_valid_json(self):
+        formatter = JSONFormatter()
+        record = self._make_record()
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        self.assertIsInstance(parsed, dict)
+
+    def test_required_fields_present(self):
+        formatter = JSONFormatter()
+        record = self._make_record(msg="test message", name="mylogger")
+        parsed = json.loads(formatter.format(record))
+        self.assertIn("timestamp", parsed)
+        self.assertIn("level", parsed)
+        self.assertIn("logger", parsed)
+        self.assertIn("message", parsed)
+
+    def test_message_and_level_values(self):
+        formatter = JSONFormatter()
+        record = self._make_record(msg="check value", level=logging.WARNING, name="mod")
+        parsed = json.loads(formatter.format(record))
+        self.assertEqual(parsed["message"], "check value")
+        self.assertEqual(parsed["level"], "WARNING")
+        self.assertEqual(parsed["logger"], "mod")
+
+    def test_exception_included_when_present(self):
+        formatter = JSONFormatter()
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="error",
+            args=(),
+            exc_info=exc_info,
+        )
+        parsed = json.loads(formatter.format(record))
+        self.assertIn("exception", parsed)
+        self.assertIn("ValueError", parsed["exception"])
+
+
+class TestConfigureLogging(unittest.TestCase):
+    def setUp(self):
+        root = logging.getLogger()
+        root.handlers.clear()
+
+    def test_default_level_is_info(self):
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("LOG_LEVEL", None)
+            os.environ.pop("LOG_FORMAT", None)
+            configure_logging()
+        self.assertEqual(logging.getLogger().level, logging.INFO)
+
+    def test_log_level_env_respected(self):
+        with patch.dict("os.environ", {"LOG_LEVEL": "DEBUG"}):
+            configure_logging()
+        self.assertEqual(logging.getLogger().level, logging.DEBUG)
+
+    def test_text_format_uses_standard_formatter(self):
+        with patch.dict("os.environ", {"LOG_FORMAT": "text"}):
+            configure_logging()
+        root = logging.getLogger()
+        self.assertEqual(len(root.handlers), 1)
+        self.assertNotIsInstance(root.handlers[0].formatter, JSONFormatter)
+
+    def test_json_format_uses_json_formatter(self):
+        with patch.dict("os.environ", {"LOG_FORMAT": "json"}):
+            configure_logging()
+        root = logging.getLogger()
+        self.assertEqual(len(root.handlers), 1)
+        self.assertIsInstance(root.handlers[0].formatter, JSONFormatter)
+
+    def test_repeated_calls_do_not_add_handlers(self):
+        configure_logging()
+        configure_logging()
+        self.assertEqual(len(logging.getLogger().handlers), 1)
+
+    def test_json_output_is_parseable(self):
+        stream = StringIO()
+        with patch.dict("os.environ", {"LOG_FORMAT": "json"}):
+            configure_logging()
+        root = logging.getLogger()
+        root.handlers[0].stream = stream
+        logging.getLogger("test.json").info("structured message")
+        output = stream.getvalue().strip()
+        parsed = json.loads(output)
+        self.assertEqual(parsed["message"], "structured message")
+        self.assertEqual(parsed["level"], "INFO")
+
+
+import os
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/utils/external_project_parsers/base_parser.py
+++ b/application/utils/external_project_parsers/base_parser.py
@@ -9,9 +9,7 @@ from application.utils.external_project_parsers.parsers import *
 from application.utils import gap_analysis
 import os, json
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class BaseParser:

--- a/application/utils/external_project_parsers/parsers/capec_parser.py
+++ b/application/utils/external_project_parsers/parsers/capec_parser.py
@@ -7,9 +7,7 @@ from application.database import db
 from application.defs import cre_defs as defs
 import xmltodict
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 from application.utils.external_project_parsers.base_parser_defs import (
     ParserInterface,

--- a/application/utils/external_project_parsers/parsers/ccmv4.py
+++ b/application/utils/external_project_parsers/parsers/ccmv4.py
@@ -5,9 +5,7 @@ from application.defs import cre_defs as defs
 
 import re
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 from application.utils.external_project_parsers.base_parser_defs import (
     ParserInterface,

--- a/application/utils/external_project_parsers/parsers/cloud_native_security_controls.py
+++ b/application/utils/external_project_parsers/parsers/cloud_native_security_controls.py
@@ -10,9 +10,7 @@ from application.utils.external_project_parsers.base_parser_defs import (
 )
 import requests
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class CloudNativeSecurityControls(ParserInterface):

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -13,9 +13,7 @@ from application.utils.external_project_parsers.base_parser_defs import (
     ParseResult,
 )
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class CWE(ParserInterface):

--- a/application/utils/external_project_parsers/parsers/dsomm.py
+++ b/application/utils/external_project_parsers/parsers/dsomm.py
@@ -10,9 +10,7 @@ from application.utils.external_project_parsers.base_parser_defs import (
     ParseResult,
 )
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class DSOMM(ParserInterface):

--- a/application/utils/external_project_parsers/parsers/iso27001.py
+++ b/application/utils/external_project_parsers/parsers/iso27001.py
@@ -14,9 +14,7 @@ from application.utils.external_project_parsers.base_parser_defs import (
 )
 from typing import List
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 nist_id_re = re.compile("(?P<nist_id>\w\w\-\d+)")
 

--- a/application/utils/external_project_parsers/parsers/juiceshop.py
+++ b/application/utils/external_project_parsers/parsers/juiceshop.py
@@ -13,9 +13,7 @@ from application.utils.external_project_parsers.base_parser_defs import (
 )
 import requests
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class JuiceShop(ParserInterface):

--- a/application/utils/external_project_parsers/parsers/misc_tools_parser.py
+++ b/application/utils/external_project_parsers/parsers/misc_tools_parser.py
@@ -15,9 +15,7 @@ from application.utils.external_project_parsers.base_parser_defs import (
 )
 import requests
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class MiscTools(ParserInterface):

--- a/application/utils/external_project_parsers/parsers/pci_dss.py
+++ b/application/utils/external_project_parsers/parsers/pci_dss.py
@@ -12,9 +12,7 @@ from application.utils.external_project_parsers.base_parser_defs import (
     ParseResult,
 )
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class PciDss(ParserInterface):

--- a/application/utils/external_project_parsers/parsers/zap_alerts_parser.py
+++ b/application/utils/external_project_parsers/parsers/zap_alerts_parser.py
@@ -9,9 +9,7 @@ from application.database import db
 from application.defs import cre_defs as defs
 from application.utils import git
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 from application.prompt_client import prompt_client as prompt_client
 from application.utils.external_project_parsers.base_parser_defs import (

--- a/application/utils/gap_analysis.py
+++ b/application/utils/gap_analysis.py
@@ -9,9 +9,7 @@ from flask import json as flask_json
 import json
 from application.defs import cre_defs as defs
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 PENALTIES = {
     "RELATED": 2,

--- a/application/utils/git.py
+++ b/application/utils/git.py
@@ -10,8 +10,6 @@ from git.repo.base import Repo
 from github import Github
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logging.basicConfig()
 
 commit_msg_base = "cre_sync_%s" % (datetime.now().isoformat().replace(":", "."))
 

--- a/application/utils/logging_config.py
+++ b/application/utils/logging_config.py
@@ -1,0 +1,42 @@
+import json
+import logging
+import os
+
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_entry["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            log_entry["stack_info"] = self.formatStack(record.stack_info)
+        return json.dumps(log_entry)
+
+
+def configure_logging() -> None:
+    """Configure root logger from environment variables.
+
+    LOG_LEVEL: log level name (default INFO)
+    LOG_FORMAT: 'json' for structured JSON output, anything else for plain text
+    """
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    log_format = os.environ.get("LOG_FORMAT", "text").lower()
+
+    handler = logging.StreamHandler()
+    if log_format == "json":
+        handler.setFormatter(JSONFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        )
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers.clear()
+    root.addHandler(handler)

--- a/application/utils/redis.py
+++ b/application/utils/redis.py
@@ -6,9 +6,7 @@ from typing import Callable, List
 import rq
 import time
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def empty_queues(redis: redis.Redis):

--- a/application/utils/spreadsheet.py
+++ b/application/utils/spreadsheet.py
@@ -12,8 +12,6 @@ from application.defs import cre_defs as defs
 from enum import Enum
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logging.basicConfig()
 
 
 class GspreadAuth(Enum):

--- a/application/utils/spreadsheet_parsers.py
+++ b/application/utils/spreadsheet_parsers.py
@@ -12,8 +12,6 @@ from application.defs import cre_defs as defs
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logging.basicConfig()
 
 
 # the supported resources from the main CSV

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -57,9 +57,7 @@ app = Blueprint(
     ),
 )
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class SupportedFormats(Enum):

--- a/application/worker.py
+++ b/application/worker.py
@@ -1,10 +1,10 @@
 from rq import Worker, Queue
 import logging
 from application.utils import redis
+from application.utils.logging_config import configure_logging
 
-logging.basicConfig()
+configure_logging()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 listen = ["high", "default", "low"]
 


### PR DESCRIPTION
## Summary

Fixes #855

- Add `application/utils/logging_config.py` with a `configure_logging()` function and a `JSONFormatter` class
- `LOG_LEVEL` env var controls log level (default `INFO`)
- `LOG_FORMAT=json` switches to structured JSON output (one object per line), useful for log aggregation
- Remove `logging.basicConfig()` and `logger.setLevel(logging.INFO)` from all 25 affected modules
- Call `configure_logging()` from `create_app()`, `cre_main`, and `worker` so every runtime path is covered

No functional changes to application behaviour. Plain text format remains the default.

## Test plan

- [ ] 10 new tests in `application/tests/logging_config_test.py` covering `JSONFormatter` output, `configure_logging()` level and format selection, env var overrides, and idempotent handler setup
- [ ] All 10 pass: `python -m pytest application/tests/logging_config_test.py`
- [ ] No regressions: `python -m pytest application/tests/db_test.py application/tests/web_main_test.py`
- [ ] `LOG_FORMAT=json` produces valid JSON lines at runtime