### PR TITLE
test: smartlink critical edge-case regression tests (#945)

### DIFF
--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -634,6 +634,87 @@ class TestMain(unittest.TestCase):
             )
             self.assertEqual(302, response.status_code)
 
+    def _smartlink_redirect_location(self, client, path: str) -> tuple[int, str]:
+        response = client.get(path, headers={"Content-Type": "application/json"})
+        location = ""
+        for head in response.headers:
+            if head[0] == "Location":
+                location = head[1]
+        return response.status_code, location
+
+    def test_smartlink_critical_edge_cases(self) -> None:
+        """Critical smartlink paths from #945 — multi-CRE, unlinked node, ntype, version."""
+        collection = db.Node_collection().with_graph()
+        with self.app.test_client() as client:
+            # Multiple CREs → standard-section node page (preserved by #938).
+            cwe_multi = defs.Standard(name="CWEmulti", sectionID="789")
+            ce = defs.CRE(id="444-444", description="CE", name="CE", tags=[])
+            cf = defs.CRE(id="555-555", description="CF", name="CF", tags=[])
+            dcwe_multi = collection.add_node(cwe_multi)
+            dce = collection.add_cre(ce)
+            dcf = collection.add_cre(cf)
+            collection.add_link(dce, dcwe_multi, ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcf, dcwe_multi, ltype=defs.LinkTypes.LinkedTo)
+
+            status, location = self._smartlink_redirect_location(
+                client, "/smartlink/standard/CWEmulti/789"
+            )
+            self.assertEqual(status, 302)
+            self.assertEqual(location, "/node/standard/CWEmulti/sectionid/789")
+
+            # Local standard with no CRE links → MITRE external redirect, not node page.
+            orphan = defs.Standard(name="CWE", sectionID="8888")
+            collection.add_node(orphan)
+            status, location = self._smartlink_redirect_location(
+                client, "/smartlink/standard/CWE/8888"
+            )
+            self.assertEqual(status, 302)
+            self.assertEqual(
+                location, "https://cwe.mitre.org/data/definitions/8888.html"
+            )
+
+            # Case-insensitive ntype still resolves the standard node.
+            cwe_std = defs.Standard(name="CWE", sectionID="456")
+            cre_a = defs.CRE(id="222-222", description="CD", name="CD", tags=[])
+            cre_b = defs.CRE(id="223-223", description="CE", name="CE", tags=[])
+            dcwe = collection.add_node(cwe_std)
+            dcre_a = collection.add_cre(cre_a)
+            dcre_b = collection.add_cre(cre_b)
+            collection.add_link(dcre_a, dcwe, ltype=defs.LinkTypes.LinkedTo)
+            collection.add_link(dcre_b, dcwe, ltype=defs.LinkTypes.LinkedTo)
+
+            status, location = self._smartlink_redirect_location(
+                client, "/smartlink/STANDARD/CWE/456"
+            )
+            self.assertEqual(status, 302)
+            self.assertEqual(location, "/node/STANDARD/CWE/sectionid/456")
+
+            # version query param selects the matching standard row (multi-CRE → node page).
+            std_v1 = defs.Standard(name="VERSTD", sectionID="100", version="1.0")
+            std_v2 = defs.Standard(name="VERSTD", sectionID="200", version="2.0")
+            cre_v1a = defs.CRE(id="100-100", description="v1a", name="V1A", tags=[])
+            cre_v1b = defs.CRE(id="100-101", description="v1b", name="V1B", tags=[])
+            cre_v2a = defs.CRE(id="200-200", description="v2a", name="V2A", tags=[])
+            cre_v2b = defs.CRE(id="200-201", description="v2b", name="V2B", tags=[])
+            dstd_v1 = collection.add_node(std_v1)
+            dstd_v2 = collection.add_node(std_v2)
+            for cre in (cre_v1a, cre_v1b, cre_v2a, cre_v2b):
+                dcre = collection.add_cre(cre)
+                target = dstd_v1 if cre.id.startswith("100") else dstd_v2
+                collection.add_link(dcre, target, ltype=defs.LinkTypes.LinkedTo)
+
+            status, location = self._smartlink_redirect_location(
+                client, "/smartlink/standard/VERSTD/100?version=1.0"
+            )
+            self.assertEqual(status, 302)
+            self.assertEqual(location, "/node/standard/VERSTD/sectionid/100")
+
+            status, location = self._smartlink_redirect_location(
+                client, "/smartlink/standard/VERSTD/200?version=2.0"
+            )
+            self.assertEqual(status, 302)
+            self.assertEqual(location, "/node/standard/VERSTD/sectionid/200")
+
     @patch.object(redis, "from_url")
     @patch.object(db, "Node_collection")
     def test_gap_analysis_from_cache_full_response(


### PR DESCRIPTION
## Summary

Adds `test_smartlink_critical_edge_cases` for [#945](https://github.com/OWASP/OpenCRE/issues/945), locking in critical smartlink behaviour ahead of / alongside [#938](https://github.com/OWASP/OpenCRE/pull/938) (#486).

**New coverage:**
- **Multi-CRE** → standard-section node page (unchanged when #938 lands)
- **Unlinked local standard** (no CRE links) → MITRE external redirect, not node page
- **Case-insensitive `ntype`** (`STANDARD` vs `standard`)
- **`?version=`** query param selects the correct standard row

Multi-CRE setups are used where needed so assertions remain valid after #938’s single-CRE direct redirect.

## Test plan

- [x] `python -m unittest application.tests.web_main_test.TestMain.test_smartlink_critical_edge_cases`

Made with [Cursor](https://cursor.com)