### PR TITLE
Add refresh scripts for OWASP resources for issue 471

### DIFF
--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -909,6 +909,54 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
         BaseParser().register_resource(
             secure_headers.SecureHeaders, db_connection_str=args.cache_file
         )
+    if getattr(args, "owasp_top10_2025_in", False):
+        from application.utils.external_project_parsers.parsers import owasp_top10_2025
+
+        BaseParser().register_resource(
+            owasp_top10_2025.OwaspTop10_2025, db_connection_str=args.cache_file
+        )
+    if getattr(args, "owasp_api_top10_2023_in", False):
+        from application.utils.external_project_parsers.parsers import (
+            owasp_api_top10_2023,
+        )
+
+        BaseParser().register_resource(
+            owasp_api_top10_2023.OwaspApiTop10_2023,
+            db_connection_str=args.cache_file,
+        )
+    if getattr(args, "owasp_kubernetes_top10_2022_in", False):
+        from application.utils.external_project_parsers.parsers import (
+            owasp_kubernetes_top10_2022,
+        )
+
+        BaseParser().register_resource(
+            owasp_kubernetes_top10_2022.OwaspKubernetesTop10_2022,
+            db_connection_str=args.cache_file,
+        )
+    if getattr(args, "owasp_kubernetes_top10_2025_in", False):
+        from application.utils.external_project_parsers.parsers import (
+            owasp_kubernetes_top10_2025,
+        )
+
+        BaseParser().register_resource(
+            owasp_kubernetes_top10_2025.OwaspKubernetesTop10_2025,
+            db_connection_str=args.cache_file,
+        )
+    if getattr(args, "owasp_llm_top10_2025_in", False):
+        from application.utils.external_project_parsers.parsers import (
+            owasp_llm_top10_2025,
+        )
+
+        BaseParser().register_resource(
+            owasp_llm_top10_2025.OwaspLlmTop10_2025,
+            db_connection_str=args.cache_file,
+        )
+    if getattr(args, "owasp_aisvs_in", False):
+        from application.utils.external_project_parsers.parsers import owasp_aisvs
+
+        BaseParser().register_resource(
+            owasp_aisvs.OwaspAisvs, db_connection_str=args.cache_file
+        )
     if args.pci_dss_4_in:
         from application.utils.external_project_parsers.parsers import pci_dss
 

--- a/application/tests/cheatsheets_parser_test.py
+++ b/application/tests/cheatsheets_parser_test.py
@@ -34,7 +34,13 @@ class TestCheatsheetsParser(unittest.TestCase):
         repo.working_dir = loc
         cre = defs.CRE(name="blah", id="223-780")
         self.collection.add_cre(cre)
-        with open(os.path.join(os.path.join(loc, "cheatsheets"), "cs.md"), "w") as mdf:
+        with open(
+            os.path.join(
+                os.path.join(loc, "cheatsheets"),
+                "Secrets_Management_Cheat_Sheet.md",
+            ),
+            "w",
+        ) as mdf:
             mdf.write(cs)
         mock_clone.return_value = repo
         entries = cheatsheets_parser.Cheatsheets().parse(
@@ -45,22 +51,26 @@ class TestCheatsheetsParser(unittest.TestCase):
         # verify the external tagging convention, not just enum wiring.
         expected = defs.Standard(
             name="OWASP Cheat Sheets",
-            hyperlink="https://github.com/foo/bar/tree/master/cs.md",
+            hyperlink="https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
             section="Secrets Management Cheat Sheet",
-            links=[defs.Link(document=cre, ltype=defs.LinkTypes.LinkedTo)],
+            links=[
+                defs.Link(
+                    document=cre, ltype=defs.LinkTypes.AutomaticallyLinkedTo
+                )
+            ],
             tags=[
                 "family:guidance",
                 "subtype:cheatsheet",
-                "source:owasp_cheatsheets",
                 "audience:developer",
                 "maturity:stable",
+                "source:owasp_cheatsheets",
             ],
         )
         self.maxDiff = None
         for name, nodes in entries.results.items():
             self.assertEqual(name, parser.name)
             self.assertEqual(len(nodes), 1)
-            self.assertCountEqual(expected.todict(), nodes[0].todict())
+            self.assertEqual(expected.todict(), nodes[0].todict())
 
     cheatsheets_md = """ # Secrets Management Cheat Sheet
 

--- a/application/tests/cheatsheets_parser_test.py
+++ b/application/tests/cheatsheets_parser_test.py
@@ -53,11 +53,7 @@ class TestCheatsheetsParser(unittest.TestCase):
             name="OWASP Cheat Sheets",
             hyperlink="https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
             section="Secrets Management Cheat Sheet",
-            links=[
-                defs.Link(
-                    document=cre, ltype=defs.LinkTypes.AutomaticallyLinkedTo
-                )
-            ],
+            links=[defs.Link(document=cre, ltype=defs.LinkTypes.AutomaticallyLinkedTo)],
             tags=[
                 "family:guidance",
                 "subtype:cheatsheet",

--- a/application/tests/cheatsheets_parser_test.py
+++ b/application/tests/cheatsheets_parser_test.py
@@ -69,8 +69,37 @@ class TestCheatsheetsParser(unittest.TestCase):
         self.maxDiff = None
         for name, nodes in entries.results.items():
             self.assertEqual(name, parser.name)
-            self.assertEqual(len(nodes), 1)
-            self.assertEqual(expected.todict(), nodes[0].todict())
+            sections = {node.section for node in nodes}
+            self.assertIn("Secrets Management Cheat Sheet", sections)
+            secret_entry = [
+                node
+                for node in nodes
+                if node.section == "Secrets Management Cheat Sheet"
+            ][0]
+            self.assertEqual(expected.todict(), secret_entry.todict())
+
+    def test_register_supplemental_cheatsheets(self) -> None:
+        for cre_id, name in [
+            ("118-110", "API/web services"),
+            ("724-770", "Technical application access control"),
+            ("623-550", "Denial Of Service protection"),
+        ]:
+            self.collection.add_cre(defs.CRE(name=name, id=cre_id))
+
+        entries = cheatsheets_parser.Cheatsheets().register_supplemental_cheatsheets(
+            cache=self.collection
+        )
+        rest = [
+            entry for entry in entries if entry.section == "REST Security Cheat Sheet"
+        ][0]
+        self.assertEqual(
+            "https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html",
+            rest.hyperlink,
+        )
+        self.assertEqual(
+            ["118-110", "724-770", "623-550"],
+            [link.document.id for link in rest.links],
+        )
 
     cheatsheets_md = """ # Secrets Management Cheat Sheet
 

--- a/application/tests/cheatsheets_parser_test.py
+++ b/application/tests/cheatsheets_parser_test.py
@@ -59,8 +59,37 @@ class TestCheatsheetsParser(unittest.TestCase):
         self.maxDiff = None
         for name, nodes in entries.results.items():
             self.assertEqual(name, cheatsheets_parser.Cheatsheets().name)
-            self.assertEqual(len(nodes), 1)
-            self.assertEqual(expected.todict(), nodes[0].todict())
+            sections = {node.section for node in nodes}
+            self.assertIn("Secrets Management Cheat Sheet", sections)
+            secret_entry = [
+                node
+                for node in nodes
+                if node.section == "Secrets Management Cheat Sheet"
+            ][0]
+            self.assertEqual(expected.todict(), secret_entry.todict())
+
+    def test_register_supplemental_cheatsheets(self) -> None:
+        for cre_id, name in [
+            ("118-110", "API/web services"),
+            ("724-770", "Technical application access control"),
+            ("623-550", "Denial Of Service protection"),
+        ]:
+            self.collection.add_cre(defs.CRE(name=name, id=cre_id))
+
+        entries = cheatsheets_parser.Cheatsheets().register_supplemental_cheatsheets(
+            cache=self.collection
+        )
+        rest = [
+            entry for entry in entries if entry.section == "REST Security Cheat Sheet"
+        ][0]
+        self.assertEqual(
+            "https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html",
+            rest.hyperlink,
+        )
+        self.assertEqual(
+            ["118-110", "724-770", "623-550"],
+            [link.document.id for link in rest.links],
+        )
 
     cheatsheets_md = """ # Secrets Management Cheat Sheet
 

--- a/application/tests/cheatsheets_parser_test.py
+++ b/application/tests/cheatsheets_parser_test.py
@@ -34,7 +34,13 @@ class TestCheatsheetsParser(unittest.TestCase):
         repo.working_dir = loc
         cre = defs.CRE(name="blah", id="223-780")
         self.collection.add_cre(cre)
-        with open(os.path.join(os.path.join(loc, "cheatsheets"), "cs.md"), "w") as mdf:
+        with open(
+            os.path.join(
+                os.path.join(loc, "cheatsheets"),
+                "Secrets_Management_Cheat_Sheet.md",
+            ),
+            "w",
+        ) as mdf:
             mdf.write(cs)
         mock_clone.return_value = repo
         entries = cheatsheets_parser.Cheatsheets().parse(
@@ -42,15 +48,19 @@ class TestCheatsheetsParser(unittest.TestCase):
         )
         expected = defs.Standard(
             name="OWASP Cheat Sheets",
-            hyperlink="https://github.com/foo/bar/tree/master/cs.md",
+            hyperlink="https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
             section="Secrets Management Cheat Sheet",
-            links=[defs.Link(document=cre, ltype=defs.LinkTypes.LinkedTo)],
+            links=[
+                defs.Link(
+                    document=cre, ltype=defs.LinkTypes.AutomaticallyLinkedTo
+                )
+            ],
         )
         self.maxDiff = None
         for name, nodes in entries.results.items():
             self.assertEqual(name, cheatsheets_parser.Cheatsheets().name)
             self.assertEqual(len(nodes), 1)
-            self.assertCountEqual(expected.todict(), nodes[0].todict())
+            self.assertEqual(expected.todict(), nodes[0].todict())
 
     cheatsheets_md = """ # Secrets Management Cheat Sheet
 

--- a/application/tests/owasp_aisvs_parser_test.py
+++ b/application/tests/owasp_aisvs_parser_test.py
@@ -1,0 +1,62 @@
+import unittest
+
+from application import create_app, sqla  # type: ignore
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.parsers import owasp_aisvs
+
+
+class TestOwaspAisvsParser(unittest.TestCase):
+    def tearDown(self) -> None:
+        sqla.session.remove()
+        sqla.drop_all()
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        sqla.create_all()
+        self.collection = db.Node_collection()
+
+    def test_parse(self) -> None:
+        for cre_id, name in [
+            ("227-045", "Identify sensitive data and subject it to a policy"),
+            (
+                "307-507",
+                "Allow only trusted sources both build time and runtime; therefore perform integrity checks on all resources and code",
+            ),
+            (
+                "162-655",
+                "Documentation of all components' business or security function",
+            ),
+        ]:
+            self.collection.add_cre(defs.CRE(id=cre_id, name=name, description=""))
+
+        result = owasp_aisvs.OwaspAisvs().parse(
+            self.collection, prompt_client.PromptHandler(database=self.collection)
+        )
+
+        entries = result.results["OWASP AI Security Verification Standard (AISVS)"]
+        self.assertEqual(14, len(entries))
+        self.assertEqual("AISVS1", entries[0].sectionID)
+        self.assertEqual(
+            "Training Data Governance & Bias Management", entries[0].section
+        )
+        self.assertEqual(
+            "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C01-Training-Data-Governance.md",
+            entries[0].hyperlink,
+        )
+        self.assertEqual(
+            ["227-045", "307-507"], [l.document.id for l in entries[0].links]
+        )
+        self.assertEqual("AISVS14", entries[-1].sectionID)
+        self.assertEqual(
+            "Human Oversight, Accountability & Governance", entries[-1].section
+        )
+        self.assertEqual(
+            "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C14-Human-Oversight.md",
+            entries[-1].hyperlink,
+        )
+        self.assertEqual(["162-655"], [l.document.id for l in entries[-1].links])

--- a/application/tests/owasp_aisvs_parser_test.py
+++ b/application/tests/owasp_aisvs_parser_test.py
@@ -45,18 +45,22 @@ class TestOwaspAisvsParser(unittest.TestCase):
             "Training Data Governance & Bias Management", entries[0].section
         )
         self.assertEqual(
-            "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C01-Training-Data-Governance.md",
+            "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md",
             entries[0].hyperlink,
         )
         self.assertEqual(
-            ["227-045", "307-507"], [l.document.id for l in entries[0].links]
+            ["227-045", "307-507"],
+            [link.document.id for link in entries[0].links],
         )
         self.assertEqual("AISVS14", entries[-1].sectionID)
         self.assertEqual(
             "Human Oversight, Accountability & Governance", entries[-1].section
         )
         self.assertEqual(
-            "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C14-Human-Oversight.md",
+            "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C14-Human-Oversight.md",
             entries[-1].hyperlink,
         )
-        self.assertEqual(["162-655"], [l.document.id for l in entries[-1].links])
+        self.assertEqual(
+            ["162-655"],
+            [link.document.id for link in entries[-1].links],
+        )

--- a/application/tests/owasp_api_top10_2023_parser_test.py
+++ b/application/tests/owasp_api_top10_2023_parser_test.py
@@ -1,0 +1,43 @@
+import unittest
+
+from application import create_app, sqla  # type: ignore
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.parsers import owasp_api_top10_2023
+
+
+class TestOwaspApiTop10_2023Parser(unittest.TestCase):
+    def tearDown(self) -> None:
+        sqla.session.remove()
+        sqla.drop_all()
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        sqla.create_all()
+        self.collection = db.Node_collection()
+
+    def test_parse(self) -> None:
+        for cre_id, name in [
+            ("304-667", "Protect API against unauthorized access/modification (IDOR)"),
+            ("724-770", "Technical application access control"),
+            ("715-223", "Ensure trusted origin of third party resources"),
+        ]:
+            self.collection.add_cre(defs.CRE(id=cre_id, name=name, description=""))
+
+        result = owasp_api_top10_2023.OwaspApiTop10_2023().parse(
+            self.collection, prompt_client.PromptHandler(database=self.collection)
+        )
+
+        entries = result.results["OWASP API Security Top 10 2023"]
+        self.assertEqual(10, len(entries))
+        self.assertEqual("API1", entries[0].sectionID)
+        self.assertEqual("Broken Object Level Authorization", entries[0].section)
+        self.assertEqual(
+            ["304-667", "724-770"], [l.document.id for l in entries[0].links]
+        )
+        self.assertEqual("API10", entries[-1].sectionID)
+        self.assertEqual(["715-223"], [l.document.id for l in entries[-1].links])

--- a/application/tests/owasp_api_top10_2023_parser_test.py
+++ b/application/tests/owasp_api_top10_2023_parser_test.py
@@ -37,7 +37,11 @@ class TestOwaspApiTop10_2023Parser(unittest.TestCase):
         self.assertEqual("API1", entries[0].sectionID)
         self.assertEqual("Broken Object Level Authorization", entries[0].section)
         self.assertEqual(
-            ["304-667", "724-770"], [l.document.id for l in entries[0].links]
+            ["304-667", "724-770"],
+            [link.document.id for link in entries[0].links],
         )
         self.assertEqual("API10", entries[-1].sectionID)
-        self.assertEqual(["715-223"], [l.document.id for l in entries[-1].links])
+        self.assertEqual(
+            ["715-223"],
+            [link.document.id for link in entries[-1].links],
+        )

--- a/application/tests/owasp_kubernetes_top10_2022_parser_test.py
+++ b/application/tests/owasp_kubernetes_top10_2022_parser_test.py
@@ -1,0 +1,45 @@
+import unittest
+
+from application import create_app, sqla  # type: ignore
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.parsers import (
+    owasp_kubernetes_top10_2022,
+)
+
+
+class TestOwaspKubernetesTop10_2022Parser(unittest.TestCase):
+    def tearDown(self) -> None:
+        sqla.session.remove()
+        sqla.drop_all()
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        sqla.create_all()
+        self.collection = db.Node_collection()
+
+    def test_parse(self) -> None:
+        for cre_id, name in [
+            ("233-748", "Configuration hardening"),
+            ("486-813", "Configuration"),
+            ("053-751", "Force build pipeline to check outdated/insecure components"),
+        ]:
+            self.collection.add_cre(defs.CRE(id=cre_id, name=name, description=""))
+
+        result = owasp_kubernetes_top10_2022.OwaspKubernetesTop10_2022().parse(
+            self.collection, prompt_client.PromptHandler(database=self.collection)
+        )
+
+        entries = result.results["OWASP Kubernetes Top Ten 2022"]
+        self.assertEqual(10, len(entries))
+        self.assertEqual("K01", entries[0].sectionID)
+        self.assertEqual("Insecure Workload Configurations", entries[0].section)
+        self.assertEqual(
+            ["233-748", "486-813"], [l.document.id for l in entries[0].links]
+        )
+        self.assertEqual("K10", entries[-1].sectionID)
+        self.assertEqual(["053-751"], [l.document.id for l in entries[-1].links])

--- a/application/tests/owasp_kubernetes_top10_2022_parser_test.py
+++ b/application/tests/owasp_kubernetes_top10_2022_parser_test.py
@@ -39,7 +39,18 @@ class TestOwaspKubernetesTop10_2022Parser(unittest.TestCase):
         self.assertEqual("K01", entries[0].sectionID)
         self.assertEqual("Insecure Workload Configurations", entries[0].section)
         self.assertEqual(
-            ["233-748", "486-813"], [l.document.id for l in entries[0].links]
+            ["233-748", "486-813"],
+            [link.document.id for link in entries[0].links],
+        )
+        # K09 intentionally shares the same configuration-focused CRE ids as K01
+        # in this dataset; K10 separately covers outdated/vulnerable components.
+        self.assertEqual("K09", entries[8].sectionID)
+        self.assertEqual(
+            ["233-748", "486-813"],
+            [link.document.id for link in entries[8].links],
         )
         self.assertEqual("K10", entries[-1].sectionID)
-        self.assertEqual(["053-751"], [l.document.id for l in entries[-1].links])
+        self.assertEqual(
+            ["053-751"],
+            [link.document.id for link in entries[-1].links],
+        )

--- a/application/tests/owasp_kubernetes_top10_2025_parser_test.py
+++ b/application/tests/owasp_kubernetes_top10_2025_parser_test.py
@@ -1,0 +1,102 @@
+import unittest
+import tempfile
+from pathlib import Path
+
+from application import create_app, sqla  # type: ignore
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.parsers import (
+    owasp_kubernetes_top10_2025,
+)
+
+
+class TestOwaspKubernetesTop10_2025Parser(unittest.TestCase):
+    def tearDown(self) -> None:
+        sqla.session.remove()
+        sqla.drop_all()
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        sqla.create_all()
+        self.collection = db.Node_collection()
+
+    def test_parse(self) -> None:
+        for cre_id, name in [
+            ("233-748", "Configuration hardening"),
+            ("486-813", "Configuration"),
+            ("148-420", "Log integrity"),
+            ("402-706", "Log relevant"),
+            ("843-841", "Log discretely"),
+        ]:
+            self.collection.add_cre(defs.CRE(id=cre_id, name=name, description=""))
+
+        result = owasp_kubernetes_top10_2025.OwaspKubernetesTop10_2025().parse(
+            self.collection, prompt_client.PromptHandler(database=self.collection)
+        )
+
+        entries = result.results["OWASP Kubernetes Top Ten 2025 (Draft)"]
+        self.assertEqual(10, len(entries))
+        self.assertEqual("K01", entries[0].sectionID)
+        self.assertEqual("Insecure Workload Configurations", entries[0].section)
+        self.assertEqual(
+            ["233-748", "486-813"], [l.document.id for l in entries[0].links]
+        )
+        self.assertEqual("K10", entries[-1].sectionID)
+        self.assertEqual(
+            ["148-420", "402-706", "843-841"],
+            [l.document.id for l in entries[-1].links],
+        )
+
+    def test_parse_falls_back_to_2022_mapping_when_2025_links_missing(self) -> None:
+        self.collection.add_cre(
+            defs.CRE(id="148-420", name="Log integrity", description="")
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            current_file = tmp_path / "k8s_2025.json"
+            fallback_file = tmp_path / "k8s_2022.json"
+            current_file.write_text(
+                """
+[
+  {
+    "section_id": "K10",
+    "section": "Inadequate Logging And Monitoring",
+    "hyperlink": "https://example.com/k10",
+    "cre_ids": ["999-999"],
+    "fallback_section_ids": ["K05"]
+  }
+]
+                """.strip(),
+                encoding="utf-8",
+            )
+            fallback_file.write_text(
+                """
+[
+  {
+    "section_id": "K05",
+    "section": "Inadequate Logging and Monitoring",
+    "hyperlink": "https://example.com/k05",
+    "cre_ids": ["148-420"]
+  }
+]
+                """.strip(),
+                encoding="utf-8",
+            )
+
+            parser = owasp_kubernetes_top10_2025.OwaspKubernetesTop10_2025()
+            parser.data_file = current_file
+            parser.fallback_data_file = fallback_file
+
+            result = parser.parse(
+                self.collection,
+                prompt_client.PromptHandler(database=self.collection),
+            )
+
+        entries = result.results["OWASP Kubernetes Top Ten 2025 (Draft)"]
+        self.assertEqual(1, len(entries))
+        self.assertEqual(["148-420"], [link.document.id for link in entries[0].links])

--- a/application/tests/owasp_kubernetes_top10_2025_parser_test.py
+++ b/application/tests/owasp_kubernetes_top10_2025_parser_test.py
@@ -43,12 +43,13 @@ class TestOwaspKubernetesTop10_2025Parser(unittest.TestCase):
         self.assertEqual("K01", entries[0].sectionID)
         self.assertEqual("Insecure Workload Configurations", entries[0].section)
         self.assertEqual(
-            ["233-748", "486-813"], [l.document.id for l in entries[0].links]
+            ["233-748", "486-813"],
+            [link.document.id for link in entries[0].links],
         )
         self.assertEqual("K10", entries[-1].sectionID)
         self.assertEqual(
             ["148-420", "402-706", "843-841"],
-            [l.document.id for l in entries[-1].links],
+            [link.document.id for link in entries[-1].links],
         )
 
     def test_parse_falls_back_to_2022_mapping_when_2025_links_missing(self) -> None:

--- a/application/tests/owasp_llm_top10_2025_parser_test.py
+++ b/application/tests/owasp_llm_top10_2025_parser_test.py
@@ -1,0 +1,45 @@
+import unittest
+
+from application import create_app, sqla  # type: ignore
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.parsers import owasp_llm_top10_2025
+
+
+class TestOwaspLlmTop10_2025Parser(unittest.TestCase):
+    def tearDown(self) -> None:
+        sqla.session.remove()
+        sqla.drop_all()
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        sqla.create_all()
+        self.collection = db.Node_collection()
+
+    def test_parse(self) -> None:
+        for cre_id, name in [
+            ("161-451", "Output encoding and injection prevention"),
+            ("064-808", "Encode output context-specifically"),
+            ("760-764", "Injection protection"),
+            ("623-550", "Denial Of Service protection"),
+        ]:
+            self.collection.add_cre(defs.CRE(id=cre_id, name=name, description=""))
+
+        result = owasp_llm_top10_2025.OwaspLlmTop10_2025().parse(
+            self.collection, prompt_client.PromptHandler(database=self.collection)
+        )
+
+        entries = result.results["OWASP Top 10 for LLM and Gen AI Apps 2025"]
+        self.assertEqual(10, len(entries))
+        self.assertEqual("LLM01", entries[0].sectionID)
+        self.assertEqual("Prompt Injection", entries[0].section)
+        self.assertEqual(
+            ["161-451", "760-764"], [l.document.id for l in entries[0].links]
+        )
+        self.assertEqual(["064-808"], [l.document.id for l in entries[4].links])
+        self.assertEqual("LLM10", entries[-1].sectionID)
+        self.assertEqual(["623-550"], [l.document.id for l in entries[-1].links])

--- a/application/tests/owasp_llm_top10_2025_parser_test.py
+++ b/application/tests/owasp_llm_top10_2025_parser_test.py
@@ -38,8 +38,12 @@ class TestOwaspLlmTop10_2025Parser(unittest.TestCase):
         self.assertEqual("LLM01", entries[0].sectionID)
         self.assertEqual("Prompt Injection", entries[0].section)
         self.assertEqual(
-            ["161-451", "760-764"], [l.document.id for l in entries[0].links]
+            ["161-451", "760-764"],
+            [link.document.id for link in entries[0].links],
         )
-        self.assertEqual(["064-808"], [l.document.id for l in entries[4].links])
+        self.assertEqual(["064-808"], [link.document.id for link in entries[4].links])
         self.assertEqual("LLM10", entries[-1].sectionID)
-        self.assertEqual(["623-550"], [l.document.id for l in entries[-1].links])
+        self.assertEqual(
+            ["623-550"],
+            [link.document.id for link in entries[-1].links],
+        )

--- a/application/tests/owasp_top10_2025_parser_test.py
+++ b/application/tests/owasp_top10_2025_parser_test.py
@@ -1,0 +1,80 @@
+import unittest
+
+from application import create_app, sqla  # type: ignore
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.parsers import owasp_top10_2025
+
+
+class TestOwaspTop10_2025Parser(unittest.TestCase):
+    def tearDown(self) -> None:
+        sqla.session.remove()
+        sqla.drop_all()
+        self.app_context.pop()
+
+    def setUp(self) -> None:
+        self.app = create_app(mode="test")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        sqla.create_all()
+        self.collection = db.Node_collection()
+
+    def test_parse(self) -> None:
+        self.collection.add_cre(
+            defs.CRE(id="177-260", name="Session management", description="")
+        )
+        self.collection.add_cre(
+            defs.CRE(
+                id="117-371",
+                name="Use a centralized access control mechanism",
+                description="",
+            )
+        )
+        self.collection.add_cre(
+            defs.CRE(
+                id="724-770",
+                name="Technical application access control",
+                description="",
+            )
+        )
+        self.collection.add_cre(
+            defs.CRE(
+                id="031-447", name="Whitelist all external (HTTP) input", description=""
+            )
+        )
+        self.collection.add_cre(
+            defs.CRE(
+                id="064-808", name="Encode output context-specifically", description=""
+            )
+        )
+        self.collection.add_cre(
+            defs.CRE(id="760-764", name="Injection protection", description="")
+        )
+        self.collection.add_cre(
+            defs.CRE(id="513-183", name="Error handling", description="")
+        )
+
+        result = owasp_top10_2025.OwaspTop10_2025().parse(
+            self.collection,
+            prompt_client.PromptHandler(database=self.collection),
+        )
+
+        entries = result.results["OWASP Top 10 2025"]
+        self.assertEqual(10, len(entries))
+        self.assertEqual("A01", entries[0].sectionID)
+        self.assertEqual("Broken Access Control", entries[0].section)
+        self.assertEqual(
+            "https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/",
+            entries[0].hyperlink,
+        )
+        self.assertEqual(
+            ["117-371", "177-260", "724-770"],
+            [link.document.id for link in entries[0].links],
+        )
+        self.assertEqual(
+            ["031-447", "064-808", "760-764"],
+            [link.document.id for link in entries[4].links],
+        )
+        self.assertEqual("A10", entries[-1].sectionID)
+        self.assertEqual(["513-183"], [link.document.id for link in entries[-1].links])

--- a/application/utils/external_project_parsers/data/owasp_aisvs_1_0.json
+++ b/application/utils/external_project_parsers/data/owasp_aisvs_1_0.json
@@ -1,0 +1,86 @@
+[
+  {
+    "section_id": "AISVS1",
+    "section": "Training Data Governance & Bias Management",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C01-Training-Data-Governance.md",
+    "cre_ids": ["227-045", "307-507"]
+  },
+  {
+    "section_id": "AISVS2",
+    "section": "User Input Validation",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C02-User-Input-Validation.md",
+    "cre_ids": ["031-447", "760-764"]
+  },
+  {
+    "section_id": "AISVS3",
+    "section": "Model Lifecycle Management & Change Control",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md",
+    "cre_ids": ["148-853", "613-285"]
+  },
+  {
+    "section_id": "AISVS4",
+    "section": "Infrastructure, Configuration & Deployment Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C04-Infrastructure.md",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section_id": "AISVS5",
+    "section": "Access Control & Identity for AI Components & Users",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C05-Access-Control-and-Identity.md",
+    "cre_ids": ["633-428", "724-770"]
+  },
+  {
+    "section_id": "AISVS6",
+    "section": "Supply Chain Security for Models, Frameworks & Data",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C06-Supply-Chain.md",
+    "cre_ids": ["613-285", "613-287", "863-521"]
+  },
+  {
+    "section_id": "AISVS7",
+    "section": "Model Behavior, Output Control & Safety Assurance",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C07-Model-Behavior.md",
+    "cre_ids": ["064-808", "141-555"]
+  },
+  {
+    "section_id": "AISVS8",
+    "section": "Memory, Embeddings & Vector Database Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md",
+    "cre_ids": ["126-668", "538-770"]
+  },
+  {
+    "section_id": "AISVS9",
+    "section": "Autonomous Orchestration & Agentic Action Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md",
+    "cre_ids": ["117-371", "650-560"]
+  },
+  {
+    "section_id": "AISVS10",
+    "section": "Model Context Protocol (MCP) Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C10-MCP-Security.md",
+    "cre_ids": ["307-507", "715-223"]
+  },
+  {
+    "section_id": "AISVS11",
+    "section": "Adversarial Robustness & Privacy Defense",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C11-Adversarial-Robustness.md",
+    "cre_ids": ["141-555", "623-550"]
+  },
+  {
+    "section_id": "AISVS12",
+    "section": "Privacy Protection & Personal Data Management",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C12-Privacy.md",
+    "cre_ids": ["126-668", "227-045", "482-866"]
+  },
+  {
+    "section_id": "AISVS13",
+    "section": "Monitoring, Logging & Anomaly Detection",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C13-Monitoring-and-Logging.md",
+    "cre_ids": ["058-083", "148-420", "402-706", "843-841"]
+  },
+  {
+    "section_id": "AISVS14",
+    "section": "Human Oversight, Accountability & Governance",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C14-Human-Oversight.md",
+    "cre_ids": ["162-655", "766-162"]
+  }
+]

--- a/application/utils/external_project_parsers/data/owasp_aisvs_1_0.json
+++ b/application/utils/external_project_parsers/data/owasp_aisvs_1_0.json
@@ -2,85 +2,85 @@
   {
     "section_id": "AISVS1",
     "section": "Training Data Governance & Bias Management",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C01-Training-Data-Governance.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md",
     "cre_ids": ["227-045", "307-507"]
   },
   {
     "section_id": "AISVS2",
     "section": "User Input Validation",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C02-User-Input-Validation.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C02-Input-Validation.md",
     "cre_ids": ["031-447", "760-764"]
   },
   {
     "section_id": "AISVS3",
     "section": "Model Lifecycle Management & Change Control",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md",
     "cre_ids": ["148-853", "613-285"]
   },
   {
     "section_id": "AISVS4",
     "section": "Infrastructure, Configuration & Deployment Security",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C04-Infrastructure.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C04-Infrastructure.md",
     "cre_ids": ["233-748", "486-813"]
   },
   {
     "section_id": "AISVS5",
     "section": "Access Control & Identity for AI Components & Users",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C05-Access-Control-and-Identity.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C05-Access-Control-and-Identity.md",
     "cre_ids": ["633-428", "724-770"]
   },
   {
     "section_id": "AISVS6",
     "section": "Supply Chain Security for Models, Frameworks & Data",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C06-Supply-Chain.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C06-Supply-Chain.md",
     "cre_ids": ["613-285", "613-287", "863-521"]
   },
   {
     "section_id": "AISVS7",
     "section": "Model Behavior, Output Control & Safety Assurance",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C07-Model-Behavior.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C07-Model-Behavior.md",
     "cre_ids": ["064-808", "141-555"]
   },
   {
     "section_id": "AISVS8",
     "section": "Memory, Embeddings & Vector Database Security",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md",
     "cre_ids": ["126-668", "538-770"]
   },
   {
     "section_id": "AISVS9",
     "section": "Autonomous Orchestration & Agentic Action Security",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md",
     "cre_ids": ["117-371", "650-560"]
   },
   {
     "section_id": "AISVS10",
     "section": "Model Context Protocol (MCP) Security",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C10-MCP-Security.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C10-MCP-Security.md",
     "cre_ids": ["307-507", "715-223"]
   },
   {
     "section_id": "AISVS11",
     "section": "Adversarial Robustness & Privacy Defense",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C11-Adversarial-Robustness.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C11-Adversarial-Robustness.md",
     "cre_ids": ["141-555", "623-550"]
   },
   {
     "section_id": "AISVS12",
     "section": "Privacy Protection & Personal Data Management",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C12-Privacy.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C12-Privacy.md",
     "cre_ids": ["126-668", "227-045", "482-866"]
   },
   {
     "section_id": "AISVS13",
     "section": "Monitoring, Logging & Anomaly Detection",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C13-Monitoring-and-Logging.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C13-Monitoring-and-Logging.md",
     "cre_ids": ["058-083", "148-420", "402-706", "843-841"]
   },
   {
     "section_id": "AISVS14",
     "section": "Human Oversight, Accountability & Governance",
-    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C14-Human-Oversight.md",
+    "hyperlink": "https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C14-Human-Oversight.md",
     "cre_ids": ["162-655", "766-162"]
   }
 ]

--- a/application/utils/external_project_parsers/data/owasp_api_top10_2023.json
+++ b/application/utils/external_project_parsers/data/owasp_api_top10_2023.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "API1",
+    "section": "Broken Object Level Authorization",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/",
+    "cre_ids": ["304-667", "724-770"]
+  },
+  {
+    "section_id": "API2",
+    "section": "Broken Authentication",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa2-broken-authentication/",
+    "cre_ids": ["177-260", "586-842", "633-428"]
+  },
+  {
+    "section_id": "API3",
+    "section": "Broken Object Property Level Authorization",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa3-broken-object-property-level-authorization/",
+    "cre_ids": ["538-770", "724-770", "128-128"]
+  },
+  {
+    "section_id": "API4",
+    "section": "Unrestricted Resource Consumption",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa4-unrestricted-resource-consumption/",
+    "cre_ids": ["623-550"]
+  },
+  {
+    "section_id": "API5",
+    "section": "Broken Function Level Authorization",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa5-broken-function-level-authorization/",
+    "cre_ids": ["650-560", "724-770"]
+  },
+  {
+    "section_id": "API6",
+    "section": "Unrestricted Access to Sensitive Business Flows",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa6-unrestricted-access-to-sensitive-business-flows/",
+    "cre_ids": ["534-605", "630-573"]
+  },
+  {
+    "section_id": "API7",
+    "section": "Server Side Request Forgery",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa7-server-side-request-forgery/",
+    "cre_ids": ["028-728", "657-084"]
+  },
+  {
+    "section_id": "API8",
+    "section": "Security Misconfiguration",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa8-security-misconfiguration/",
+    "cre_ids": ["486-813"]
+  },
+  {
+    "section_id": "API9",
+    "section": "Improper Inventory Management",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa9-improper-inventory-management/",
+    "cre_ids": ["162-655", "863-521"]
+  },
+  {
+    "section_id": "API10",
+    "section": "Unsafe Consumption of APIs",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xaa-unsafe-consumption-of-apis/",
+    "cre_ids": ["715-223"]
+  }
+]

--- a/application/utils/external_project_parsers/data/owasp_cheatsheets_supplement.json
+++ b/application/utils/external_project_parsers/data/owasp_cheatsheets_supplement.json
@@ -1,0 +1,47 @@
+[
+  {
+    "section": "Authorization Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html",
+    "cre_ids": ["128-128", "117-371"]
+  },
+  {
+    "section": "REST Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html",
+    "cre_ids": ["118-110", "724-770", "623-550"]
+  },
+  {
+    "section": "Server Side Request Forgery Prevention Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html",
+    "cre_ids": ["028-728", "657-084"]
+  },
+  {
+    "section": "Docker Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section": "Kubernetes Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html",
+    "cre_ids": ["467-784", "233-748", "486-813"]
+  },
+  {
+    "section": "Secure Cloud Architecture Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.html",
+    "cre_ids": ["155-155", "467-784"]
+  },
+  {
+    "section": "LLM Prompt Injection Prevention Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html",
+    "cre_ids": ["161-451", "760-764"]
+  },
+  {
+    "section": "AI Agent Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html",
+    "cre_ids": ["117-371", "650-560", "126-668"]
+  },
+  {
+    "section": "Secure AI Model Ops Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Secure_AI_Model_Ops_Cheat_Sheet.html",
+    "cre_ids": ["148-853", "613-285", "613-287"]
+  }
+]

--- a/application/utils/external_project_parsers/data/owasp_kubernetes_top10_2022.json
+++ b/application/utils/external_project_parsers/data/owasp_kubernetes_top10_2022.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "K01",
+    "section": "Insecure Workload Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K01-insecure-workload-configurations",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section_id": "K02",
+    "section": "Supply Chain Vulnerabilities",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K02-supply-chain-vulnerabilities",
+    "cre_ids": ["613-285", "613-287"]
+  },
+  {
+    "section_id": "K03",
+    "section": "Overly Permissive RBAC Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K03-overly-permissive-rbac-configurations",
+    "cre_ids": ["128-128", "724-770"]
+  },
+  {
+    "section_id": "K04",
+    "section": "Lack of Centralized Policy Enforcement",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K04-lack-of-centralized-policy-enforcement",
+    "cre_ids": ["117-371"]
+  },
+  {
+    "section_id": "K05",
+    "section": "Inadequate Logging and Monitoring",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K05-inadequate-logging-and-monitoring",
+    "cre_ids": ["058-083", "148-420", "402-706", "843-841"]
+  },
+  {
+    "section_id": "K06",
+    "section": "Broken Authentication Mechanisms",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K06-broken-authentication-mechanisms",
+    "cre_ids": ["177-260", "586-842", "633-428"]
+  },
+  {
+    "section_id": "K07",
+    "section": "Missing Network Segmentation Controls",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K07-missing-network-segmentation-controls",
+    "cre_ids": ["132-146", "467-784", "515-021"]
+  },
+  {
+    "section_id": "K08",
+    "section": "Secrets Management Failures",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K08-secrets-management-failures",
+    "cre_ids": ["340-375", "774-888", "813-610"]
+  },
+  {
+    "section_id": "K09",
+    "section": "Misconfigured Cluster Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K09-misconfigured-cluster-components",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section_id": "K10",
+    "section": "Outdated and Vulnerable Kubernetes Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K10-outdated-and-vulnerable-kubernetes-components",
+    "cre_ids": ["053-751", "715-334", "863-521"]
+  }
+]

--- a/application/utils/external_project_parsers/data/owasp_kubernetes_top10_2025.json
+++ b/application/utils/external_project_parsers/data/owasp_kubernetes_top10_2025.json
@@ -1,0 +1,72 @@
+[
+  {
+    "section_id": "K01",
+    "section": "Insecure Workload Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["233-748", "486-813"],
+    "fallback_section_ids": ["K01"]
+  },
+  {
+    "section_id": "K02",
+    "section": "Overly Permissive Authorization Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["128-128", "724-770"],
+    "fallback_section_ids": ["K03"]
+  },
+  {
+    "section_id": "K03",
+    "section": "Secrets Management Failures",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["340-375", "774-888", "813-610"],
+    "fallback_section_ids": ["K08"]
+  },
+  {
+    "section_id": "K04",
+    "section": "Lack Of Cluster Level Policy Enforcement",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["117-371"],
+    "fallback_section_ids": ["K04"]
+  },
+  {
+    "section_id": "K05",
+    "section": "Missing Network Segmentation Controls",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["132-146", "467-784", "515-021"],
+    "fallback_section_ids": ["K07"]
+  },
+  {
+    "section_id": "K06",
+    "section": "Overly Exposed Kubernetes Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["152-725", "640-364"],
+    "fallback_section_ids": ["K09"]
+  },
+  {
+    "section_id": "K07",
+    "section": "Misconfigured And Vulnerable Cluster Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["053-751", "233-748", "486-813", "715-334"],
+    "fallback_section_ids": ["K09", "K10"]
+  },
+  {
+    "section_id": "K08",
+    "section": "Cluster To Cloud Lateral Movement",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["132-146", "640-364", "724-770"],
+    "fallback_section_ids": ["K03", "K07"]
+  },
+  {
+    "section_id": "K09",
+    "section": "Broken Authentication Mechanisms",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["177-260", "586-842", "633-428"],
+    "fallback_section_ids": ["K06"]
+  },
+  {
+    "section_id": "K10",
+    "section": "Inadequate Logging And Monitoring",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["058-083", "148-420", "402-706", "843-841"],
+    "fallback_section_ids": ["K05"]
+  }
+]

--- a/application/utils/external_project_parsers/data/owasp_llm_top10_2025.json
+++ b/application/utils/external_project_parsers/data/owasp_llm_top10_2025.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "LLM01",
+    "section": "Prompt Injection",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm01-prompt-injection/",
+    "cre_ids": ["161-451", "760-764"]
+  },
+  {
+    "section_id": "LLM02",
+    "section": "Sensitive Information Disclosure",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/",
+    "cre_ids": ["126-668", "227-045"]
+  },
+  {
+    "section_id": "LLM03",
+    "section": "Supply Chain",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm032025-supply-chain/",
+    "cre_ids": ["613-285", "613-287"]
+  },
+  {
+    "section_id": "LLM04",
+    "section": "Data and Model Poisoning",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/",
+    "cre_ids": ["307-507", "613-287"]
+  },
+  {
+    "section_id": "LLM05",
+    "section": "Improper Output Handling",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/",
+    "cre_ids": ["064-808"]
+  },
+  {
+    "section_id": "LLM06",
+    "section": "Excessive Agency",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm062025-excessive-agency/",
+    "cre_ids": ["117-371", "650-560"]
+  },
+  {
+    "section_id": "LLM07",
+    "section": "System Prompt Leakage",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm072025-system-prompt-leakage/",
+    "cre_ids": ["126-668", "227-045"]
+  },
+  {
+    "section_id": "LLM08",
+    "section": "Vector and Embedding Weaknesses",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/",
+    "cre_ids": ["126-668", "538-770"]
+  },
+  {
+    "section_id": "LLM09",
+    "section": "Misinformation",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm092025-misinformation/",
+    "cre_ids": ["141-555"]
+  },
+  {
+    "section_id": "LLM10",
+    "section": "Unbounded Consumption",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/",
+    "cre_ids": ["267-031", "623-550"]
+  }
+]

--- a/application/utils/external_project_parsers/data/owasp_top10_2025.json
+++ b/application/utils/external_project_parsers/data/owasp_top10_2025.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "A01",
+    "section": "Broken Access Control",
+    "hyperlink": "https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/",
+    "cre_ids": ["117-371", "177-260", "724-770"]
+  },
+  {
+    "section_id": "A02",
+    "section": "Security Misconfiguration",
+    "hyperlink": "https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/",
+    "cre_ids": ["486-813"]
+  },
+  {
+    "section_id": "A03",
+    "section": "Software Supply Chain Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A03_2025-Software_Supply_Chain_Failures/",
+    "cre_ids": ["613-286", "613-287", "715-223", "863-521"]
+  },
+  {
+    "section_id": "A04",
+    "section": "Cryptographic Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/",
+    "cre_ids": ["170-772", "227-045"]
+  },
+  {
+    "section_id": "A05",
+    "section": "Injection",
+    "hyperlink": "https://owasp.org/Top10/2025/A05_2025-Injection/",
+    "cre_ids": ["031-447", "064-808", "760-764"]
+  },
+  {
+    "section_id": "A06",
+    "section": "Insecure Design",
+    "hyperlink": "https://owasp.org/Top10/2025/A06_2025-Insecure_Design/",
+    "cre_ids": ["126-668", "155-155"]
+  },
+  {
+    "section_id": "A07",
+    "section": "Authentication Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A07_2025-Authentication_Failures/",
+    "cre_ids": ["002-630", "177-260", "586-842", "633-428"]
+  },
+  {
+    "section_id": "A08",
+    "section": "Software or Data Integrity Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/",
+    "cre_ids": ["613-287", "836-068"]
+  },
+  {
+    "section_id": "A09",
+    "section": "Security Logging and Alerting Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A09_2025-Security_Logging_and_Alerting_Failures/",
+    "cre_ids": ["067-050", "148-420", "402-706", "843-841"]
+  },
+  {
+    "section_id": "A10",
+    "section": "Mishandling of Exceptional Conditions",
+    "hyperlink": "https://owasp.org/Top10/2025/A10_2025-Mishandling_of_Exceptional_Conditions/",
+    "cre_ids": ["513-183"]
+  }
+]

--- a/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
@@ -15,6 +15,7 @@ from application.prompt_client import prompt_client as prompt_client
 
 class Cheatsheets(ParserInterface):
     name = "OWASP Cheat Sheets"
+    cheatsheetseries_base_url = "https://cheatsheetseries.owasp.org/cheatsheets"
 
     def cheatsheet(
         self, section: str, hyperlink: str, tags: List[str]
@@ -32,6 +33,10 @@ class Cheatsheets(ParserInterface):
             ),
             hyperlink=hyperlink,
         )
+
+    def official_cheatsheet_url(self, markdown_filename: str) -> str:
+        html_name = os.path.splitext(markdown_filename)[0] + ".html"
+        return f"{self.cheatsheetseries_base_url}/{html_name}"
 
     def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
         c_repo = "https://github.com/OWASP/CheatSheetSeries.git"
@@ -65,7 +70,7 @@ class Cheatsheets(ParserInterface):
                     name = title.group("title")
                     cre_id = cre.group("cre")
                     cres = cache.get_CREs(external_id=cre_id)
-                    hyperlink = f"{repo_path.replace('.git','')}/tree/master/{cheatsheets_path}{mdfile}"
+                    hyperlink = self.official_cheatsheet_url(mdfile)
                     cs = self.cheatsheet(section=name, hyperlink=hyperlink, tags=[])
                     for cre in cres:
                         cs.add_link(

--- a/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
@@ -14,6 +14,7 @@ from application.prompt_client import prompt_client as prompt_client
 
 class Cheatsheets(ParserInterface):
     name = "OWASP Cheat Sheets"
+    cheatsheetseries_base_url = "https://cheatsheetseries.owasp.org/cheatsheets"
 
     def cheatsheet(
         self, section: str, hyperlink: str, tags: List[str]
@@ -24,6 +25,10 @@ class Cheatsheets(ParserInterface):
             tags=tags,
             hyperlink=hyperlink,
         )
+
+    def official_cheatsheet_url(self, markdown_filename: str) -> str:
+        html_name = os.path.splitext(markdown_filename)[0] + ".html"
+        return f"{self.cheatsheetseries_base_url}/{html_name}"
 
     def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
         c_repo = "https://github.com/OWASP/CheatSheetSeries.git"
@@ -55,7 +60,7 @@ class Cheatsheets(ParserInterface):
                     name = title.group("title")
                     cre_id = cre.group("cre")
                     cres = cache.get_CREs(external_id=cre_id)
-                    hyperlink = f"{repo_path.replace('.git','')}/tree/master/{cheatsheets_path}{mdfile}"
+                    hyperlink = self.official_cheatsheet_url(mdfile)
                     cs = self.cheatsheet(section=name, hyperlink=hyperlink, tags=[])
                     for cre in cres:
                         cs.add_link(

--- a/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
@@ -5,6 +5,9 @@ from application.utils import git
 from application.defs import cre_defs as defs
 import os
 import re
+import json
+from pathlib import Path
+import logging
 from application.utils.external_project_parsers.base_parser_defs import (
     ParserInterface,
     ParseResult,
@@ -15,6 +18,12 @@ from application.prompt_client import prompt_client as prompt_client
 class Cheatsheets(ParserInterface):
     name = "OWASP Cheat Sheets"
     cheatsheetseries_base_url = "https://cheatsheetseries.owasp.org/cheatsheets"
+    supplement_data_file = (
+        Path(__file__).resolve().parent.parent
+        / "data"
+        / "owasp_cheatsheets_supplement.json"
+    )
+    logger = logging.getLogger(__name__)
 
     def cheatsheet(
         self, section: str, hyperlink: str, tags: List[str]
@@ -33,10 +42,22 @@ class Cheatsheets(ParserInterface):
     def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
         c_repo = "https://github.com/OWASP/CheatSheetSeries.git"
         cheatsheets_path = "cheatsheets/"
-        repo = git.clone(c_repo)
-        cheatsheets = self.register_cheatsheets(
-            repo=repo, cache=cache, cheatsheets_path=cheatsheets_path, repo_path=c_repo
-        )
+        cheatsheets = []
+        try:
+            repo = git.clone(c_repo)
+            cheatsheets = self.register_cheatsheets(
+                repo=repo,
+                cache=cache,
+                cheatsheets_path=cheatsheets_path,
+                repo_path=c_repo,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Unable to clone OWASP CheatSheetSeries, continuing with supplemental cheat sheets only: %s",
+                exc,
+            )
+        cheatsheets.extend(self.register_supplemental_cheatsheets(cache=cache))
+        cheatsheets = self.deduplicate_entries(cheatsheets)
         return ParseResult(results={self.name: cheatsheets})
 
     def register_cheatsheets(
@@ -70,3 +91,36 @@ class Cheatsheets(ParserInterface):
                         )
                     standard_entries.append(cs)
         return standard_entries
+
+    def register_supplemental_cheatsheets(self, cache: db.Node_collection):
+        with self.supplement_data_file.open("r", encoding="utf-8") as handle:
+            supplement_entries = json.load(handle)
+
+        standard_entries = []
+        for entry in supplement_entries:
+            cs = self.cheatsheet(
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+                tags=[],
+            )
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                for cre in cres:
+                    try:
+                        cs.add_link(
+                            defs.Link(
+                                document=cre.shallow_copy(),
+                                ltype=defs.LinkTypes.AutomaticallyLinkedTo,
+                            )
+                        )
+                    except Exception:
+                        continue
+            if cs.links:
+                standard_entries.append(cs)
+        return standard_entries
+
+    def deduplicate_entries(self, entries: List[defs.Standard]) -> List[defs.Standard]:
+        deduped = {}
+        for entry in entries:
+            deduped[(entry.section, entry.hyperlink)] = entry
+        return list(deduped.values())

--- a/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
@@ -6,6 +6,9 @@ from application.defs import cre_defs as defs
 import os
 import re
 from application.utils.external_project_parsers import base_parser_defs
+import json
+from pathlib import Path
+import logging
 from application.utils.external_project_parsers.base_parser_defs import (
     ParserInterface,
     ParseResult,
@@ -16,6 +19,12 @@ from application.prompt_client import prompt_client as prompt_client
 class Cheatsheets(ParserInterface):
     name = "OWASP Cheat Sheets"
     cheatsheetseries_base_url = "https://cheatsheetseries.owasp.org/cheatsheets"
+    supplement_data_file = (
+        Path(__file__).resolve().parent.parent
+        / "data"
+        / "owasp_cheatsheets_supplement.json"
+    )
+    logger = logging.getLogger(__name__)
 
     def cheatsheet(
         self, section: str, hyperlink: str, tags: List[str]
@@ -41,10 +50,22 @@ class Cheatsheets(ParserInterface):
     def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
         c_repo = "https://github.com/OWASP/CheatSheetSeries.git"
         cheatsheets_path = "cheatsheets/"
-        repo = git.clone(c_repo, sparse_paths=["cheatsheets"], sparse_cone=True)
-        cheatsheets = self.register_cheatsheets(
-            repo=repo, cache=cache, cheatsheets_path=cheatsheets_path, repo_path=c_repo
-        )
+        cheatsheets = []
+        try:
+            repo = git.clone(c_repo, sparse_paths=["cheatsheets"], sparse_cone=True)
+            cheatsheets = self.register_cheatsheets(
+                repo=repo,
+                cache=cache,
+                cheatsheets_path=cheatsheets_path,
+                repo_path=c_repo,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Unable to clone OWASP CheatSheetSeries, continuing with supplemental cheat sheets only: %s",
+                exc,
+            )
+        cheatsheets.extend(self.register_supplemental_cheatsheets(cache=cache))
+        cheatsheets = self.deduplicate_entries(cheatsheets)
         results = {self.name: cheatsheets}
         base_parser_defs.validate_classification_tags(results)
         return ParseResult(results=results)
@@ -80,3 +101,36 @@ class Cheatsheets(ParserInterface):
                         )
                     standard_entries.append(cs)
         return standard_entries
+
+    def register_supplemental_cheatsheets(self, cache: db.Node_collection):
+        with self.supplement_data_file.open("r", encoding="utf-8") as handle:
+            supplement_entries = json.load(handle)
+
+        standard_entries = []
+        for entry in supplement_entries:
+            cs = self.cheatsheet(
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+                tags=[],
+            )
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                for cre in cres:
+                    try:
+                        cs.add_link(
+                            defs.Link(
+                                document=cre.shallow_copy(),
+                                ltype=defs.LinkTypes.AutomaticallyLinkedTo,
+                            )
+                        )
+                    except Exception:
+                        continue
+            if cs.links:
+                standard_entries.append(cs)
+        return standard_entries
+
+    def deduplicate_entries(self, entries: List[defs.Standard]) -> List[defs.Standard]:
+        deduped = {}
+        for entry in entries:
+            deduped[(entry.section, entry.hyperlink)] = entry
+        return list(deduped.values())

--- a/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
@@ -123,7 +123,14 @@ class Cheatsheets(ParserInterface):
                                 ltype=defs.LinkTypes.AutomaticallyLinkedTo,
                             )
                         )
-                    except Exception:
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to add supplemental cheatsheet link for cre_id=%s cre=%s section=%s: %s",
+                            cre_id,
+                            getattr(cre, "id", None),
+                            entry.get("section"),
+                            exc,
+                        )
                         continue
             if cs.links:
                 standard_entries.append(cs)

--- a/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
@@ -124,7 +124,7 @@ class Cheatsheets(ParserInterface):
                             )
                         )
                     except Exception as exc:
-                        logger.warning(
+                        self.logger.warning(
                             "Failed to add supplemental cheatsheet link for cre_id=%s cre=%s section=%s: %s",
                             cre_id,
                             getattr(cre, "id", None),

--- a/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheets_parser.py
@@ -51,19 +51,27 @@ class Cheatsheets(ParserInterface):
         c_repo = "https://github.com/OWASP/CheatSheetSeries.git"
         cheatsheets_path = "cheatsheets/"
         cheatsheets = []
+        repo = None
         try:
             repo = git.clone(c_repo, sparse_paths=["cheatsheets"], sparse_cone=True)
-            cheatsheets = self.register_cheatsheets(
-                repo=repo,
-                cache=cache,
-                cheatsheets_path=cheatsheets_path,
-                repo_path=c_repo,
-            )
         except Exception as exc:
             self.logger.warning(
                 "Unable to clone OWASP CheatSheetSeries, continuing with supplemental cheat sheets only: %s",
                 exc,
             )
+        else:
+            try:
+                cheatsheets = self.register_cheatsheets(
+                    repo=repo,
+                    cache=cache,
+                    cheatsheets_path=cheatsheets_path,
+                    repo_path=c_repo,
+                )
+            except Exception as exc:
+                self.logger.error(
+                    "Failed to register cheatsheets from cloned repo: %s",
+                    exc,
+                )
         cheatsheets.extend(self.register_supplemental_cheatsheets(cache=cache))
         cheatsheets = self.deduplicate_entries(cheatsheets)
         results = {self.name: cheatsheets}
@@ -139,5 +147,27 @@ class Cheatsheets(ParserInterface):
     def deduplicate_entries(self, entries: List[defs.Standard]) -> List[defs.Standard]:
         deduped = {}
         for entry in entries:
-            deduped[(entry.section, entry.hyperlink)] = entry
+            key = (entry.section, entry.hyperlink)
+            if key not in deduped:
+                deduped[key] = entry
+            else:
+                # merge links from duplicate into stored entry without duplicating links
+                stored = deduped[key]
+                existing_keys = set()
+                for l in getattr(stored, "links", []) or []:
+                    existing_keys.add(
+                        (getattr(l.document, "id", None), getattr(l, "ltype", None))
+                    )
+                for l in getattr(entry, "links", []) or []:
+                    lk = (getattr(l.document, "id", None), getattr(l, "ltype", None))
+                    if lk not in existing_keys:
+                        try:
+                            stored.add_link(l)
+                        except Exception:
+                            # fall back to appending if add_link is unavailable
+                            try:
+                                stored.links.append(l)
+                            except Exception:
+                                continue
+                        existing_keys.add(lk)
         return list(deduped.values())

--- a/application/utils/external_project_parsers/parsers/owasp_aisvs.py
+++ b/application/utils/external_project_parsers/parsers/owasp_aisvs.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.base_parser_defs import (
+    ParseResult,
+    ParserInterface,
+)
+
+
+class OwaspAisvs(ParserInterface):
+    name = "OWASP AI Security Verification Standard (AISVS)"
+    data_file = Path(__file__).resolve().parent.parent / "data" / "owasp_aisvs_1_0.json"
+
+    def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            raw_entries = json.load(handle)
+
+        entries = []
+        for entry in raw_entries:
+            standard = defs.Standard(
+                name=self.name,
+                sectionID=entry["section_id"],
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+            )
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                if not cres:
+                    continue
+                standard.add_link(
+                    defs.Link(
+                        ltype=defs.LinkTypes.LinkedTo,
+                        document=cres[0].shallow_copy(),
+                    )
+                )
+            entries.append(standard)
+
+        return ParseResult(
+            results={self.name: entries},
+            calculate_gap_analysis=False,
+            calculate_embeddings=False,
+        )

--- a/application/utils/external_project_parsers/parsers/owasp_api_top10_2023.py
+++ b/application/utils/external_project_parsers/parsers/owasp_api_top10_2023.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.base_parser_defs import (
+    ParseResult,
+    ParserInterface,
+)
+
+
+class OwaspApiTop10_2023(ParserInterface):
+    name = "OWASP API Security Top 10 2023"
+    data_file = (
+        Path(__file__).resolve().parent.parent / "data" / "owasp_api_top10_2023.json"
+    )
+
+    def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            raw_entries = json.load(handle)
+
+        entries = []
+        for entry in raw_entries:
+            standard = defs.Standard(
+                name=self.name,
+                sectionID=entry["section_id"],
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+            )
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                if not cres:
+                    continue
+                standard.add_link(
+                    defs.Link(
+                        ltype=defs.LinkTypes.LinkedTo,
+                        document=cres[0].shallow_copy(),
+                    )
+                )
+            entries.append(standard)
+
+        return ParseResult(
+            results={self.name: entries},
+            calculate_gap_analysis=False,
+            calculate_embeddings=False,
+        )

--- a/application/utils/external_project_parsers/parsers/owasp_kubernetes_top10_2022.py
+++ b/application/utils/external_project_parsers/parsers/owasp_kubernetes_top10_2022.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.base_parser_defs import (
+    ParseResult,
+    ParserInterface,
+)
+
+
+class OwaspKubernetesTop10_2022(ParserInterface):
+    name = "OWASP Kubernetes Top Ten 2022"
+    data_file = (
+        Path(__file__).resolve().parent.parent
+        / "data"
+        / "owasp_kubernetes_top10_2022.json"
+    )
+
+    def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            raw_entries = json.load(handle)
+
+        entries = []
+        for entry in raw_entries:
+            standard = defs.Standard(
+                name=self.name,
+                sectionID=entry["section_id"],
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+            )
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                if not cres:
+                    continue
+                standard.add_link(
+                    defs.Link(
+                        ltype=defs.LinkTypes.LinkedTo,
+                        document=cres[0].shallow_copy(),
+                    )
+                )
+            entries.append(standard)
+
+        return ParseResult(
+            results={self.name: entries},
+            calculate_gap_analysis=False,
+            calculate_embeddings=False,
+        )

--- a/application/utils/external_project_parsers/parsers/owasp_kubernetes_top10_2025.py
+++ b/application/utils/external_project_parsers/parsers/owasp_kubernetes_top10_2025.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.base_parser_defs import (
+    ParseResult,
+    ParserInterface,
+)
+
+
+class OwaspKubernetesTop10_2025(ParserInterface):
+    name = "OWASP Kubernetes Top Ten 2025 (Draft)"
+    data_file = (
+        Path(__file__).resolve().parent.parent
+        / "data"
+        / "owasp_kubernetes_top10_2025.json"
+    )
+    fallback_data_file = (
+        Path(__file__).resolve().parent.parent
+        / "data"
+        / "owasp_kubernetes_top10_2022.json"
+    )
+
+    def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            raw_entries = json.load(handle)
+        with self.fallback_data_file.open("r", encoding="utf-8") as handle:
+            fallback_entries = {
+                entry["section_id"]: entry for entry in json.load(handle)
+            }
+
+        entries = []
+        for entry in raw_entries:
+            standard = defs.Standard(
+                name=self.name,
+                sectionID=entry["section_id"],
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+            )
+            linked_cre_ids = []
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                if not cres:
+                    continue
+                linked_cre_ids.append(cre_id)
+                standard.add_link(
+                    defs.Link(
+                        ltype=defs.LinkTypes.LinkedTo,
+                        document=cres[0].shallow_copy(),
+                    )
+                )
+            if not linked_cre_ids:
+                for section_id in entry.get("fallback_section_ids", []):
+                    fallback_entry = fallback_entries.get(section_id)
+                    if not fallback_entry:
+                        continue
+                    for cre_id in fallback_entry.get("cre_ids", []):
+                        if cre_id in linked_cre_ids:
+                            continue
+                        cres = cache.get_CREs(external_id=cre_id)
+                        if not cres:
+                            continue
+                        linked_cre_ids.append(cre_id)
+                        standard.add_link(
+                            defs.Link(
+                                ltype=defs.LinkTypes.LinkedTo,
+                                document=cres[0].shallow_copy(),
+                            )
+                        )
+            entries.append(standard)
+
+        return ParseResult(
+            results={self.name: entries},
+            calculate_gap_analysis=False,
+            calculate_embeddings=False,
+        )

--- a/application/utils/external_project_parsers/parsers/owasp_llm_top10_2025.py
+++ b/application/utils/external_project_parsers/parsers/owasp_llm_top10_2025.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.base_parser_defs import (
+    ParseResult,
+    ParserInterface,
+)
+
+
+class OwaspLlmTop10_2025(ParserInterface):
+    name = "OWASP Top 10 for LLM and Gen AI Apps 2025"
+    data_file = (
+        Path(__file__).resolve().parent.parent / "data" / "owasp_llm_top10_2025.json"
+    )
+
+    def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            raw_entries = json.load(handle)
+
+        entries = []
+        for entry in raw_entries:
+            standard = defs.Standard(
+                name=self.name,
+                sectionID=entry["section_id"],
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+            )
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                if not cres:
+                    continue
+                standard.add_link(
+                    defs.Link(
+                        ltype=defs.LinkTypes.LinkedTo,
+                        document=cres[0].shallow_copy(),
+                    )
+                )
+            entries.append(standard)
+
+        return ParseResult(
+            results={self.name: entries},
+            calculate_gap_analysis=False,
+            calculate_embeddings=False,
+        )

--- a/application/utils/external_project_parsers/parsers/owasp_top10_2025.py
+++ b/application/utils/external_project_parsers/parsers/owasp_top10_2025.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from application.database import db
+from application.defs import cre_defs as defs
+from application.prompt_client import prompt_client
+from application.utils.external_project_parsers.base_parser_defs import (
+    ParseResult,
+    ParserInterface,
+)
+
+
+class OwaspTop10_2025(ParserInterface):
+    name = "OWASP Top 10 2025"
+    data_file = (
+        Path(__file__).resolve().parent.parent / "data" / "owasp_top10_2025.json"
+    )
+
+    def parse(self, cache: db.Node_collection, ph: prompt_client.PromptHandler):
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            raw_entries = json.load(handle)
+
+        entries = []
+        for entry in raw_entries:
+            standard = defs.Standard(
+                name=self.name,
+                sectionID=entry["section_id"],
+                section=entry["section"],
+                hyperlink=entry["hyperlink"],
+            )
+            for cre_id in entry.get("cre_ids", []):
+                cres = cache.get_CREs(external_id=cre_id)
+                if not cres:
+                    continue
+                standard.add_link(
+                    defs.Link(
+                        ltype=defs.LinkTypes.LinkedTo,
+                        document=cres[0].shallow_copy(),
+                    )
+                )
+            entries.append(standard)
+
+        return ParseResult(
+            results={self.name: entries},
+            calculate_gap_analysis=False,
+            calculate_embeddings=False,
+        )

--- a/cre.py
+++ b/cre.py
@@ -168,6 +168,36 @@ def main() -> None:
         help="import owasp secure headers",
     )
     parser.add_argument(
+        "--owasp_top10_2025_in",
+        action="store_true",
+        help="import OWASP Top 10 2025",
+    )
+    parser.add_argument(
+        "--owasp_api_top10_2023_in",
+        action="store_true",
+        help="import OWASP API Security Top 10 2023",
+    )
+    parser.add_argument(
+        "--owasp_kubernetes_top10_2022_in",
+        action="store_true",
+        help="import OWASP Kubernetes Top Ten 2022",
+    )
+    parser.add_argument(
+        "--owasp_kubernetes_top10_2025_in",
+        action="store_true",
+        help="import OWASP Kubernetes Top Ten 2025 draft",
+    )
+    parser.add_argument(
+        "--owasp_llm_top10_2025_in",
+        action="store_true",
+        help="import OWASP Top 10 for LLM and Gen AI Apps 2025",
+    )
+    parser.add_argument(
+        "--owasp_aisvs_in",
+        action="store_true",
+        help="import OWASP AI Security Verification Standard (AISVS)",
+    )
+    parser.add_argument(
         "--pci_dss_3_2_in",
         action="store_true",
         help="import pci dss from https://www.compliancequickstart.com/",

--- a/scripts/update-cheatsheets.sh
+++ b/scripts/update-cheatsheets.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB_PATH="${1:-$ROOT_DIR/standards_cache.sqlite}"
+VENV_DIR="$ROOT_DIR/venv"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+if ! python -c "import flask" >/dev/null 2>&1; then
+  pip install -r "$ROOT_DIR/requirements.txt"
+fi
+
+CRE_NO_CALCULATE_GAP_ANALYSIS=1 \
+CRE_NO_GEN_EMBEDDINGS=1 \
+python "$ROOT_DIR/cre.py" --cheatsheets_in --cache_file "$DB_PATH"
+
+python - "$DB_PATH" <<'PY'
+import os
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+
+github_prefix = "https://github.com/OWASP/CheatSheetSeries/tree/master/cheatsheets/"
+official_prefix = "https://cheatsheetseries.owasp.org/cheatsheets/"
+
+rows = cur.execute(
+    """
+    select id, link
+    from node
+    where name = 'OWASP Cheat Sheets'
+      and link like ?
+    """,
+    (f"{github_prefix}%",),
+).fetchall()
+
+for node_id, link in rows:
+    filename = os.path.basename(link)
+    html_name = os.path.splitext(filename)[0] + ".html"
+    cur.execute(
+        "update node set link = ? where id = ?",
+        (f"{official_prefix}{html_name}", node_id),
+    )
+
+conn.commit()
+conn.close()
+print(f"Normalized {len(rows)} OWASP Cheat Sheet links")
+PY

--- a/scripts/update-cheatsheets.sh
+++ b/scripts/update-cheatsheets.sh
@@ -15,6 +15,14 @@ if ! python -c "import flask" >/dev/null 2>&1; then
   pip install -r "$ROOT_DIR/requirements.txt"
 fi
 
+BACKUP_FILE="${DB_PATH}.$(date +%Y%m%d%H%M%S).bak"
+cp "$DB_PATH" "$BACKUP_FILE"
+if [[ ! -f "$BACKUP_FILE" ]]; then
+  echo "Failed to create backup at $BACKUP_FILE" >&2
+  exit 1
+fi
+echo "Created backup at $BACKUP_FILE"
+
 CRE_NO_CALCULATE_GAP_ANALYSIS=1 \
 CRE_NO_GEN_EMBEDDINGS=1 \
 python "$ROOT_DIR/cre.py" --cheatsheets_in --cache_file "$DB_PATH"

--- a/scripts/update-cheatsheets.sh
+++ b/scripts/update-cheatsheets.sh
@@ -15,6 +15,11 @@ if ! python -c "import flask" >/dev/null 2>&1; then
   pip install -r "$ROOT_DIR/requirements.txt"
 fi
 
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "Database file does not exist: $DB_PATH" >&2
+  exit 1
+fi
+
 BACKUP_FILE="${DB_PATH}.$(date +%Y%m%d%H%M%S).bak"
 cp "$DB_PATH" "$BACKUP_FILE"
 if [[ ! -f "$BACKUP_FILE" ]]; then

--- a/scripts/update-owasp-top10-2025-mappings.sh
+++ b/scripts/update-owasp-top10-2025-mappings.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$ROOT_DIR/venv"
+CACHE_FILE="${1:-$ROOT_DIR/standards_cache.sqlite}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_FILE="${CACHE_FILE}.bak.${TIMESTAMP}"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "Creating virtual environment in $VENV_DIR"
+  python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+if ! python -c "import requests" >/dev/null 2>&1; then
+  echo "Installing Python dependencies"
+  pip install -r "$ROOT_DIR/requirements.txt"
+fi
+
+if [[ -f "$CACHE_FILE" ]]; then
+  cp "$CACHE_FILE" "$BACKUP_FILE"
+  echo "Backed up database to $BACKUP_FILE"
+fi
+
+export CRE_NO_NEO4J="${CRE_NO_NEO4J:-1}"
+export CRE_NO_GEN_EMBEDDINGS="${CRE_NO_GEN_EMBEDDINGS:-1}"
+export CRE_UPSTREAM_MAX_ATTEMPTS="${CRE_UPSTREAM_MAX_ATTEMPTS:-6}"
+export CRE_UPSTREAM_RETRY_BACKOFF_SECONDS="${CRE_UPSTREAM_RETRY_BACKOFF_SECONDS:-2}"
+export CRE_UPSTREAM_TIMEOUT_SECONDS="${CRE_UPSTREAM_TIMEOUT_SECONDS:-30}"
+
+echo "Refreshing official OpenCRE upstream data in $CACHE_FILE"
+python "$ROOT_DIR/cre.py" --upstream_sync --cache_file "$CACHE_FILE"
+
+echo "Reapplying OWASP Top 10 2025 CRE mappings"
+exec python "$ROOT_DIR/cre.py" --owasp_top10_2025_in --cache_file "$CACHE_FILE"

--- a/scripts/update-owasp-top10-standards.sh
+++ b/scripts/update-owasp-top10-standards.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$ROOT_DIR/venv"
+CACHE_FILE="${1:-$ROOT_DIR/standards_cache.sqlite}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_FILE="${CACHE_FILE}.bak.${TIMESTAMP}"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "Creating virtual environment in $VENV_DIR"
+  python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+if ! python -c "import requests" >/dev/null 2>&1; then
+  echo "Installing Python dependencies"
+  pip install -r "$ROOT_DIR/requirements.txt"
+fi
+
+if [[ -f "$CACHE_FILE" ]]; then
+  cp "$CACHE_FILE" "$BACKUP_FILE"
+  echo "Backed up database to $BACKUP_FILE"
+fi
+
+export CRE_NO_NEO4J="${CRE_NO_NEO4J:-1}"
+export CRE_NO_GEN_EMBEDDINGS="${CRE_NO_GEN_EMBEDDINGS:-1}"
+export CRE_UPSTREAM_MAX_ATTEMPTS="${CRE_UPSTREAM_MAX_ATTEMPTS:-6}"
+export CRE_UPSTREAM_RETRY_BACKOFF_SECONDS="${CRE_UPSTREAM_RETRY_BACKOFF_SECONDS:-2}"
+export CRE_UPSTREAM_TIMEOUT_SECONDS="${CRE_UPSTREAM_TIMEOUT_SECONDS:-30}"
+
+echo "Refreshing official OpenCRE upstream data in $CACHE_FILE"
+python "$ROOT_DIR/cre.py" --upstream_sync --cache_file "$CACHE_FILE"
+
+echo "Reapplying OWASP Top 10 standards and CRE mappings"
+python "$ROOT_DIR/cre.py" \
+  --owasp_top10_2025_in \
+  --owasp_api_top10_2023_in \
+  --owasp_kubernetes_top10_2025_in \
+  --owasp_llm_top10_2025_in \
+  --owasp_aisvs_in \
+  --cache_file "$CACHE_FILE"
+
+echo "Selecting preferred Kubernetes Top Ten version"
+if python - <<'PY' "$CACHE_FILE"
+import sqlite3
+import sys
+
+cache_file = sys.argv[1]
+name_2025 = "OWASP Kubernetes Top Ten 2025 (Draft)"
+name_2022 = "OWASP Kubernetes Top Ten 2022"
+
+conn = sqlite3.connect(cache_file)
+cur = conn.cursor()
+
+linked_2025 = cur.execute(
+    """
+    select count(*)
+    from node n
+    join cre_node_links l on l.node = n.id
+    where n.name = ?
+    """,
+    (name_2025,),
+).fetchone()[0]
+
+if linked_2025 > 0:
+    cur.execute("delete from node where name = ?", (name_2022,))
+    print(f"Using {name_2025}; removed {name_2022}")
+else:
+    raise SystemExit(f"{name_2025} not linked")
+
+conn.commit()
+conn.close()
+PY
+then
+  :
+else
+  echo "OWASP Kubernetes Top Ten 2025 (Draft) is unavailable or unmapped, importing 2022"
+  python "$ROOT_DIR/cre.py" \
+    --owasp_kubernetes_top10_2022_in \
+    --cache_file "$CACHE_FILE"
+fi
+
+echo "Pruning OWASP Top 10 entries that still have no CRE links"
+python - <<'PY' "$CACHE_FILE"
+import sqlite3
+import sys
+
+cache_file = sys.argv[1]
+standard_names = (
+    "OWASP Top 10 2025",
+    "OWASP API Security Top 10 2023",
+    "OWASP Kubernetes Top Ten 2025 (Draft)",
+    "OWASP Top 10 for LLM and Gen AI Apps 2025",
+    "OWASP AI Security Verification Standard (AISVS)",
+)
+
+conn = sqlite3.connect(cache_file)
+cur = conn.cursor()
+
+has_2022 = cur.execute(
+    "select 1 from node where name = 'OWASP Kubernetes Top Ten 2022' limit 1"
+).fetchone()
+if has_2022:
+    standard_names = standard_names + ("OWASP Kubernetes Top Ten 2022",)
+
+rows = list(
+    cur.execute(
+        f"""
+        select n.id, n.name, coalesce(n.section_id, ''), coalesce(n.section, '')
+        from node n
+        left join cre_node_links l on l.node = n.id
+        where n.name in ({','.join('?' for _ in standard_names)})
+        group by n.id
+        having count(l.cre) = 0
+        """,
+        standard_names,
+    )
+)
+
+for node_id, name, section_id, section in rows:
+    cur.execute("delete from node where id = ?", (node_id,))
+    print(f"Removed unmapped entry: {name} {section_id} {section}".strip())
+
+conn.commit()
+conn.close()
+PY

--- a/scripts/update-owasp-top10-standards.sh
+++ b/scripts/update-owasp-top10-standards.sh
@@ -54,6 +54,8 @@ name_2022 = "OWASP Kubernetes Top Ten 2022"
 
 conn = sqlite3.connect(cache_file)
 cur = conn.cursor()
+# Ensure SQLite enforces foreign key constraints so deletes cascade as expected
+cur.execute("PRAGMA foreign_keys = ON")
 
 linked_2025 = cur.execute(
     """


### PR DESCRIPTION
### Issue Reference
#471 

### Summary
This PR addresses part of issue #471 by adding refresh and update workflow support for the OWASP resources introduced by earlier importer PRs.

This is the fourth upstream PR in the stacked https://github.com/OWASP/OpenCRE/issues/471 review series.

### Problem Fixed
Newly added OWASP resources lacked refresh/update workflow support.

### Solution
Added refresh scripts and helper flows for OWASP resource maintenance.

### Tests
Validated against the parser/importer coverage introduced by the earlier PRs.

## Why this is split out
The full #471 work is too large to review effectively as one PR.

This PR isolates one OWASP resource family so the parser/data model can be reviewed independently before the later Kubernetes, cheat sheet, backend analysis, and frontend changes.