### PR TITLE
fix: always show all CRE links on CRE pages without collapsing (#901)

### DIFF
--- a/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
+++ b/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
@@ -8,6 +8,7 @@ import { Icon } from 'semantic-ui-react';
 import { DocumentNode } from '../../components/DocumentNode';
 import { ClearFilterButton, FilterButton } from '../../components/FilterButton/FilterButton';
 import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndicator';
+import { DOCUMENT_TYPES } from '../../const';
 import { useEnvironment } from '../../hooks';
 import { applyFilters, filterContext } from '../../hooks/applyFilters';
 import { Document } from '../../types';
@@ -106,25 +107,30 @@ export const CommonRequirementEnumeration = () => {
                 const sortedResults = links.sort((a, b) =>
                   getDocumentDisplayName(a.document).localeCompare(getDocumentDisplayName(b.document))
                 );
+                const allLinksAreCres =
+                  sortedResults.length > 0 &&
+                  sortedResults.every((link) => link.document.doctype === DOCUMENT_TYPES.TYPE_CRE);
+                const visibleResults =
+                  allLinksAreCres || showAll[type]
+                    ? sortedResults
+                    : sortedResults.slice(0, MAX_LENGTH_FOR_AUTO_EXPAND);
                 return (
                   <div className="cre-page__links" key={type}>
                     <div className="cre-page__links-eader">
                       <b>Which {getDocumentTypeText(type, links[0].document.doctype)}</b>:
                       {/* Risk of mixed doctype in here causing odd output */}
                     </div>
-                    {sortedResults
-                      .slice(0, showAll[type] ? sortedResults.length : MAX_LENGTH_FOR_AUTO_EXPAND)
-                      .map((link, i) => (
-                        <div
-                          key={i}
-                          className="accordion ui fluid styled cre-page__links-container"
-                          style={{ marginBottom: '4px' }}
-                        >
-                          <DocumentNode node={link.document} linkType={type} />
-                          <FilterButton document={link.document} />
-                        </div>
-                      ))}
-                    {sortedResults.length > MAX_LENGTH_FOR_AUTO_EXPAND && (
+                    {visibleResults.map((link, i) => (
+                      <div
+                        key={i}
+                        className="accordion ui fluid styled cre-page__links-container"
+                        style={{ marginBottom: '4px' }}
+                      >
+                        <DocumentNode node={link.document} linkType={type} />
+                        <FilterButton document={link.document} />
+                      </div>
+                    ))}
+                    {!allLinksAreCres && sortedResults.length > MAX_LENGTH_FOR_AUTO_EXPAND && (
                       <button
                         onClick={() => setShowAll((prev) => ({ ...prev, [type]: !prev[type] }))}
                         style={{ marginTop: '8px', cursor: 'pointer' }}


### PR DESCRIPTION
Fixes #901

## Problem
On a CRE page, lists of linked CREs were being collapsed after 5 items,
requiring users to click "Show more" to see the rest. This happened because
the collapse logic in CommonRequirementEnumeration.tsx did not distinguish
between CRE links and links to external standards.

## Fix
Added a check in CommonRequirementEnumeration.tsx: if all links in a group
are CREs, show all of them without collapsing and hide the "Show more" button.
Links to external standards still collapse as before.

This matches the logic already present in DocumentNode.tsx (allLinksAreCres).

## Changes
- `application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx`
  - Import `DOCUMENT_TYPES` from `../../const`
  - Compute `allLinksAreCres` before rendering each link group
  - Use `visibleResults` (full list when CREs, sliced otherwise) instead of inline slice
  - Guard the "Show more" button with `!allLinksAreCres`