### PR TITLE
ci(test): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Test


### PR DESCRIPTION
The `test` workflow runs unit tests; no GitHub API writes. Workflow-level `contents: read` is the right cap.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening shape. YAML validated locally.