### PR TITLE
feat: smartlink redirects directly to CRE when only one CRE is linked

### DIFF
--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -585,7 +585,7 @@ class TestMain(unittest.TestCase):
             for head in response.headers:
                 if head[0] == "Location":
                     location = head[1]
-            self.assertEqual(location, "/node/standard/CWE/sectionid/456")
+            self.assertEqual(location, "/cre/222-222")
             self.assertEqual(302, response.status_code)
 
             response = client.get(
@@ -596,7 +596,28 @@ class TestMain(unittest.TestCase):
             for head in response.headers:
                 if head[0] == "Location":
                     location = head[1]
-            self.assertEqual(location, "/node/standard/ASVS/section/v0.1.2")
+            self.assertEqual(location, "/cre/333-333")
+            self.assertEqual(302, response.status_code)
+
+            # Multiple CREs linked to same standard → should fall back to node page
+            cwe_multi = defs.Standard(name="CWEmulti", sectionID="789")
+            ce = defs.CRE(id="444-444", description="CE", name="CE", tags=[])
+            cf = defs.CRE(id="555-555", description="CF", name="CF", tags=[])
+            dcwe_multi = collection.add_node(cwe_multi)
+            dce = collection.add_cre(ce)
+            dcf = collection.add_cre(cf)
+            collection.add_link(dce, dcwe_multi, ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcf, dcwe_multi, ltype=defs.LinkTypes.LinkedTo)
+
+            response = client.get(
+                "/smartlink/standard/CWEmulti/789",
+                headers={"Content-Type": "application/json"},
+            )
+            location = ""
+            for head in response.headers:
+                if head[0] == "Location":
+                    location = head[1]
+            self.assertEqual(location, "/node/standard/CWEmulti/sectionid/789")
             self.assertEqual(302, response.status_code)
 
             # negative test, this cwe does not exist, therefore we redirect to Mitre!

--- a/application/web/web_main.py
+++ b/application/web/web_main.py
@@ -635,7 +635,15 @@ def index(path: str) -> Any:
 def smartlink(
     name: str, ntype: str = defs.Credoctypes.Standard.value, section: str = ""
 ) -> Any:
-    """if node is found, show node, else redirect"""
+    """If a standard section node is found, redirect to it.
+
+    If the node has exactly one linked CRE, redirect directly to that CRE
+    page instead of the intermediate standard-section page, so the user
+    immediately sees the full wealth of CRE information.
+    If the node has multiple CRE links, redirect to the standard-section
+    node page as before.  If the node is not found in the database, fall
+    back to any known external redirect (e.g. the Mitre CWE catalogue).
+    """
     # ATTENTION: DO NOT MESS WITH THIS FUNCTIONALITY WITHOUT A TICKET AND CORE CONTRIBUTORS APPROVAL!
     # CRITICAL FUNCTIONALITY DEPENDS ON THIS!
     if posthog:
@@ -673,6 +681,17 @@ def smartlink(
         logger.info(
             f"found node of type {ntype}, name {name} and section {section}, redirecting to opencre"
         )
+        cre_links = [
+            lnk
+            for lnk in nodes[0].links
+            if lnk.document.doctype == defs.Credoctypes.CRE
+        ]
+        if len(cre_links) == 1:
+            logger.info(
+                f"exactly one CRE linked to {ntype}/{name}/{section},"
+                f" redirecting directly to CRE {cre_links[0].document.id}"
+            )
+            return redirect(f"/cre/{cre_links[0].document.id}")
         if found_section_id:
             return redirect(f"/node/{ntype}/{name}/sectionid/{section}")
         return redirect(f"/node/{ntype}/{name}/section/{section}")


### PR DESCRIPTION
When a smartlink resolves to a standard section that has exactly one linked CRE, redirect the user directly to that CRE page instead of the intermediate standard-section node page. The CRE page already contains all the information the landing page would show.

If multiple CREs are linked, behaviour is unchanged.

Closes #486
Supercedes #906 

Addressed the review comments in #906 