### PR TITLE
feat: implement structured extraction checkpoints B1 and B2

### DIFF
--- a/application/defs/cheatsheet_defs.py
+++ b/application/defs/cheatsheet_defs.py
@@ -43,7 +43,9 @@ class CheatsheetRecord:
         }
 
         # Validate fields which require string values.
-        for field_name, value in required_str_fields.items():
+        for field_name in required_str_fields:
+            value = getattr(self, field_name)
+
             if not isinstance(value, str) or not value:
                 raise ValueError(
                     f"CheatsheetRecord: field '{field_name}' "

--- a/application/defs/cheatsheet_defs.py
+++ b/application/defs/cheatsheet_defs.py
@@ -54,7 +54,7 @@ class CheatsheetRecord:
             for item in value:
                 if not isinstance(item, str):
                     raise ValueError(
-                        f"CheatsheetRecord : value of '{field_name}' must be a string, got {item!r}"
+                        f"CheatsheetRecord: value of '{field_name}' must be a string, got {item!r}"
                     )
 
         # Validate input for metadata

--- a/application/defs/cheatsheet_defs.py
+++ b/application/defs/cheatsheet_defs.py
@@ -17,9 +17,7 @@ class CheatsheetRecord:
     metadata: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
-
-        self.summary = self.summary.strip()[:SUMMARY_MAX_LENGTH]
-
+        
         required_str_fields = {
             "source_id": self.source_id,
             "title": self.title,
@@ -28,22 +26,28 @@ class CheatsheetRecord:
             "raw_markdown_path": self.raw_markdown_path,
         }
 
+        # Summary-specific normalization
+        self.summary = self.summary.strip()[:SUMMARY_MAX_LENGTH]
+        
+        # Normalize fields which require string values.   
+        for field_name, value in required_str_fields.items():
+            if isinstance(value, str):
+                setattr(self, field_name, value.strip())
+
         list_str_fields = {
             "headings": self.headings,
             "category_hints": self.category_hints,
         }
 
-        # Validate required value type string fields.
-
-        for field_name, value in required_str_fields.items():
-            if not isinstance(value, str) or not value.strip():
+        # Validate fields which require string values.
+        for field_name, value in required_str_fields.items():    
+            if not isinstance(value, str) or not value:
                 raise ValueError(
                     f"CheatsheetRecord: field '{field_name}' "
                     f"must be a non-empty string, got {value!r}"
                 )
 
-        # Validate required value type list[string] fields.
-
+        # Validate fields which require list[str] values.
         for field_name, value in list_str_fields.items():
             if not isinstance(value, list):
                 raise ValueError(
@@ -57,8 +61,7 @@ class CheatsheetRecord:
                         f"CheatsheetRecord: value of '{field_name}' must be a string, got {item!r}"
                     )
 
-        # Validate input for metadata
-
+        # Validate input for metadata.
         if not isinstance(self.metadata, dict):
             raise ValueError(
                 "CheatsheetRecord: field 'metadata' must be a dict[str, str]"

--- a/application/defs/cheatsheet_defs.py
+++ b/application/defs/cheatsheet_defs.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+SUMMARY_MAX_LENGTH = 500
+
+
+@dataclass
+class CheatsheetRecord:
+    source: str = field(default="owasp_cheatsheets", init=False)
+    source_id: str
+    title: str
+    hyperlink: str
+    summary: str
+    headings: List[str]
+    raw_markdown_path: str
+    category_hints: List[str] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+
+        self.summary = self.summary.strip()[:SUMMARY_MAX_LENGTH]
+
+        required_str_fields = {
+            "source_id": self.source_id,
+            "title": self.title,
+            "hyperlink": self.hyperlink,
+            "summary": self.summary,
+            "raw_markdown_path": self.raw_markdown_path,
+        }
+
+        list_str_fields = {
+            "headings": self.headings,
+            "category_hints": self.category_hints,
+        }
+
+        # Validate required value type string fields.
+
+        for field_name, value in required_str_fields.items():
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"CheatsheetRecord: field '{field_name}' "
+                    f"must be a non-empty string, got {value!r}"
+                )
+
+        # Validate required value type list[string] fields.
+
+        for field_name, value in list_str_fields.items():
+            if not isinstance(value, list):
+                raise ValueError(
+                    f"CheatsheetRecord: field '{field_name}' "
+                    f"must be a list[str], got {type(value)!r}"
+                )
+
+            for item in value:
+                if not isinstance(item, str):
+                    raise ValueError(
+                        f"CheatsheetRecord : value of '{field_name}' must be a string, got {item!r}"
+                    )
+
+        # Validate input for metadata
+
+        if not isinstance(self.metadata, dict):
+            raise ValueError(
+                "CheatsheetRecord: field 'metadata' must be a dict[str, str]"
+            )
+
+        for key, value in self.metadata.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError(
+                    "CheatsheetRecord: metadata keys and values must be strings, "
+                    f"got {key!r}: {value!r}"
+                )

--- a/application/defs/cheatsheet_defs.py
+++ b/application/defs/cheatsheet_defs.py
@@ -6,6 +6,8 @@ SUMMARY_MAX_LENGTH = 500
 
 @dataclass
 class CheatsheetRecord:
+    """Structured representation of an OWASP cheatsheet record."""
+
     source: str = field(default="owasp_cheatsheets", init=False)
     source_id: str
     title: str
@@ -17,7 +19,8 @@ class CheatsheetRecord:
     metadata: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
-        
+        """Normalize and validate CheatsheetRecord fields."""
+
         required_str_fields = {
             "source_id": self.source_id,
             "title": self.title,
@@ -28,8 +31,8 @@ class CheatsheetRecord:
 
         # Summary-specific normalization
         self.summary = self.summary.strip()[:SUMMARY_MAX_LENGTH]
-        
-        # Normalize fields which require string values.   
+
+        # Normalize fields which require string values.
         for field_name, value in required_str_fields.items():
             if isinstance(value, str):
                 setattr(self, field_name, value.strip())
@@ -40,7 +43,7 @@ class CheatsheetRecord:
         }
 
         # Validate fields which require string values.
-        for field_name, value in required_str_fields.items():    
+        for field_name, value in required_str_fields.items():
             if not isinstance(value, str) or not value:
                 raise ValueError(
                     f"CheatsheetRecord: field '{field_name}' "
@@ -58,7 +61,8 @@ class CheatsheetRecord:
             for item in value:
                 if not isinstance(item, str):
                     raise ValueError(
-                        f"CheatsheetRecord: value of '{field_name}' must be a string, got {item!r}"
+                        f"CheatsheetRecord: value of '{field_name}' "
+                        f"must be a string, got {item!r}"
                     )
 
         # Validate input for metadata.

--- a/application/utils/external_project_parsers/parsers/cheatsheet_extractor.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheet_extractor.py
@@ -1,0 +1,80 @@
+import os
+import re
+from application.defs.cheatsheet_defs import CheatsheetRecord
+
+PARSER_VERSION = "v1"
+FALLBACK_USED = "false"
+CANONICAL_BASE_URL = "https://cheatsheetseries.owasp.org/cheatsheets/"
+
+_TITLE_RE = re.compile(r"^#\s+(?P<title>.+)$", re.MULTILINE)
+_HEADING_RE = re.compile(r"^##\s+(?P<heading>.+)$", re.MULTILINE)
+_ANY_HEADING_RE = re.compile(r"^#{1,6}\s+.+$", re.MULTILINE)
+
+
+def _derive_source_id(source_path: str) -> str:
+    basename = os.path.basename(source_path)
+    source_id, _ = os.path.splitext(basename)
+    return source_id
+
+
+def _derive_hyperlink(source_path: str) -> str:
+    source_id = _derive_source_id(source_path)
+    return f"{CANONICAL_BASE_URL}{source_id}.html"
+
+
+def _extract_body_after_heading(markdown: str, heading_match: re.Match) -> str:
+    start = heading_match.end()
+    next_heading = _ANY_HEADING_RE.search(markdown, start)
+    end = next_heading.start() if next_heading else len(markdown)
+    return markdown[start:end].strip()
+
+
+def _extract_summary(markdown: str) -> str:
+    all_heading_matches = list(_ANY_HEADING_RE.finditer(markdown))
+
+    for match in all_heading_matches:
+        heading_text = match.group().lstrip("#").strip()
+
+        if heading_text.lower() == "introduction":
+            body = _extract_body_after_heading(markdown, match)
+
+            if body:
+                return body
+            break
+
+    for match in all_heading_matches:
+        body = _extract_body_after_heading(markdown, match)
+
+        if body:
+            return body
+
+    raise ValueError("_extract_summary: no summary could be extracted from markdown.")
+
+
+def extract_cheatsheet_record(
+    markdown: str,
+    source_path: str,
+) -> CheatsheetRecord:
+    title_match = _TITLE_RE.search(markdown)
+    title = title_match.group("title").strip()
+
+    headings = [m.group("heading").strip() for m in _HEADING_RE.finditer(markdown)]
+
+    summary = _extract_summary(markdown)
+
+    source_id = _derive_source_id(source_path)
+    hyperlink = _derive_hyperlink(source_path)
+
+    return CheatsheetRecord(
+        source_id=source_id,
+        title=title,
+        hyperlink=hyperlink,
+        summary=summary,
+        headings=headings,
+        raw_markdown_path=source_path,
+        category_hints=[],
+        metadata={
+            "parser_version": PARSER_VERSION,
+            "fallback_used": FALLBACK_USED,
+        },
+    )

--- a/application/utils/external_project_parsers/parsers/cheatsheet_extractor.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheet_extractor.py
@@ -62,9 +62,7 @@ def _extract_summary(markdown: str) -> str:
         if body:
             return body
 
-    raise ValueError(
-        "_extract_summary: no summary could be extracted from markdown."
-    )
+    raise ValueError("_extract_summary: no summary could be extracted from markdown.")
 
 
 def extract_cheatsheet_record(

--- a/application/utils/external_project_parsers/parsers/cheatsheet_extractor.py
+++ b/application/utils/external_project_parsers/parsers/cheatsheet_extractor.py
@@ -1,9 +1,11 @@
 import os
 import re
+
 from application.defs.cheatsheet_defs import CheatsheetRecord
 
 PARSER_VERSION = "v1"
 FALLBACK_USED = "false"
+
 CANONICAL_BASE_URL = "https://cheatsheetseries.owasp.org/cheatsheets/"
 
 _TITLE_RE = re.compile(r"^#\s+(?P<title>.+)$", re.MULTILINE)
@@ -12,24 +14,35 @@ _ANY_HEADING_RE = re.compile(r"^#{1,6}\s+.+$", re.MULTILINE)
 
 
 def _derive_source_id(source_path: str) -> str:
+    """Derive the cheatsheet source ID from the markdown file path."""
+
     basename = os.path.basename(source_path)
     source_id, _ = os.path.splitext(basename)
+
     return source_id
 
 
 def _derive_hyperlink(source_path: str) -> str:
+    """Generate the canonical OWASP cheatsheet hyperlink."""
+
     source_id = _derive_source_id(source_path)
+
     return f"{CANONICAL_BASE_URL}{source_id}.html"
 
 
 def _extract_body_after_heading(markdown: str, heading_match: re.Match) -> str:
+    """Extract body content until the next markdown heading."""
+
     start = heading_match.end()
     next_heading = _ANY_HEADING_RE.search(markdown, start)
     end = next_heading.start() if next_heading else len(markdown)
+
     return markdown[start:end].strip()
 
 
 def _extract_summary(markdown: str) -> str:
+    """Extract a summary section from cheatsheet markdown."""
+
     all_heading_matches = list(_ANY_HEADING_RE.finditer(markdown))
 
     for match in all_heading_matches:
@@ -40,6 +53,7 @@ def _extract_summary(markdown: str) -> str:
 
             if body:
                 return body
+
             break
 
     for match in all_heading_matches:
@@ -48,13 +62,17 @@ def _extract_summary(markdown: str) -> str:
         if body:
             return body
 
-    raise ValueError("_extract_summary: no summary could be extracted from markdown.")
+    raise ValueError(
+        "_extract_summary: no summary could be extracted from markdown."
+    )
 
 
 def extract_cheatsheet_record(
     markdown: str,
     source_path: str,
 ) -> CheatsheetRecord:
+    """Extract a structured CheatsheetRecord from markdown content."""
+
     title_match = _TITLE_RE.search(markdown)
     title = title_match.group("title").strip()
 


### PR DESCRIPTION


This PR implements Workstream B checkpoints B1 and B2 from the OWASP Cheat Sheet to CRE Mapping pipeline RFC.

## Added

### 1. `cheatsheet_defs.py`

Adds the `CheatsheetRecord` data model required for Checkpoint B1.

Introduces validation logic corresponding to the RFC-defined contract.

Current validation functions ensure:

- whether the parameter types passed during object creation match the expected RFC contract (e.g. `str`, `list[str]`, etc.)
- summary normalization and truncation to the predefined length bounds

Validation errors raise field-specific exceptions as required by the RFC.

The `source` field value is currently hardcoded to the expected OWASP Cheat Sheet source mapping.

---

### 2. `cheatsheet_extractor.py`

Adds the `extract_cheatsheet_record()` implementation required for Checkpoint B2.

Regex patterns were defined for extracting:

- title (`h1`)
- headings (`h2`)
- generic heading matching later used during summary extraction

The extractor also contains helper functions that deterministically derive:

- source ID
- canonical hyperlinks

Summary extraction currently assumes well-structured OWASP Cheat Sheet markdown (i.e. no malformed structures), as described in the RFC.

The summary extraction logic was designed after observing the structure and content layout across multiple OWASP Cheat Sheets and currently follows a deterministic extraction strategy.

The current implementation primarily focuses on the `Introduction` heading, since most OWASP Cheat Sheets define the overall context and contents of the cheat sheet within this section, making it a suitable candidate for summary extraction.

The current extraction flow works as follows:

- If an `Introduction` heading is present, the extractor returns the content under that section until the next heading.
- If no `Introduction` heading exists, the extractor falls back to the first valid content block found under subsequent headings.
- Empty heading sections are skipped during this process.

The extracted summary is truncated correctly according to the RFC-defined bounds.

For parser metadata, the current implementation intentionally keeps the structure lightweight since this is an initial V1 implementation.

The extractor finally returns a typed `CheatsheetRecord` object.

---

## Notes

Fallback handling for malformed markdown structures, missing titles, irregular heading layouts, and other defensive parsing logic will be handled with the implementation of B3.
