### PR TITLE
fix: createPullRequest target branch handling

### DIFF
--- a/application/tests/git_utils_test.py
+++ b/application/tests/git_utils_test.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from application.utils.git import createPullRequest
+
+
+class TestGitUtils(unittest.TestCase):
+    @patch("application.utils.git.Github")
+    def test_create_pull_request_uses_target_branch(self, mocked_github) -> None:
+        github_client = MagicMock()
+        repo = MagicMock()
+        mocked_github.return_value = github_client
+        github_client.get_repo.return_value = repo
+
+        createPullRequest(
+            apiToken="token",
+            repo="OWASP/OpenCRE",
+            title="test-title",
+            srcBranch="feature-branch",
+            targetBranch="main",
+        )
+
+        mocked_github.assert_called_once_with("token")
+        github_client.get_repo.assert_called_once_with("OWASP/OpenCRE")
+        repo.create_pull.assert_called_once_with(
+            title="test-title",
+            body="CRE Sync test-title",
+            head="feature-branch",
+            base="main",
+        )
+
+    @patch("application.utils.git.Github")
+    def test_create_pull_request_defaults_to_master(self, mocked_github) -> None:
+        github_client = MagicMock()
+        repo = MagicMock()
+        mocked_github.return_value = github_client
+        github_client.get_repo.return_value = repo
+
+        createPullRequest(
+            apiToken="token",
+            repo="OWASP/OpenCRE",
+            title="default-target",
+            srcBranch="feature-branch",
+        )
+
+        repo.create_pull.assert_called_once_with(
+            title="default-target",
+            body="CRE Sync default-target",
+            head="feature-branch",
+            base="master",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/utils/git.py
+++ b/application/utils/git.py
@@ -61,12 +61,13 @@ def createPullRequest(
     apiToken: str, repo: str, title: str, srcBranch: str, targetBranch: str = "master"
 ) -> None:
     logger.info(
-        "Issuing pull request from %s to master for repo %s" % (srcBranch, repo)
+        "Issuing pull request from %s to %s for repo %s"
+        % (srcBranch, targetBranch, repo)
     )
     github = Github(apiToken)
     body = "CRE Sync %s" % title
-    pr = github.get_repo(repo).create_pull(
-        title=title, body=body, head=srcBranch, base="master"
+    github.get_repo(repo).create_pull(
+        title=title, body=body, head=srcBranch, base=targetBranch
     )
 
 


### PR DESCRIPTION
## Note
This is a small, scoped helper bugfix with targeted regression tests.  
Given the limited scope, no separate issue was opened to avoid extra triage overhead.

## Summary
This PR fixes base-branch selection in the GitHub PR helper.

`createPullRequest(...)` accepted a `targetBranch` argument, but the implementation always used `base="master"`.  
As a result, callers could not control the PR target branch.

## Issue
- `application/utils/git.py`
- `createPullRequest(...)` ignored the provided `targetBranch`
- Risk: PRs can be opened against the wrong base branch

## Scope
- Focused bug fix only
- No unrelated logic changes
- Backward-compatible default behavior remains unchanged

## Changes
- Updated `application/utils/git.py`:
  - `create_pull(..., base="master")` -> `create_pull(..., base=targetBranch)`
  - Log message updated to print the actual target branch
- Added regression tests in:
  - `application/tests/git_utils_test.py`

## Test File
- `application/tests/git_utils_test.py`

## Test Description
The new test file validates both explicit and default behavior:

1. `test_create_pull_request_uses_target_branch`
- Mocks GitHub client/repo
- Calls `createPullRequest(..., targetBranch="main")`
- Asserts `repo.create_pull(...)` is called with `base="main"`

2. `test_create_pull_request_defaults_to_master`
- Mocks GitHub client/repo
- Calls `createPullRequest(...)` without `targetBranch`
- Asserts `repo.create_pull(...)` is called with `base="master"`

## Validation
Ran:

`./venv/bin/python -m pytest application/tests/git_utils_test.py -q`

Result:
- `2 passed`
