### PR TITLE
GSoC 2026 Module B — Week 3: Stage 2 LLM relevance classifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,16 +51,9 @@ VERTEX_EMBED_CONTENT_MODEL=gemini-embedding-001
 
 # Noise / Relevance Filter (Module B)
 
-# Dedicated cheap classification model for the Stage 2 gate. Decoupled from
-# CRE_LLM_CHAT_MODEL on purpose: Module B runs on every harvested commit and
-# must stay cheap. LiteLLM reads the provider key (GEMINI_API_KEY above)
-# automatically for gemini/* models.
 CRE_NOISE_FILTER_LLM_MODEL=gemini/gemini-2.5-flash-lite
-# Chunks per LLM request (cost/latency vs prompt-size tradeoff).
 CRE_NOISE_FILTER_BATCH_SIZE=10
-# Per-chunk character cap before sending to the LLM (longer chunks truncated).
 CRE_NOISE_FILTER_MAX_CHARS=1500
-# Minimum confidence for a KNOWLEDGE verdict to be enqueued (used from Week 4+).
 CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD=0.8
 
 # Spreadsheet Auth

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,20 @@ GEMINI_API_KEY=your-gemini-api-key
 VERTEX_CHAT_MODEL=gemini-2.5-flash
 VERTEX_EMBED_CONTENT_MODEL=gemini-embedding-001
 
+# Noise / Relevance Filter (Module B)
+
+# Dedicated cheap classification model for the Stage 2 gate. Decoupled from
+# CRE_LLM_CHAT_MODEL on purpose: Module B runs on every harvested commit and
+# must stay cheap. LiteLLM reads the provider key (GEMINI_API_KEY above)
+# automatically for gemini/* models.
+CRE_NOISE_FILTER_LLM_MODEL=gemini/gemini-2.5-flash-lite
+# Chunks per LLM request (cost/latency vs prompt-size tradeoff).
+CRE_NOISE_FILTER_BATCH_SIZE=10
+# Per-chunk character cap before sending to the LLM (longer chunks truncated).
+CRE_NOISE_FILTER_MAX_CHARS=1500
+# Minimum confidence for a KNOWLEDGE verdict to be enqueued (used from Week 4+).
+CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD=0.8
+
 # Spreadsheet Auth
 
 OpenCRE_gspread_Auth=path/to/credentials.json

--- a/application/tests/noise_filter/config_loader_test.py
+++ b/application/tests/noise_filter/config_loader_test.py
@@ -1,0 +1,83 @@
+"""Tests for application.utils.noise_filter.config_loader.
+
+Uses unittest to match the project-wide discovery pattern. Covers defaults,
+environment overrides, and the NoiseFilterConfig invariants enforced in
+__post_init__ (so every construction path -- not just load_config -- fails
+fast on bad settings).
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from application.utils.noise_filter.config_loader import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_CONFIDENCE_THRESHOLD,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_MAX_CHARS,
+    NoiseFilterConfig,
+    load_config,
+)
+
+_ENV_KEYS = (
+    "CRE_NOISE_FILTER_LLM_MODEL",
+    "CRE_NOISE_FILTER_BATCH_SIZE",
+    "CRE_NOISE_FILTER_MAX_CHARS",
+    "CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD",
+)
+
+
+class LoadConfigTests(unittest.TestCase):
+
+    def test_defaults_when_env_unset(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            for k in _ENV_KEYS:
+                os.environ.pop(k, None)
+            cfg = load_config()
+        self.assertEqual(cfg.llm_model, DEFAULT_LLM_MODEL)
+        self.assertEqual(cfg.batch_size, DEFAULT_BATCH_SIZE)
+        self.assertEqual(cfg.max_chars, DEFAULT_MAX_CHARS)
+        self.assertEqual(cfg.confidence_threshold, DEFAULT_CONFIDENCE_THRESHOLD)
+
+    def test_env_overrides_applied(self) -> None:
+        overrides = {
+            "CRE_NOISE_FILTER_LLM_MODEL": "openai/gpt-4o-mini",
+            "CRE_NOISE_FILTER_BATCH_SIZE": "5",
+            "CRE_NOISE_FILTER_MAX_CHARS": "800",
+            "CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD": "0.6",
+        }
+        with patch.dict(os.environ, overrides):
+            cfg = load_config()
+        self.assertEqual(cfg.llm_model, "openai/gpt-4o-mini")
+        self.assertEqual(cfg.batch_size, 5)
+        self.assertEqual(cfg.max_chars, 800)
+        self.assertEqual(cfg.confidence_threshold, 0.6)
+
+
+class InvariantTests(unittest.TestCase):
+
+    def test_valid_config_constructs(self) -> None:
+        cfg = NoiseFilterConfig(batch_size=1, max_chars=1, confidence_threshold=0.0)
+        self.assertEqual(cfg.batch_size, 1)
+
+    def test_batch_size_below_one_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            NoiseFilterConfig(batch_size=0)
+
+    def test_max_chars_below_one_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            NoiseFilterConfig(max_chars=0)
+
+    def test_confidence_above_one_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            NoiseFilterConfig(confidence_threshold=1.5)
+
+    def test_confidence_below_zero_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            NoiseFilterConfig(confidence_threshold=-0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/noise_filter/llm_classifier_test.py
+++ b/application/tests/noise_filter/llm_classifier_test.py
@@ -233,6 +233,22 @@ class FallbackTests(unittest.TestCase):
         self.assertEqual(out[0].label, "KNOWLEDGE")
         self.assertEqual(formats, ["json_schema", "json_object"])
 
+    def test_non_capability_error_does_not_fall_back(self) -> None:
+        """A non-schema error must propagate, not trigger a json_object retry."""
+        clf = _classifier()
+        formats = []
+
+        def completion(**kw):
+            formats.append(kw["response_format"]["type"])
+            raise ValueError("authentication token invalid")  # not a capability gap
+
+        clf._litellm = Mock(completion=completion)
+        out = clf.classify_batch([_record()])
+        # No fallback attempt; the error surfaces as a failed batch.
+        self.assertEqual(formats, ["json_schema"])
+        self.assertEqual(out[0].label, "UNCERTAIN")
+        self.assertEqual(out[0].reasoning, "llm_call_failed")
+
 
 # --- Rate-limit retry -----------------------------------------------------
 

--- a/application/tests/noise_filter/llm_classifier_test.py
+++ b/application/tests/noise_filter/llm_classifier_test.py
@@ -1,0 +1,305 @@
+"""Tests for application.utils.noise_filter.llm_classifier.
+
+Uses unittest (project-wide discovery pattern). The LLM is fully mocked --
+no network calls. We swap LLMClassifier._litellm with a Mock and assert on
+the messages it receives and how responses are parsed back into verdicts.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from application.utils.noise_filter.config_loader import NoiseFilterConfig
+from application.utils.noise_filter.llm_classifier import LLMClassifier
+from application.utils.noise_filter.prompts import (
+    FEW_SHOT_EXAMPLES,
+    SYSTEM_PROMPT_WITH_EXAMPLES,
+)
+from application.utils.noise_filter.schemas import ChangeRecord
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _record(text: str = "some security text", heading_path=None) -> ChangeRecord:
+    return ChangeRecord.model_validate(
+        {
+            "schema_version": "0.2.0",
+            "chunk_id": "chk:test",
+            "artifact_id": "art:test",
+            "pipeline_run_id": "20260618T000000Z",
+            "text": text,
+            "span": {"index": 0, "total": 1, "heading_path": heading_path or []},
+            "source": {
+                "type": "github",
+                "repo": "OWASP/test",
+                "commit_sha": "abc123",
+                "committed_at": "2026-06-18T00:00:00Z",
+            },
+            "locator": {"kind": "repo_path", "id": "p.md", "path": "p.md"},
+        }
+    )
+
+
+def _resp(content) -> SimpleNamespace:
+    """A LiteLLM-shaped response wrapping `content` (str or dict)."""
+    text = content if isinstance(content, str) else json.dumps(content)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+    )
+
+
+def _classifier(batch_size: int = 10, max_chars: int = 1500) -> LLMClassifier:
+    clf = LLMClassifier(NoiseFilterConfig(batch_size=batch_size, max_chars=max_chars))
+    clf._retry_sleep_seconds = 0
+    return clf
+
+
+# --- Prompt content -------------------------------------------------------
+
+
+class PromptContentTests(unittest.TestCase):
+
+    def test_system_prompt_states_recall_first_rule(self) -> None:
+        for needle in (
+            "KNOWLEDGE",
+            "NOISE",
+            "UNCERTAIN",
+            "When in doubt",
+            "Recall matters more than precision",
+        ):
+            self.assertIn(needle, SYSTEM_PROMPT_WITH_EXAMPLES)
+
+    def test_all_few_shot_examples_embedded(self) -> None:
+        for ex in FEW_SHOT_EXAMPLES:
+            # First line of each example (newline-free, so it survives the
+            # JSON encoding the prompt applies) should appear verbatim.
+            needle = ex["text"].split("\n", 1)[0][:40]
+            self.assertIn(needle, SYSTEM_PROMPT_WITH_EXAMPLES)
+
+    def test_few_shot_label_distribution(self) -> None:
+        labels = [e["label"] for e in FEW_SHOT_EXAMPLES]
+        self.assertEqual(labels.count("KNOWLEDGE"), 5)
+        self.assertEqual(labels.count("NOISE"), 3)
+        self.assertEqual(labels.count("UNCERTAIN"), 2)
+
+
+# --- Batch ordering / splitting -------------------------------------------
+
+
+class BatchOrderingTests(unittest.TestCase):
+
+    def test_out_of_order_results_mapped_by_index(self) -> None:
+        clf = _classifier(batch_size=3)
+        clf._litellm = Mock(
+            completion=lambda **kw: _resp(
+                {
+                    "results": [
+                        {
+                            "index": 2,
+                            "label": "UNCERTAIN",
+                            "confidence": 0.5,
+                            "reasoning": "c",
+                        },
+                        {
+                            "index": 0,
+                            "label": "KNOWLEDGE",
+                            "confidence": 0.9,
+                            "reasoning": "a",
+                        },
+                        {
+                            "index": 1,
+                            "label": "NOISE",
+                            "confidence": 0.8,
+                            "reasoning": "b",
+                        },
+                    ]
+                }
+            )
+        )
+        out = clf.classify_batch([_record(), _record(), _record()])
+        self.assertEqual([v.label for v in out], ["KNOWLEDGE", "NOISE", "UNCERTAIN"])
+
+    def test_batches_split_by_size(self) -> None:
+        clf = _classifier(batch_size=2)
+        calls = []
+
+        def completion(**kw):
+            calls.append(kw)
+            n = kw["messages"][1]["content"].count('"index"')
+            return _resp(
+                {
+                    "results": [
+                        {
+                            "index": i,
+                            "label": "KNOWLEDGE",
+                            "confidence": 0.9,
+                            "reasoning": "x",
+                        }
+                        for i in range(n)
+                    ]
+                }
+            )
+
+        clf._litellm = Mock(completion=completion)
+        out = clf.classify_batch([_record() for _ in range(5)])
+        self.assertEqual(len(out), 5)
+        self.assertEqual(len(calls), 3)  # 2 + 2 + 1
+        self.assertTrue(all(v.label == "KNOWLEDGE" for v in out))
+
+
+# --- Malformed output -----------------------------------------------------
+
+
+class MalformedOutputTests(unittest.TestCase):
+
+    def _single(self, content):
+        clf = _classifier()
+        clf._litellm = Mock(completion=lambda **kw: _resp(content))
+        return clf.classify_batch([_record()])[0]
+
+    def test_non_json_marks_uncertain(self) -> None:
+        v = self._single("not json at all")
+        self.assertEqual(
+            (v.label, v.confidence, v.reasoning),
+            ("UNCERTAIN", 0.0, "malformed_output"),
+        )
+
+    def test_missing_entry_marks_uncertain(self) -> None:
+        v = self._single({"results": []})
+        self.assertEqual((v.label, v.confidence), ("UNCERTAIN", 0.0))
+
+    def test_invalid_label_marks_uncertain(self) -> None:
+        v = self._single(
+            {
+                "results": [
+                    {"index": 0, "label": "SPAM", "confidence": 0.9, "reasoning": "x"}
+                ]
+            }
+        )
+        self.assertEqual((v.label, v.confidence), ("UNCERTAIN", 0.0))
+
+    def test_out_of_range_confidence_marks_uncertain(self) -> None:
+        v = self._single(
+            {
+                "results": [
+                    {
+                        "index": 0,
+                        "label": "KNOWLEDGE",
+                        "confidence": 9.9,
+                        "reasoning": "x",
+                    }
+                ]
+            }
+        )
+        self.assertEqual((v.label, v.confidence), ("UNCERTAIN", 0.0))
+
+    def test_empty_content_marks_uncertain(self) -> None:
+        v = self._single("")
+        self.assertEqual((v.label, v.confidence), ("UNCERTAIN", 0.0))
+
+
+# --- Strict-schema -> json_object fallback --------------------------------
+
+
+class FallbackTests(unittest.TestCase):
+
+    def test_strict_failure_falls_back_to_json_object(self) -> None:
+        clf = _classifier()
+        formats = []
+
+        def completion(**kw):
+            formats.append(kw["response_format"]["type"])
+            if kw["response_format"]["type"] == "json_schema":
+                raise ValueError("provider does not support strict schema")
+            return _resp(
+                {
+                    "results": [
+                        {
+                            "index": 0,
+                            "label": "KNOWLEDGE",
+                            "confidence": 0.9,
+                            "reasoning": "x",
+                        }
+                    ]
+                }
+            )
+
+        clf._litellm = Mock(completion=completion)
+        out = clf.classify_batch([_record()])
+        self.assertEqual(out[0].label, "KNOWLEDGE")
+        self.assertEqual(formats, ["json_schema", "json_object"])
+
+
+# --- Rate-limit retry -----------------------------------------------------
+
+
+class RetryTests(unittest.TestCase):
+
+    def test_rate_limit_retried_then_succeeds(self) -> None:
+        clf = _classifier()
+        clf._max_retries = 2
+        ok = _resp(
+            {
+                "results": [
+                    {"index": 0, "label": "NOISE", "confidence": 0.9, "reasoning": "x"}
+                ]
+            }
+        )
+        clf._litellm = Mock(
+            completion=Mock(side_effect=[Exception("HTTP 429 too many requests"), ok])
+        )
+        with patch("application.utils.noise_filter.llm_classifier.time.sleep"):
+            out = clf.classify_batch([_record()])
+        self.assertEqual(out[0].label, "NOISE")
+        self.assertEqual(clf._litellm.completion.call_count, 2)
+
+    def test_rate_limit_exhausted_marks_batch_failed(self) -> None:
+        clf = _classifier()
+        clf._max_retries = 1
+        clf._litellm = Mock(
+            completion=Mock(side_effect=Exception("HTTP 429 too many requests"))
+        )
+        with patch("application.utils.noise_filter.llm_classifier.time.sleep"):
+            out = clf.classify_batch([_record(), _record()])
+        self.assertEqual([v.label for v in out], ["UNCERTAIN", "UNCERTAIN"])
+        self.assertEqual(
+            [v.reasoning for v in out], ["llm_call_failed", "llm_call_failed"]
+        )
+
+
+# --- Truncation -----------------------------------------------------------
+
+
+class TruncationTests(unittest.TestCase):
+
+    def test_long_text_is_truncated_before_send(self) -> None:
+        clf = _classifier(max_chars=50)
+        captured = {}
+
+        def completion(**kw):
+            captured["user"] = kw["messages"][1]["content"]
+            return _resp(
+                {
+                    "results": [
+                        {
+                            "index": 0,
+                            "label": "KNOWLEDGE",
+                            "confidence": 0.9,
+                            "reasoning": "x",
+                        }
+                    ]
+                }
+            )
+
+        clf._litellm = Mock(completion=completion)
+        clf.classify_batch([_record(text="A" * 500)])
+        self.assertIn("…[truncated]", captured["user"])
+        self.assertNotIn("A" * 100, captured["user"])  # full text not sent
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/utils/noise_filter/config_loader.py
+++ b/application/utils/noise_filter/config_loader.py
@@ -1,0 +1,65 @@
+"""Module B configuration loader.
+
+Reads the CRE_NOISE_FILTER_* environment variables into a typed, frozen
+NoiseFilterConfig. Mirrors the upstream convention (prompt_client.py reads
+CRE_* vars inline via os.environ) rather than threading Module B config
+through the Flask Config class -- Module B runs as a standalone CLI gate and
+does not depend on the Flask app config object.
+
+Retry tuning is intentionally NOT a Module B concern: the Stage 2 classifier
+reuses the upstream CRE_LLM_MAX_RETRIES / CRE_LLM_RETRY_SLEEP_SECONDS vars
+(read in llm_classifier.py) so noise filtering and the chatbot share one
+retry policy.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Cheap, dedicated classification model. Decoupled from CRE_LLM_CHAT_MODEL by
+# design: Module B is the cheap gate and must not pull in the chatbot's
+# heavier model.
+DEFAULT_LLM_MODEL = "gemini/gemini-2.5-flash-lite"
+DEFAULT_BATCH_SIZE = 10
+DEFAULT_MAX_CHARS = 1500
+DEFAULT_CONFIDENCE_THRESHOLD = 0.8
+
+
+@dataclass(frozen=True)
+class NoiseFilterConfig:
+    """Resolved Module B settings for the Stage 2 classifier."""
+
+    llm_model: str = DEFAULT_LLM_MODEL
+    batch_size: int = DEFAULT_BATCH_SIZE
+    max_chars: int = DEFAULT_MAX_CHARS
+    confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD
+
+
+def load_config() -> NoiseFilterConfig:
+    """Build a NoiseFilterConfig from the CRE_NOISE_FILTER_* environment."""
+    return NoiseFilterConfig(
+        llm_model=os.environ.get("CRE_NOISE_FILTER_LLM_MODEL", DEFAULT_LLM_MODEL),
+        batch_size=int(
+            os.environ.get("CRE_NOISE_FILTER_BATCH_SIZE", str(DEFAULT_BATCH_SIZE))
+        ),
+        max_chars=int(
+            os.environ.get("CRE_NOISE_FILTER_MAX_CHARS", str(DEFAULT_MAX_CHARS))
+        ),
+        confidence_threshold=float(
+            os.environ.get(
+                "CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD",
+                str(DEFAULT_CONFIDENCE_THRESHOLD),
+            )
+        ),
+    )
+
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_CONFIDENCE_THRESHOLD",
+    "DEFAULT_LLM_MODEL",
+    "DEFAULT_MAX_CHARS",
+    "NoiseFilterConfig",
+    "load_config",
+]

--- a/application/utils/noise_filter/config_loader.py
+++ b/application/utils/noise_filter/config_loader.py
@@ -35,6 +35,23 @@ class NoiseFilterConfig:
     max_chars: int = DEFAULT_MAX_CHARS
     confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD
 
+    def __post_init__(self) -> None:
+        """Fail fast on invalid settings, regardless of construction path.
+
+        Validated here (not only in load_config) so direct constructors --
+        e.g. tests -- get the same guarantees. batch_size in particular must
+        be >= 1: it becomes the step of range() when batching records.
+        """
+        if self.batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
+        if self.max_chars < 1:
+            raise ValueError(f"max_chars must be >= 1, got {self.max_chars}")
+        if not 0.0 <= self.confidence_threshold <= 1.0:
+            raise ValueError(
+                f"confidence_threshold must be in [0.0, 1.0], got "
+                f"{self.confidence_threshold}"
+            )
+
 
 def load_config() -> NoiseFilterConfig:
     """Build a NoiseFilterConfig from the CRE_NOISE_FILTER_* environment."""

--- a/application/utils/noise_filter/llm_classifier.py
+++ b/application/utils/noise_filter/llm_classifier.py
@@ -1,0 +1,215 @@
+"""Module B Stage 2: LLM relevance classifier (recall-first).
+
+Self-contained by design (decided 2026-06-18, Option B): this module talks to
+LiteLLM directly rather than wrapping PromptHandler, whose constructor is
+DB-coupled and whose retry/litellm members are private. We reuse the one
+shared, public piece -- llm_error_utils.is_rate_limit_error -- inside a small
+retry loop over the upstream CRE_LLM_MAX_RETRIES / CRE_LLM_RETRY_SLEEP_SECONDS
+vars, so noise filtering and the chatbot share one retry policy.
+
+The classifier uses a dedicated cheap model (config.llm_model, default
+gemini/gemini-2.5-flash-lite) and never falls back to CRE_LLM_CHAT_MODEL:
+Module B is the cheap gate and must stay decoupled from the chatbot's model.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any, Iterator
+
+from pydantic import ValidationError
+
+from application.prompt_client.llm_error_utils import is_rate_limit_error
+from application.utils.noise_filter.config_loader import NoiseFilterConfig
+from application.utils.noise_filter.prompts import (
+    SYSTEM_PROMPT_WITH_EXAMPLES,
+    build_user_prompt,
+)
+from application.utils.noise_filter.schemas import ChangeRecord, ClassifyResult
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_NAME = "noise_filter_classification"
+
+# Strict response schema (response_format). additionalProperties=False and all
+# keys required is what providers expect in strict json_schema mode.
+CLASSIFY_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "label": {
+                        "type": "string",
+                        "enum": ["KNOWLEDGE", "NOISE", "UNCERTAIN"],
+                    },
+                    "confidence": {"type": "number"},
+                    "reasoning": {"type": "string"},
+                },
+                "required": ["index", "label", "confidence", "reasoning"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["results"],
+    "additionalProperties": False,
+}
+
+_TRUNCATION_NOTE = " …[truncated]"
+
+
+def _uncertain(reason: str) -> ClassifyResult:
+    """Build the fallback verdict used when the LLM output can't be trusted."""
+    return ClassifyResult(label="UNCERTAIN", confidence=0.0, reasoning=reason)
+
+
+def _batches(seq: list[Any], size: int) -> Iterator[list[Any]]:
+    """Yield consecutive slices of `seq` of length `size` (last may be shorter)."""
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
+def _extract_text(resp: Any) -> str:
+    """Pull message content from a LiteLLM response (object or dict shaped)."""
+    try:
+        choices = resp.choices if hasattr(resp, "choices") else resp["choices"]
+        first = choices[0]
+        msg = first.message if hasattr(first, "message") else first["message"]
+        content = msg.content if hasattr(msg, "content") else msg["content"]
+        return content or ""
+    except (AttributeError, KeyError, IndexError, TypeError):
+        return ""
+
+
+class LLMClassifier:
+    """Stage 2 classifier: ChangeRecord -> ClassifyResult via a cheap LLM."""
+
+    def __init__(self, config: NoiseFilterConfig) -> None:
+        self.config = config
+        try:
+            import litellm  # type: ignore
+        except ImportError as e:
+            raise RuntimeError(
+                "litellm is required for the Module B Stage 2 classifier"
+            ) from e
+        self._litellm = litellm
+        self._max_retries = int(os.environ.get("CRE_LLM_MAX_RETRIES", "2"))
+        self._retry_sleep_seconds = int(
+            os.environ.get("CRE_LLM_RETRY_SLEEP_SECONDS", "15")
+        )
+
+    def classify_batch(self, records: list[ChangeRecord]) -> list[ClassifyResult]:
+        """Classify records, one verdict per record in input order.
+
+        Splits into config.batch_size groups; each group is one LLM call.
+        """
+        verdicts: list[ClassifyResult] = []
+        for batch in _batches(records, self.config.batch_size):
+            verdicts.extend(self._classify_one_batch(batch))
+        return verdicts
+
+    # --- internals --------------------------------------------------------
+
+    def _truncate(self, text: str) -> str:
+        limit = self.config.max_chars
+        if len(text) <= limit:
+            return text
+        return text[:limit] + _TRUNCATION_NOTE
+
+    def _classify_one_batch(self, batch: list[ChangeRecord]) -> list[ClassifyResult]:
+        items = [(rec.span.heading_path, self._truncate(rec.text)) for rec in batch]
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT_WITH_EXAMPLES},
+            {"role": "user", "content": build_user_prompt(items)},
+        ]
+        try:
+            text = self._call_llm(messages)
+        except Exception as e:  # noqa: BLE001 -- a bad batch must not kill the run
+            logger.warning(
+                "LLM classification failed for batch of %s: %s; marking UNCERTAIN",
+                len(batch),
+                e,
+            )
+            return [_uncertain("llm_call_failed") for _ in batch]
+        return self._parse(text, len(batch))
+
+    def _call_llm(self, messages: list[dict]) -> str:
+        strict_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": _SCHEMA_NAME,
+                "strict": True,
+                "schema": CLASSIFY_RESPONSE_SCHEMA,
+            },
+        }
+        try:
+            resp = self._completion_with_retry(
+                messages=messages, response_format=strict_format
+            )
+        except Exception as e:  # noqa: BLE001 -- provider may not support strict schema
+            logger.warning(
+                "strict json_schema mode failed for model=%s: %s; retrying json_object",
+                self.config.llm_model,
+                e,
+            )
+            resp = self._completion_with_retry(
+                messages=messages, response_format={"type": "json_object"}
+            )
+        return _extract_text(resp)
+
+    def _completion_with_retry(self, **kwargs: Any) -> Any:
+        for attempt in range(self._max_retries + 1):
+            try:
+                return self._litellm.completion(
+                    model=self.config.llm_model, temperature=0.0, **kwargs
+                )
+            except Exception as e:
+                if not is_rate_limit_error(e) or attempt >= self._max_retries:
+                    raise
+                logger.info(
+                    "rate/quota limited; sleeping %ss (attempt %s/%s)",
+                    self._retry_sleep_seconds,
+                    attempt + 1,
+                    self._max_retries + 1,
+                )
+                time.sleep(self._retry_sleep_seconds)
+        raise RuntimeError("unreachable: retry loop exited unexpectedly")
+
+    def _parse(self, text: str, n: int) -> list[ClassifyResult]:
+        verdicts = [_uncertain("malformed_output") for _ in range(n)]
+        try:
+            data = json.loads(text)
+            results = data.get("results", []) if isinstance(data, dict) else []
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("could not parse LLM JSON output; marking batch UNCERTAIN")
+            return verdicts
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            idx = item.get("index")
+            if not isinstance(idx, int) or not (0 <= idx < n):
+                continue
+            try:
+                verdicts[idx] = ClassifyResult.model_validate(
+                    {
+                        "label": item.get("label"),
+                        "confidence": item.get("confidence"),
+                        "reasoning": item.get("reasoning"),
+                    }
+                )
+            except ValidationError:
+                # leave this slot as the UNCERTAIN/malformed default
+                continue
+        return verdicts
+
+
+__all__ = [
+    "CLASSIFY_RESPONSE_SCHEMA",
+    "LLMClassifier",
+]

--- a/application/utils/noise_filter/llm_classifier.py
+++ b/application/utils/noise_filter/llm_classifier.py
@@ -87,6 +87,42 @@ def _extract_text(resp: Any) -> str:
         return ""
 
 
+def _is_schema_unsupported_error(err: Exception) -> bool:
+    """Best-effort: did the strict json_schema request fail *because the provider
+    doesn't support it* (vs. an auth/network/quota error)?
+
+    Only a capability gap should trigger the json_object fallback; every other
+    error must propagate so it isn't masked by a second attempt. LiteLLM surfaces
+    a provider's rejection of response_format/json_schema as a 400-class
+    BadRequestError whose message references the schema or response format.
+    """
+    # Rate-limit / quota errors have their own retry and must propagate if
+    # exhausted -- never treat them as a capability gap.
+    if is_rate_limit_error(err):
+        return False
+    msg = str(err).lower()
+    if any(
+        token in msg
+        for token in (
+            "response_format",
+            "response format",
+            "json_schema",
+            "json schema",
+            "schema",
+            "not supported",
+            "unsupported",
+            "does not support",
+        )
+    ):
+        return True
+    status = (
+        getattr(err, "status_code", None)
+        or getattr(err, "status", None)
+        or getattr(err, "code", None)
+    )
+    return status == 400
+
+
 class LLMClassifier:
     """Stage 2 classifier: ChangeRecord -> ClassifyResult via a cheap LLM."""
 
@@ -152,9 +188,16 @@ class LLMClassifier:
             resp = self._completion_with_retry(
                 messages=messages, response_format=strict_format
             )
-        except Exception as e:  # noqa: BLE001 -- provider may not support strict schema
+        except (
+            Exception
+        ) as e:  # noqa: BLE001 -- inspect; fall back only on a capability gap
+            if not _is_schema_unsupported_error(e):
+                # Auth/network/quota/etc. -- propagate; a json_object retry would
+                # only mask the real error.
+                raise
             logger.warning(
-                "strict json_schema mode failed for model=%s: %s; retrying json_object",
+                "strict json_schema unsupported for model=%s (%s); "
+                "retrying in json_object mode",
                 self.config.llm_model,
                 e,
             )

--- a/application/utils/noise_filter/prompts.py
+++ b/application/utils/noise_filter/prompts.py
@@ -1,0 +1,216 @@
+"""Module B Stage 2 prompt: recall-first security-knowledge classification.
+
+The system prompt pins the recall-first rule agreed with the maintainer
+(2026-06-01): bias hard toward KNOWLEDGE; NOISE is only for chunks with no
+security signal at all; UNCERTAIN is rare. NOISE rows are dropped before
+Module C, so a misclassified security chunk is lost forever while a
+misclassified noise chunk merely wastes downstream compute that Module C
+re-judges -- recall matters more than precision.
+
+The few-shot block deliberately includes the cases that were NOISE under the
+old novelty-first rule and are KNOWLEDGE under recall-first (clarifications,
+typo fixes, added examples/links inside security sections), so the model
+learns the bias from worked examples, not only the instruction.
+"""
+
+from __future__ import annotations
+
+import json
+
+SYSTEM_PROMPT = """You are classifying chunks of OWASP repository content for a \
+security-knowledge pipeline.
+
+Label each chunk as exactly one of:
+
+- KNOWLEDGE: ANY chunk with a security signal -- vulnerabilities, attack \
+vectors, testing methodology, mitigations, code samples, advisories, security \
+configurations, EVEN clarifications, typo fixes, expanded examples, \
+restatements of well-known material, added reference links, or restructured \
+security sections. When in doubt, choose KNOWLEDGE.
+- NOISE: ONLY chunks with no security signal at all -- sponsorship pages, \
+meeting notes, CI/build configuration, release tags, website layout, \
+contributor onboarding, project governance.
+- UNCERTAIN: only when genuinely 50/50 even after applying the bias above. \
+This label is rare.
+
+Recall matters more than precision: NOISE rows are dropped from the pipeline, \
+so a misclassified security chunk is lost forever, while a misclassified noise \
+chunk just wastes downstream compute that a later stage re-judges.
+
+Respond with a single JSON object of the form:
+{"results": [{"index": <int>, "label": "KNOWLEDGE"|"NOISE"|"UNCERTAIN", \
+"confidence": <float between 0.0 and 1.0>, "reasoning": "<one short sentence>"}]}
+Return exactly one result object per input chunk, with `index` matching the \
+chunk's number. Do not output any text outside the JSON object."""
+
+
+# Worked examples. `heading_path` + `text` are what the model sees per chunk;
+# label/confidence/reasoning are the expected verdict. Five KNOWLEDGE (including
+# the recall-first hard cases), three NOISE (strictly organizational), two
+# UNCERTAIN (genuine 50/50 anchors).
+FEW_SHOT_EXAMPLES = [
+    {
+        "heading_path": ["Testing for JWT", "Signature Bypass"],
+        "text": (
+            "A `kid` header pointing at a SQL-backed key store can be abused: "
+            "setting `kid` to `' UNION SELECT 'attacker-key' -- ` makes the "
+            "verifier return an attacker-controlled HMAC secret, so a forged "
+            "token validates."
+        ),
+        "label": "KNOWLEDGE",
+        "confidence": 0.99,
+        "reasoning": "Concrete JWT kid SQL-injection signature bypass.",
+    },
+    {
+        "heading_path": ["Cross-Site Request Forgery", "Defenses"],
+        "text": (
+            "Note: SameSite=Lax does not fully protect older browsers that "
+            "ignore the attribute; pair it with a synchronizer token for those "
+            "clients."
+        ),
+        "label": "KNOWLEDGE",
+        "confidence": 0.9,
+        "reasoning": "Clarification inside a CSRF defenses section -- still security content.",
+    },
+    {
+        "heading_path": ["OAuth", "Mitigation"],
+        "text": (
+            "Always validate the `redirect_uri` against an exact-match allowlist "
+            "to prevent authorization-code callback abuse."
+        ),
+        "label": "KNOWLEDGE",
+        "confidence": 0.92,
+        "reasoning": "Typo fix inside an OAuth mitigation -- the chunk content is security.",
+    },
+    {
+        "heading_path": ["Testing for SSRF"],
+        "text": (
+            "Example: `curl http://target/fetch?url=http://169.254.169.254/"
+            "latest/meta-data/` to confirm the cloud metadata endpoint is "
+            "reachable from the server."
+        ),
+        "label": "KNOWLEDGE",
+        "confidence": 0.95,
+        "reasoning": "Added curl example demonstrating SSRF testing methodology.",
+    },
+    {
+        "heading_path": ["Authentication Testing", "References"],
+        "text": (
+            "See also: PortSwigger Web Security Academy -- Authentication "
+            "vulnerabilities (https://portswigger.net/web-security/authentication)."
+        ),
+        "label": "KNOWLEDGE",
+        "confidence": 0.8,
+        "reasoning": "Reference link enriching a security testing section.",
+    },
+    {
+        "heading_path": ["Sponsors"],
+        "text": (
+            "Gold sponsors receive logo placement on the conference site and two "
+            "complimentary booth passes. Contact sponsorship@example.org."
+        ),
+        "label": "NOISE",
+        "confidence": 0.97,
+        "reasoning": "Pure sponsorship content, no security signal.",
+    },
+    {
+        "heading_path": ["Supporting Resources", "Meetings"],
+        "text": (
+            "Attendees: A. Smith, B. Jones, C. Lee. Topics discussed: agenda for "
+            "next quarter, budget review, schedule for the annual summit."
+        ),
+        "label": "NOISE",
+        "confidence": 0.96,
+        "reasoning": "Meeting notes; organizational, no security content.",
+    },
+    {
+        "heading_path": [],
+        "text": (
+            "name: release\non:\n  push:\n    tags: ['v*']\njobs:\n  build:\n"
+            "    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4"
+        ),
+        "label": "NOISE",
+        "confidence": 0.95,
+        "reasoning": "CI release-tagging workflow; build infrastructure, not security knowledge.",
+    },
+    {
+        "heading_path": ["About"],
+        "text": (
+            "This project began in 2015 as a community effort. Our mission is to "
+            "improve web application security for everyone."
+        ),
+        "label": "UNCERTAIN",
+        "confidence": 0.5,
+        "reasoning": "Half project history, half a generic security-mission statement.",
+    },
+    {
+        "heading_path": ["Contributing"],
+        "text": (
+            "Report security issues privately to security@example.org. For "
+            "everything else, open a pull request and sign the CLA before your "
+            "first contribution."
+        ),
+        "label": "UNCERTAIN",
+        "confidence": 0.5,
+        "reasoning": "Mixes a security-reporting contact with general onboarding.",
+    },
+]
+
+
+def _chunk_json(index: int, heading_path: list[str], text: str) -> str:
+    """Render one chunk as the compact JSON the model sees."""
+    return json.dumps(
+        {"index": index, "heading_path": heading_path, "text": text},
+        ensure_ascii=False,
+    )
+
+
+def _verdict_json(index: int, example: dict) -> str:
+    """Render one few-shot's expected verdict as JSON."""
+    return json.dumps(
+        {
+            "index": index,
+            "label": example["label"],
+            "confidence": example["confidence"],
+            "reasoning": example["reasoning"],
+        },
+        ensure_ascii=False,
+    )
+
+
+def _build_few_shot_block() -> str:
+    """Render all few-shot examples as INPUT/VERDICT pairs for the system prompt."""
+    blocks = []
+    for i, ex in enumerate(FEW_SHOT_EXAMPLES):
+        blocks.append(
+            f"INPUT: {_chunk_json(i, ex['heading_path'], ex['text'])}\n"
+            f"VERDICT: {_verdict_json(i, ex)}"
+        )
+    return "Worked examples:\n\n" + "\n\n".join(blocks)
+
+
+# System prompt + worked examples, assembled once at import time.
+SYSTEM_PROMPT_WITH_EXAMPLES = SYSTEM_PROMPT + "\n\n" + _build_few_shot_block()
+
+
+def build_user_prompt(items: list[tuple[list[str], str]]) -> str:
+    """Build the user message: a numbered batch of chunks to classify.
+
+    Args:
+        items: (heading_path, text) per chunk, already truncated by the caller.
+
+    Returns:
+        A prompt instructing the model to return one verdict per chunk.
+    """
+    lines = ["Classify each of the following chunks and return the results JSON:\n"]
+    for i, (heading_path, text) in enumerate(items):
+        lines.append(_chunk_json(i, heading_path, text))
+    return "\n".join(lines)
+
+
+__all__ = [
+    "FEW_SHOT_EXAMPLES",
+    "SYSTEM_PROMPT",
+    "SYSTEM_PROMPT_WITH_EXAMPLES",
+    "build_user_prompt",
+]


### PR DESCRIPTION
## Summary

Adds Stage 2 of Module B (Noise/Relevance Filter): an LLM classifier that labels
each content chunk as **KNOWLEDGE**, **NOISE**, or **UNCERTAIN** under the
recall-first rule. Builds on the Week 1 schemas and Week 2 regex/sanitize stages.

This PR is self-contained (classifier + prompt + config + tests). Pipeline
wiring, the queue/DB model, and the CLI entry point come in later weeks.

## What's added

- **`application/utils/noise_filter/config_loader.py`** — loads Module B settings
  from `CRE_NOISE_FILTER_*` environment variables into a typed `NoiseFilterConfig`
  (model, batch size, per-chunk char cap, confidence threshold), with defaults.
- **`application/utils/noise_filter/prompts.py`** — the recall-first system prompt
  and a few-shot block (5 KNOWLEDGE / 3 NOISE / 2 UNCERTAIN worked examples), plus
  a helper that renders a numbered batch of chunks into the user prompt.
- **`application/utils/noise_filter/llm_classifier.py`** — `LLMClassifier`, which
  classifies a list of `ChangeRecord`s and returns one `ClassifyResult` per record.
- **`application/tests/noise_filter/llm_classifier_test.py`** — 14 unit tests,
  fully mocked (no network calls).
- **`.env.example`** — documents the four new `CRE_NOISE_FILTER_*` variables.

## How the classifier works

- Sends each chunk's `heading_path` + `text` to a dedicated lightweight model via
  LiteLLM (default `gemini/gemini-2.5-flash-lite`).
- Processes records in batches (`CRE_NOISE_FILTER_BATCH_SIZE`, default 10), one
  request per batch, and maps results back to input order by index.
- Requests a strict JSON-schema response; if the provider doesn't support strict
  mode, falls back to JSON-object mode.
- Truncates each chunk to `CRE_NOISE_FILTER_MAX_CHARS` (default 1500) before sending.
- Retries on rate-limit/quota errors using the existing `CRE_LLM_MAX_RETRIES` /
  `CRE_LLM_RETRY_SLEEP_SECONDS` settings.
- Returns `UNCERTAIN` (confidence 0.0) for any unparseable, malformed, or invalid
  output, and marks a whole batch `UNCERTAIN` if the LLM call fails — so a bad
  response never aborts a run.

## Configuration

| Variable | Default | Purpose |
|---|---|---|
| `CRE_NOISE_FILTER_LLM_MODEL` | `gemini/gemini-2.5-flash-lite` | Classification model (LiteLLM string) |
| `CRE_NOISE_FILTER_BATCH_SIZE` | `10` | Chunks per LLM request |
| `CRE_NOISE_FILTER_MAX_CHARS` | `1500` | Per-chunk character cap before sending |
| `CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD` | `0.8` | Minimum confidence to enqueue a KNOWLEDGE verdict |

The model is Gemini, so it authenticates with the existing `GEMINI_API_KEY`;
no new credential is required.

## Testing

- 14 new unit tests covering prompt content, batch ordering and splitting,
  malformed/invalid/empty output handling, the JSON-schema fallback, rate-limit
  retry and exhaustion, and truncation.
- Full suite: 369 passing, 1 skipped, 0 failures.
- `black --check` clean across the repo.
