### PR TITLE
fix: return 400 when text param is missing in text_search

### DIFF
--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -452,6 +452,12 @@ class TestMain(unittest.TestCase):
         collection.add_node(docs["sa"])
 
         with self.app.test_client() as client:
+            response = client.get("/rest/v1/text_search")
+            self.assertEqual(400, response.status_code)
+
+            response = client.get("/rest/v1/text_search?text=")
+            self.assertEqual(400, response.status_code)
+
             response = client.get(f"/rest/v1/text_search?text='CRE:2'")
             self.assertEqual(404, response.status_code)
 

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -559,6 +559,8 @@ def text_search() -> Any:
     """
     database = db.Node_collection()
     text = request.args.get("text")
+    if not text:
+        return jsonify({"error": "text parameter is required"}), 400
     if posthog:
         posthog.capture(f"text_search", f"text:{text}")
 


### PR DESCRIPTION
Closes #862

## Problem
GET /rest/v1/text_search without a text query parameter causes an
unhandled TypeError deep in re.search() because
request.args.get('text') returns None.

## Fix
Return a 400 with a descriptive error message before reaching the
database call. Also handles the empty string case (?text=).

## Tests
Added two cases to test_test_search:
- missing param: 400
- empty string: 400