### PR TITLE
Fix IndexError in get_cre_by_db_id when get_CREs is empty

### DIFF
--- a/application/database/db.py
+++ b/application/database/db.py
@@ -1344,7 +1344,13 @@ class Node_collection:
         if not external_id:
             logger.error(f"CRE {id} does not exist in the db")
             return None
-        return self.get_CREs(external_id=external_id[0])[0]
+        cres = self.get_CREs(external_id=external_id[0])
+        if not cres:
+            logger.error(
+                f"CRE {id} exists but get_CREs returned no results for external_id={external_id[0]}"
+            )
+            return None
+        return cres[0]
 
     def list_node_ids_by_ntype(self, ntype: str) -> List[str]:
         # Always return plain strings (never SQLAlchemy row tuples).

--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -745,6 +745,15 @@ class TestDB(unittest.TestCase):
 
         self.assertEqual([c_id_only], collection.get_CREs(internal_id=db_id_only.id))
 
+    @patch.object(db.Node_collection, "get_CREs")
+    def test_get_cre_by_db_id_returns_none_when_get_cres_empty(
+        self, get_cres_mock
+    ) -> None:
+        get_cres_mock.return_value = []
+        result = self.collection.get_cre_by_db_id(self.dbcre.id)
+        self.assertIsNone(result)
+        get_cres_mock.assert_called_once_with(external_id=self.dbcre.external_id)
+
     def test_get_standards(self) -> None:
         """Given: a Standard 'S1' that links to cres
         return the Standard in Document format"""


### PR DESCRIPTION
## Summary
- Guard `get_cre_by_db_id` when `get_CREs` returns an empty list — log an error and return `None` instead of raising `IndexError` (fixes #861).
- Add a focused unit test mocking `get_CREs` to return `[]`.

## Test plan
- [x] `python -m unittest application.tests.db_test.TestDB.test_get_cre_by_db_id_returns_none_when_get_cres_empty`
- [x] `python -m unittest application.tests.db_test` (full db_test suite)
- [x] `black .` (via make lint — passed locally)
- [ ] CI lint / mypy / full test suite


Made with [Cursor](https://cursor.com)