### PR TITLE
ci(codeql): upgrade CodeQL Action v1→v4 and checkout v2→v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What
Brings the CodeQL code-scanning workflow up to parity with the rest of the repo:
- `github/codeql-action/{init,autobuild,analyze}`: **v1 → v4**
- `actions/checkout`: **v2 → v4** (matching every other workflow, which already use @v4)

## Why
The workflow was pinned to CodeQL Action **v1**, retired by GitHub in 2023 — so
code scanning has effectively been failing rather than just out of date. v4 runs on
the Node 24 runtime and is the correct target (v3 deprecates Dec 2026). Python is a
non-compiled language for CodeQL, so `autobuild` is a no-op and there's no build
dependency; left in place for a minimal diff.

Note: this intentionally tracks the repo's existing `checkout@v4` pin. A separate,
repo-wide migration of all workflows to Node 24 (checkout@v5, etc.) can follow.

## Validation
Ran on my fork against `main` — all checks green, including `CodeQL / Analyze (python)`
and `Code scanning results / CodeQL` (no new alerts). CI version bumps only; no
functional changes.

closes #929