### PR TITLE
cwe: add XXE search aliases and enforce prohibited CWE exclusions

### DIFF
--- a/application/database/db.py
+++ b/application/database/db.py
@@ -2162,6 +2162,7 @@ class Node_collection:
                 CRE ids before it performs a free text search
            Anything else will be a case insensitive LIKE query in the database
         """
+        search_terms = self._expand_text_search_aliases(text)
         # structured text search first
         cre_id_search = r"CRE(:| )(?P<id>\d+-\d+)"
         cre_naked_id_search = r"\d\d\d-\d\d\d"
@@ -2213,33 +2214,79 @@ class Node_collection:
             if results:
                 return list(set(results))
         # fuzzy matches second
-        args = [f"%{text}%", "", "", "", "", ""]
         results = {}
-        s = set([p for p in permutations(args, 6)])
-        for combo in s:
-            nodes = self.get_nodes(
-                name=combo[0],
-                section=combo[1],
-                subsection=combo[2],
-                link=combo[3],
-                description=combo[4],
-                partial=True,
-                ntype=None,  # type: ignore
-                sectionID=combo[5],
-            )
-            if nodes:
-                for node in nodes:
-                    node_key = f"{node.name}:{node.version}:{node.section}:{node.sectionID}:{node.subsection}:"
-                    results[node_key] = node
-        args = [f"%{text}%", None, None]
-        for combo in permutations(args, 3):
-            cres = self.get_CREs(
-                name=combo[0], external_id=combo[1], description=combo[2], partial=True
-            )
-            if cres:
-                for cre in cres:
-                    results[cre.id] = cre
+        for search_term in search_terms:
+            args = [f"%{search_term}%", "", "", "", "", ""]
+            s = set([p for p in permutations(args, 6)])
+            for combo in s:
+                nodes = self.get_nodes(
+                    name=combo[0],
+                    section=combo[1],
+                    subsection=combo[2],
+                    link=combo[3],
+                    description=combo[4],
+                    partial=True,
+                    ntype=None,  # type: ignore
+                    sectionID=combo[5],
+                )
+                if nodes:
+                    for node in nodes:
+                        node_key = f"{node.name}:{node.version}:{node.section}:{node.sectionID}:{node.subsection}:"
+                        results[node_key] = node
+            args = [f"%{search_term}%", None, None]
+            for combo in permutations(args, 3):
+                cres = self.get_CREs(
+                    name=combo[0],
+                    external_id=combo[1],
+                    description=combo[2],
+                    partial=True,
+                )
+                if cres:
+                    for cre in cres:
+                        results[cre.id] = cre
         return list(results.values())
+
+    def _expand_text_search_aliases(self, text: str) -> List[str]:
+        normalized = text.strip()
+        lowered = normalized.lower()
+        aliases = {
+            "xxe": [
+                "XXE",
+                "XML External Entity",
+                "XML External Entity Reference",
+            ],
+            "xss": [
+                "XSS",
+                "Cross Site Scripting",
+                "Cross-Site Scripting",
+            ],
+            "ssrf": [
+                "SSRF",
+                "Server Side Request Forgery",
+                "Server-Side Request Forgery",
+            ],
+            "csrf": [
+                "CSRF",
+                "Cross Site Request Forgery",
+                "Cross-Site Request Forgery",
+            ],
+            "rce": [
+                "RCE",
+                "Remote Code Execution",
+            ],
+        }
+        expanded = [normalized]
+        expanded.extend(aliases.get(lowered, []))
+
+        deduped = []
+        seen = set()
+        for entry in expanded:
+            key = entry.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(entry)
+        return deduped
 
     def get_root_cres(self):
         """Returns CRES that only have "Contains" links"""

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -2163,6 +2163,9 @@ class Node_collection:
            Anything else will be a case insensitive LIKE query in the database
         """
         search_terms = self._expand_text_search_aliases(text)
+        if not search_terms:
+            return []
+        text = text.strip()
         # structured text search first
         cre_id_search = r"CRE(:| )(?P<id>\d+-\d+)"
         cre_naked_id_search = r"\d\d\d-\d\d\d"

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import aliased
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy import func, delete, cast as sql_cast, literal, or_
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import OperationalError, IntegrityError
+from sqlalchemy.exc import OperationalError, IntegrityError, SQLAlchemyError
 
 from neomodel import (
     config,
@@ -2337,12 +2337,12 @@ class Node_collection:
                 "db_reachable": False,
                 "reason": "database unreachable",
             }
-        except Exception:  # pragma: no cover - defensive, never fail open
-            return {
-                "ok": False,
-                "db_reachable": False,
-                "reason": "database health query failed",
-            }
+        except SQLAlchemyError:  # pragma: no cover - defensive, never fail open
+             return {
+                 "ok": False,
+                 "db_reachable": False,
+                 "reason": "database health query failed",
+             }
 
         if cre_count == 0 or standards_count == 0:
             return {

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -2338,11 +2338,11 @@ class Node_collection:
                 "reason": "database unreachable",
             }
         except SQLAlchemyError:  # pragma: no cover - defensive, never fail open
-             return {
-                 "ok": False,
-                 "db_reachable": False,
-                 "reason": "database health query failed",
-             }
+            return {
+                "ok": False,
+                "db_reachable": False,
+                "reason": "database health query failed",
+            }
 
         if cre_count == 0 or standards_count == 0:
             return {

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -2248,6 +2248,8 @@ class Node_collection:
 
     def _expand_text_search_aliases(self, text: str) -> List[str]:
         normalized = text.strip()
+        if not normalized:
+            return []
         lowered = normalized.lower()
         aliases = {
             "xxe": [
@@ -2277,7 +2279,6 @@ class Node_collection:
         }
         expanded = [normalized]
         expanded.extend(aliases.get(lowered, []))
-
         deduped = []
         seen = set()
         for entry in expanded:

--- a/application/tests/cwe_parser_test.py
+++ b/application/tests/cwe_parser_test.py
@@ -258,6 +258,14 @@ class TestCWEParser(unittest.TestCase):
             imported_cwes["384"].links[0].document.todict(),
             session_management_cre.todict(),
         )
+        self.assertEqual(
+            imported_cwes["614"].links[0].document.todict(),
+            secure_cookie_cre.todict(),
+        )
+        self.assertEqual(
+            imported_cwes["502"].links[0].document.todict(),
+            deserialization_cre.todict(),
+        )
 
     @patch.object(requests, "get")
     def test_register_CWE_skips_prohibited_entries(self, mock_requests) -> None:

--- a/application/tests/cwe_parser_test.py
+++ b/application/tests/cwe_parser_test.py
@@ -258,14 +258,32 @@ class TestCWEParser(unittest.TestCase):
             imported_cwes["384"].links[0].document.todict(),
             session_management_cre.todict(),
         )
-        self.assertEqual(
-            imported_cwes["614"].links[0].document.todict(),
-            secure_cookie_cre.todict(),
+
+    @patch.object(requests, "get")
+    def test_register_CWE_skips_prohibited_entries(self, mock_requests) -> None:
+        tmpdir = mkdtemp()
+        tmpFile = os.path.join(tmpdir, "cwe.xml")
+        tmpzip = os.path.join(tmpdir, "cwe.zip")
+        with open(tmpFile, "w") as cx:
+            cx.write(self.CWE_prohibited_xml)
+        with zipfile.ZipFile(tmpzip, "w", zipfile.ZIP_DEFLATED) as zipf:
+            zipf.write(tmpFile, arcname="cwe.xml")
+
+        class fakeRequest:
+            def iter_content(self, chunk_size=None):
+                with open(tmpzip, "rb") as zipf:
+                    return [zipf.read()]
+
+        mock_requests.return_value = fakeRequest()
+
+        entries = cwe.CWE().parse(
+            cache=self.collection,
+            ph=prompt_client.PromptHandler(database=self.collection),
         )
-        self.assertEqual(
-            imported_cwes["502"].links[0].document.todict(),
-            deserialization_cre.todict(),
-        )
+        imported_cwes = {node.sectionID: node for node in entries.results["CWE"]}
+
+        self.assertIn("611", imported_cwes)
+        self.assertNotIn("9999", imported_cwes)
 
     CWE_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <Weakness_Catalog Name="CWE" Version="4.10" Date="2023-01-31" xmlns="http://cwe.mitre.org/cwe-6"
@@ -736,6 +754,19 @@ class TestCWEParser(unittest.TestCase):
       </Weakness>
       <Weakness ID="918" Name="Server-Side Request Forgery (SSRF)" Abstraction="Base" Structure="Simple" Status="Draft">
          <Description>SSRF entry.</Description>
+      </Weakness>
+   </Weaknesses>
+</Weakness_Catalog>
+"""
+
+    CWE_prohibited_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<Weakness_Catalog Name="CWE" Version="4.10" Date="2023-01-31" xmlns="http://cwe.mitre.org/cwe-6">
+   <Weaknesses>
+      <Weakness ID="611" Name="Improper Restriction of XML External Entity Reference" Abstraction="Base" Structure="Simple" Status="Draft">
+         <Description>Allowed XXE entry.</Description>
+      </Weakness>
+      <Weakness ID="9999" Name="Prohibited Example" Abstraction="Base" Structure="Simple" Status="PROHIBITED">
+         <Description>This entry should not be imported.</Description>
       </Weakness>
    </Weaknesses>
 </Weakness_Catalog>

--- a/application/tests/db_test.py
+++ b/application/tests/db_test.py
@@ -1054,6 +1054,33 @@ class TestDB(unittest.TestCase):
             res = self.collection.text_search(k)
             self.assertCountEqual(res, val)
 
+    def test_text_search_expands_xxe_aliases(self) -> None:
+        xxe_cre = defs.CRE(
+            id="764-507",
+            name="Restrict XML parsing (against XXE)",
+        )
+        cwe_611 = defs.Standard(
+            name="CWE",
+            section="Improper Restriction of XML External Entity Reference",
+            sectionID="611",
+            hyperlink="https://cwe.mitre.org/data/definitions/611.html",
+        )
+
+        self.collection.add_cre(xxe_cre)
+        self.collection.add_node(cwe_611)
+
+        results = self.collection.text_search("XXE")
+
+        self.assertIn("764-507", [doc.id for doc in results if doc.doctype == "CRE"])
+        self.assertTrue(
+            any(
+                doc.doctype == "Standard"
+                and doc.name == "CWE"
+                and doc.sectionID == "611"
+                for doc in results
+            )
+        )
+
     def test_dbNodeFromNode(self) -> None:
         data = {
             "tool": defs.Tool(

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -24,7 +24,7 @@ logger.setLevel(logging.INFO)
 class CWE(ParserInterface):
     name = "CWE"
     cwe_zip = "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip"
-    allowed_statuses = frozenset({"Stable", "Incomplete", "Draft"})    
+    allowed_statuses = frozenset({"Stable", "Incomplete", "Draft"})
     fallback_mapping_path = (
         Path(__file__).resolve().parent.parent / "data" / "cwe_fallback_mappings.json"
     )

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -24,6 +24,7 @@ logger.setLevel(logging.INFO)
 class CWE(ParserInterface):
     name = "CWE"
     cwe_zip = "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip"
+    allowed_statuses = {"Stable", "Incomplete", "Draft"}
     fallback_mapping_path = (
         Path(__file__).resolve().parent.parent / "data" / "cwe_fallback_mappings.json"
     )
@@ -180,12 +181,7 @@ class CWE(ParserInterface):
             for weakness in weaknesses:
                 statuses[weakness["@Status"]] = 1
                 cwe = None
-                if weakness["@Status"] in [
-                    "Stable",
-                    "Incomplete",
-                    "Draft",
-                    "PROHIBITED",
-                ]:
+                if weakness["@Status"] in self.allowed_statuses:
                     cwes = cache.get_nodes(self.name, sectionID=weakness["@ID"])
                     if cwes:  # update the CWE in the database
                         cwe = cwes[0]

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -24,7 +24,7 @@ logger.setLevel(logging.INFO)
 class CWE(ParserInterface):
     name = "CWE"
     cwe_zip = "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip"
-    allowed_statuses = {"Stable", "Incomplete", "Draft"}
+    allowed_statuses = frozenset({"Stable", "Incomplete", "Draft"})    
     fallback_mapping_path = (
         Path(__file__).resolve().parent.parent / "data" / "cwe_fallback_mappings.json"
     )

--- a/scripts/update-cwe.sh
+++ b/scripts/update-cwe.sh
@@ -29,4 +29,5 @@ export CRE_NO_NEO4J="${CRE_NO_NEO4J:-1}"
 export CRE_NO_GEN_EMBEDDINGS="${CRE_NO_GEN_EMBEDDINGS:-1}"
 
 echo "Importing latest MITRE CWE data into $CACHE_FILE"
+echo "CWE parser will import only allowed statuses and skip PROHIBITED entries"
 exec python "$ROOT_DIR/cre.py" --cwe_in --cache_file "$CACHE_FILE"


### PR DESCRIPTION
This PR builds on the earlier CWE mapping work (PR #823 ) and addresses two gaps found during local verification after the previous merge.

Problem:
Searching for terms like 'XXE' did not reliably surface the expected top-level CWE result, even when the corresponding CWE data existed locally. This created a mismatch between the intended curated CWE import behavior and actual API/UI discoverability.

Solution:
- Expand text-search aliases to include common security shorthand terms (e.g., XXE), ensuring related CWE and CRE records surface correctly.
- Strengthen CWE import filtering to consistently exclude prohibited entries.

Scope:
- CWE import filtering logic
- Search alias expansion for XXE and related terms
- Unit tests covering prohibited CWE exclusion and XXE search behavior
- Script messaging update for the CWE refresh workflow

Testing:
```
./venv/bin/python -m pytest application/tests/cwe_parser_test.py -k 'register_CWE or prohibited' -q 
```

```
./venv/bin/python -m pytest application/tests/db_test.py -k 'text_search' -q
```

Follows-up: #823 
References: #472 