### PR TITLE
Fix: Narrow except Exception to except SQLAlchemyError in health_check()

### DIFF
--- a/application/database/db.py
+++ b/application/database/db.py
@@ -2290,11 +2290,11 @@ class Node_collection:
                 "reason": "database unreachable",
             }
         except SQLAlchemyError:  # pragma: no cover - defensive, never fail open
-             return {
-                 "ok": False,
-                 "db_reachable": False,
-                 "reason": "database health query failed",
-             }
+            return {
+                "ok": False,
+                "db_reachable": False,
+                "reason": "database health query failed",
+            }
 
         if cre_count == 0 or standards_count == 0:
             return {

--- a/application/database/db.py
+++ b/application/database/db.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import aliased
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy import func, delete, cast as sql_cast, literal, or_
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import OperationalError, IntegrityError
+from sqlalchemy.exc import OperationalError, IntegrityError, SQLAlchemyError
 
 from neomodel import (
     config,
@@ -2289,12 +2289,12 @@ class Node_collection:
                 "db_reachable": False,
                 "reason": "database unreachable",
             }
-        except Exception:  # pragma: no cover - defensive, never fail open
-            return {
-                "ok": False,
-                "db_reachable": False,
-                "reason": "database health query failed",
-            }
+        except SQLAlchemyError:  # pragma: no cover - defensive, never fail open
+             return {
+                 "ok": False,
+                 "db_reachable": False,
+                 "reason": "database health query failed",
+             }
 
         if cre_count == 0 or standards_count == 0:
             return {


### PR DESCRIPTION
## Summary
Fixes overly broad exception handling in `Node_collection.health_check()` by replacing `except Exception` with `except SQLAlchemyError`.

Closes #940

## Problem
The `health_check()` method in `application/database/db.py` currently uses a generic `except Exception` as a fallback after catching `OperationalError`:

```python
except OperationalError:
    return {"ok": False, "db_reachable": False, "reason": "database unreachable"}
except Exception:  # pragma: no cover - defensive, never fail open
    return {"ok": False, "db_reachable": False, "reason": "database health query failed"}
```

This broad catch silently swallows programming bugs such as AttributeError, TypeError, or NameError within the health check logic itself. Instead of propagating the error (which would reveal the bug), it returns a structured {"ok": False} response, making such issues very hard to detect.

## Solution
- Add `SQLAlchemyError` to the import from `sqlalchemy.exc`

- Replace `except Exception:` with `except SQLAlchemyError:`.

Since OperationalError is a subclass of SQLAlchemyError and is caught first, the new clause only handles remaining SQLAlchemy-level errors.

## Changes
File: `application/database/db.py`

Change 1 – Import (line ~26):

```diff
- from sqlalchemy.exc import OperationalError, IntegrityError
+ from sqlalchemy.exc import OperationalError, IntegrityError, SQLAlchemyError
```
Change 2 – Exception handler (lines ~2292–2296):

```diff
- except Exception:  # pragma: no cover - defensive, never fail open
+ except SQLAlchemyError:
      return {
          "ok": False,
          "db_reachable": False,
          "reason": "database health query failed",
      }
```

## Behavioral Change
⚠️ Important: Non-SQLAlchemy exceptions (e.g., programming bugs) will now propagate naturally rather than being swallowed. This is intentional — bugs should surface during development/testing, not be hidden behind a structured health-check response.

In production, this means:

Before: Any unexpected error → `{"ok": False, ...}` (bug hidden)

After: SQLAlchemy errors → `{"ok": False, ...}`; programming bugs → HTTP 500 with stack trace (bug visible)

## Related Issue
Closes #940