### PR TITLE
fix: correct expected tags value in test_dbNodeFromNode

### DIFF
--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -1092,7 +1092,7 @@ class TestDB(unittest.TestCase):
                 name="ccc",
                 description="c2",
                 link="https://example.com/code/hyperlink",
-                tags="1,2",
+                tags="111-111,222-222",
                 ntype=defs.Credoctypes.Code.value,
             ),
         }


### PR DESCRIPTION
Closes #870

## Summary

`test_dbNodeFromNode` in `application/tests/db_test.py` (line 1083) expected `tags="1,2"` but `dbNodeFromCode` joins the input list `["111-111", "222-222"]` with commas, producing `"111-111,222-222"`. The expected value in the test was stale after the tag fix in #822 and was never updated.

## Changes

- Updated the expected `tags` value from `"1,2"` to `"111-111,222-222"` in `test_dbNodeFromNode`

## Test plan

- [x] `test_dbNodeFromNode` passes
- [x] Full `db_test.py` suite run -- no regressions introduced by this change
- [x] `black` formatting verified