### PR TITLE
test: OWASP mapping fixtures for GSoC ETL validation

### DIFF
--- a/application/tests/fixtures/owasp_mappings/owasp_aisvs_1_0.json
+++ b/application/tests/fixtures/owasp_mappings/owasp_aisvs_1_0.json
@@ -1,0 +1,86 @@
+[
+  {
+    "section_id": "AISVS1",
+    "section": "Training Data Governance & Bias Management",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C01-Training-Data-Governance.md",
+    "cre_ids": ["227-045", "307-507"]
+  },
+  {
+    "section_id": "AISVS2",
+    "section": "User Input Validation",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C02-User-Input-Validation.md",
+    "cre_ids": ["031-447", "760-764"]
+  },
+  {
+    "section_id": "AISVS3",
+    "section": "Model Lifecycle Management & Change Control",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md",
+    "cre_ids": ["148-853", "613-285"]
+  },
+  {
+    "section_id": "AISVS4",
+    "section": "Infrastructure, Configuration & Deployment Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C04-Infrastructure.md",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section_id": "AISVS5",
+    "section": "Access Control & Identity for AI Components & Users",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C05-Access-Control-and-Identity.md",
+    "cre_ids": ["633-428", "724-770"]
+  },
+  {
+    "section_id": "AISVS6",
+    "section": "Supply Chain Security for Models, Frameworks & Data",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C06-Supply-Chain.md",
+    "cre_ids": ["613-285", "613-287", "863-521"]
+  },
+  {
+    "section_id": "AISVS7",
+    "section": "Model Behavior, Output Control & Safety Assurance",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C07-Model-Behavior.md",
+    "cre_ids": ["064-808", "141-555"]
+  },
+  {
+    "section_id": "AISVS8",
+    "section": "Memory, Embeddings & Vector Database Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md",
+    "cre_ids": ["126-668", "538-770"]
+  },
+  {
+    "section_id": "AISVS9",
+    "section": "Autonomous Orchestration & Agentic Action Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md",
+    "cre_ids": ["117-371", "650-560"]
+  },
+  {
+    "section_id": "AISVS10",
+    "section": "Model Context Protocol (MCP) Security",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C10-MCP-Security.md",
+    "cre_ids": ["307-507", "715-223"]
+  },
+  {
+    "section_id": "AISVS11",
+    "section": "Adversarial Robustness & Privacy Defense",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C11-Adversarial-Robustness.md",
+    "cre_ids": ["141-555", "623-550"]
+  },
+  {
+    "section_id": "AISVS12",
+    "section": "Privacy Protection & Personal Data Management",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C12-Privacy.md",
+    "cre_ids": ["126-668", "227-045", "482-866"]
+  },
+  {
+    "section_id": "AISVS13",
+    "section": "Monitoring, Logging & Anomaly Detection",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C13-Monitoring-and-Logging.md",
+    "cre_ids": ["058-083", "148-420", "402-706", "843-841"]
+  },
+  {
+    "section_id": "AISVS14",
+    "section": "Human Oversight, Accountability & Governance",
+    "hyperlink": "https://github.com/OWASP/AISVS/tree/main/1.0/en/0x10-C14-Human-Oversight.md",
+    "cre_ids": ["162-655", "766-162"]
+  }
+]

--- a/application/tests/fixtures/owasp_mappings/owasp_api_top10_2023.json
+++ b/application/tests/fixtures/owasp_mappings/owasp_api_top10_2023.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "API1",
+    "section": "Broken Object Level Authorization",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/",
+    "cre_ids": ["304-667", "724-770"]
+  },
+  {
+    "section_id": "API2",
+    "section": "Broken Authentication",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa2-broken-authentication/",
+    "cre_ids": ["177-260", "586-842", "633-428"]
+  },
+  {
+    "section_id": "API3",
+    "section": "Broken Object Property Level Authorization",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa3-broken-object-property-level-authorization/",
+    "cre_ids": ["538-770", "724-770", "128-128"]
+  },
+  {
+    "section_id": "API4",
+    "section": "Unrestricted Resource Consumption",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa4-unrestricted-resource-consumption/",
+    "cre_ids": ["623-550"]
+  },
+  {
+    "section_id": "API5",
+    "section": "Broken Function Level Authorization",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa5-broken-function-level-authorization/",
+    "cre_ids": ["650-560", "724-770"]
+  },
+  {
+    "section_id": "API6",
+    "section": "Unrestricted Access to Sensitive Business Flows",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa6-unrestricted-access-to-sensitive-business-flows/",
+    "cre_ids": ["534-605", "630-573"]
+  },
+  {
+    "section_id": "API7",
+    "section": "Server Side Request Forgery",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa7-server-side-request-forgery/",
+    "cre_ids": ["028-728", "657-084"]
+  },
+  {
+    "section_id": "API8",
+    "section": "Security Misconfiguration",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa8-security-misconfiguration/",
+    "cre_ids": ["486-813"]
+  },
+  {
+    "section_id": "API9",
+    "section": "Improper Inventory Management",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xa9-improper-inventory-management/",
+    "cre_ids": ["162-655", "863-521"]
+  },
+  {
+    "section_id": "API10",
+    "section": "Unsafe Consumption of APIs",
+    "hyperlink": "https://owasp.org/API-Security/editions/2023/en/0xaa-unsafe-consumption-of-apis/",
+    "cre_ids": ["715-223"]
+  }
+]

--- a/application/tests/fixtures/owasp_mappings/owasp_cheatsheets_supplement.json
+++ b/application/tests/fixtures/owasp_mappings/owasp_cheatsheets_supplement.json
@@ -1,0 +1,47 @@
+[
+  {
+    "section": "Authorization Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html",
+    "cre_ids": ["128-128", "117-371"]
+  },
+  {
+    "section": "REST Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html",
+    "cre_ids": ["118-110", "724-770", "623-550"]
+  },
+  {
+    "section": "Server Side Request Forgery Prevention Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html",
+    "cre_ids": ["028-728", "657-084"]
+  },
+  {
+    "section": "Docker Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section": "Kubernetes Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html",
+    "cre_ids": ["467-784", "233-748", "486-813"]
+  },
+  {
+    "section": "Secure Cloud Architecture Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.html",
+    "cre_ids": ["155-155", "467-784"]
+  },
+  {
+    "section": "LLM Prompt Injection Prevention Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html",
+    "cre_ids": ["161-451", "760-764"]
+  },
+  {
+    "section": "AI Agent Security Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html",
+    "cre_ids": ["117-371", "650-560", "126-668"]
+  },
+  {
+    "section": "Secure AI Model Ops Cheat Sheet",
+    "hyperlink": "https://cheatsheetseries.owasp.org/cheatsheets/Secure_AI_Model_Ops_Cheat_Sheet.html",
+    "cre_ids": ["148-853", "613-285", "613-287"]
+  }
+]

--- a/application/tests/fixtures/owasp_mappings/owasp_kubernetes_top10_2022.json
+++ b/application/tests/fixtures/owasp_mappings/owasp_kubernetes_top10_2022.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "K01",
+    "section": "Insecure Workload Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K01-insecure-workload-configurations",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section_id": "K02",
+    "section": "Supply Chain Vulnerabilities",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K02-supply-chain-vulnerabilities",
+    "cre_ids": ["613-285", "613-287"]
+  },
+  {
+    "section_id": "K03",
+    "section": "Overly Permissive RBAC Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K03-overly-permissive-rbac-configurations",
+    "cre_ids": ["128-128", "724-770"]
+  },
+  {
+    "section_id": "K04",
+    "section": "Lack of Centralized Policy Enforcement",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K04-lack-of-centralized-policy-enforcement",
+    "cre_ids": ["117-371"]
+  },
+  {
+    "section_id": "K05",
+    "section": "Inadequate Logging and Monitoring",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K05-inadequate-logging-and-monitoring",
+    "cre_ids": ["058-083", "148-420", "402-706", "843-841"]
+  },
+  {
+    "section_id": "K06",
+    "section": "Broken Authentication Mechanisms",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K06-broken-authentication-mechanisms",
+    "cre_ids": ["177-260", "586-842", "633-428"]
+  },
+  {
+    "section_id": "K07",
+    "section": "Missing Network Segmentation Controls",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K07-missing-network-segmentation-controls",
+    "cre_ids": ["132-146", "467-784", "515-021"]
+  },
+  {
+    "section_id": "K08",
+    "section": "Secrets Management Failures",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K08-secrets-management-failures",
+    "cre_ids": ["340-375", "774-888", "813-610"]
+  },
+  {
+    "section_id": "K09",
+    "section": "Misconfigured Cluster Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K09-misconfigured-cluster-components",
+    "cre_ids": ["233-748", "486-813"]
+  },
+  {
+    "section_id": "K10",
+    "section": "Outdated and Vulnerable Kubernetes Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/2022/en/src/K10-outdated-and-vulnerable-kubernetes-components",
+    "cre_ids": ["053-751", "715-334", "863-521"]
+  }
+]

--- a/application/tests/fixtures/owasp_mappings/owasp_kubernetes_top10_2025.json
+++ b/application/tests/fixtures/owasp_mappings/owasp_kubernetes_top10_2025.json
@@ -1,0 +1,72 @@
+[
+  {
+    "section_id": "K01",
+    "section": "Insecure Workload Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["233-748", "486-813"],
+    "fallback_section_ids": ["K01"]
+  },
+  {
+    "section_id": "K02",
+    "section": "Overly Permissive Authorization Configurations",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["128-128", "724-770"],
+    "fallback_section_ids": ["K03"]
+  },
+  {
+    "section_id": "K03",
+    "section": "Secrets Management Failures",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["340-375", "774-888", "813-610"],
+    "fallback_section_ids": ["K08"]
+  },
+  {
+    "section_id": "K04",
+    "section": "Lack Of Cluster Level Policy Enforcement",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["117-371"],
+    "fallback_section_ids": ["K04"]
+  },
+  {
+    "section_id": "K05",
+    "section": "Missing Network Segmentation Controls",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["132-146", "467-784", "515-021"],
+    "fallback_section_ids": ["K07"]
+  },
+  {
+    "section_id": "K06",
+    "section": "Overly Exposed Kubernetes Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["152-725", "640-364"],
+    "fallback_section_ids": ["K09"]
+  },
+  {
+    "section_id": "K07",
+    "section": "Misconfigured And Vulnerable Cluster Components",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["053-751", "233-748", "486-813", "715-334"],
+    "fallback_section_ids": ["K09", "K10"]
+  },
+  {
+    "section_id": "K08",
+    "section": "Cluster To Cloud Lateral Movement",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["132-146", "640-364", "724-770"],
+    "fallback_section_ids": ["K03", "K07"]
+  },
+  {
+    "section_id": "K09",
+    "section": "Broken Authentication Mechanisms",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["177-260", "586-842", "633-428"],
+    "fallback_section_ids": ["K06"]
+  },
+  {
+    "section_id": "K10",
+    "section": "Inadequate Logging And Monitoring",
+    "hyperlink": "https://owasp.org/www-project-kubernetes-top-ten/",
+    "cre_ids": ["058-083", "148-420", "402-706", "843-841"],
+    "fallback_section_ids": ["K05"]
+  }
+]

--- a/application/tests/fixtures/owasp_mappings/owasp_llm_top10_2025.json
+++ b/application/tests/fixtures/owasp_mappings/owasp_llm_top10_2025.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "LLM01",
+    "section": "Prompt Injection",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm01-prompt-injection/",
+    "cre_ids": ["161-451", "760-764"]
+  },
+  {
+    "section_id": "LLM02",
+    "section": "Sensitive Information Disclosure",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/",
+    "cre_ids": ["126-668", "227-045"]
+  },
+  {
+    "section_id": "LLM03",
+    "section": "Supply Chain",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm032025-supply-chain/",
+    "cre_ids": ["613-285", "613-287"]
+  },
+  {
+    "section_id": "LLM04",
+    "section": "Data and Model Poisoning",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/",
+    "cre_ids": ["307-507", "613-287"]
+  },
+  {
+    "section_id": "LLM05",
+    "section": "Improper Output Handling",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/",
+    "cre_ids": ["064-808"]
+  },
+  {
+    "section_id": "LLM06",
+    "section": "Excessive Agency",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm062025-excessive-agency/",
+    "cre_ids": ["117-371", "650-560"]
+  },
+  {
+    "section_id": "LLM07",
+    "section": "System Prompt Leakage",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm072025-system-prompt-leakage/",
+    "cre_ids": ["126-668", "227-045"]
+  },
+  {
+    "section_id": "LLM08",
+    "section": "Vector and Embedding Weaknesses",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/",
+    "cre_ids": ["126-668", "538-770"]
+  },
+  {
+    "section_id": "LLM09",
+    "section": "Misinformation",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm092025-misinformation/",
+    "cre_ids": ["141-555"]
+  },
+  {
+    "section_id": "LLM10",
+    "section": "Unbounded Consumption",
+    "hyperlink": "https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/",
+    "cre_ids": ["267-031", "623-550"]
+  }
+]

--- a/application/tests/fixtures/owasp_mappings/owasp_top10_2025.json
+++ b/application/tests/fixtures/owasp_mappings/owasp_top10_2025.json
@@ -1,0 +1,62 @@
+[
+  {
+    "section_id": "A01",
+    "section": "Broken Access Control",
+    "hyperlink": "https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/",
+    "cre_ids": ["117-371", "177-260", "724-770"]
+  },
+  {
+    "section_id": "A02",
+    "section": "Security Misconfiguration",
+    "hyperlink": "https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/",
+    "cre_ids": ["486-813"]
+  },
+  {
+    "section_id": "A03",
+    "section": "Software Supply Chain Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A03_2025-Software_Supply_Chain_Failures/",
+    "cre_ids": ["613-286", "613-287", "715-223", "863-521"]
+  },
+  {
+    "section_id": "A04",
+    "section": "Cryptographic Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/",
+    "cre_ids": ["170-772", "227-045"]
+  },
+  {
+    "section_id": "A05",
+    "section": "Injection",
+    "hyperlink": "https://owasp.org/Top10/2025/A05_2025-Injection/",
+    "cre_ids": ["031-447", "064-808", "760-764"]
+  },
+  {
+    "section_id": "A06",
+    "section": "Insecure Design",
+    "hyperlink": "https://owasp.org/Top10/2025/A06_2025-Insecure_Design/",
+    "cre_ids": ["126-668", "155-155"]
+  },
+  {
+    "section_id": "A07",
+    "section": "Authentication Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A07_2025-Authentication_Failures/",
+    "cre_ids": ["002-630", "177-260", "586-842", "633-428"]
+  },
+  {
+    "section_id": "A08",
+    "section": "Software or Data Integrity Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/",
+    "cre_ids": ["613-287", "836-068"]
+  },
+  {
+    "section_id": "A09",
+    "section": "Security Logging and Alerting Failures",
+    "hyperlink": "https://owasp.org/Top10/2025/A09_2025-Security_Logging_and_Alerting_Failures/",
+    "cre_ids": ["067-050", "148-420", "402-706", "843-841"]
+  },
+  {
+    "section_id": "A10",
+    "section": "Mishandling of Exceptional Conditions",
+    "hyperlink": "https://owasp.org/Top10/2025/A10_2025-Mishandling_of_Exceptional_Conditions/",
+    "cre_ids": ["513-183"]
+  }
+]

--- a/application/tests/owasp_mapping_fixtures_test.py
+++ b/application/tests/owasp_mapping_fixtures_test.py
@@ -1,0 +1,50 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "owasp_mappings"
+EXPECTED_FIXTURES = {
+    "owasp_aisvs_1_0.json",
+    "owasp_api_top10_2023.json",
+    "owasp_cheatsheets_supplement.json",
+    "owasp_kubernetes_top10_2022.json",
+    "owasp_kubernetes_top10_2025.json",
+    "owasp_llm_top10_2025.json",
+    "owasp_top10_2025.json",
+}
+CRE_ID_PATTERN = re.compile(r"^\d{3}-\d{3}$")
+
+
+class TestOwaspMappingFixtures(unittest.TestCase):
+    def test_fixture_set_is_complete(self) -> None:
+        actual = {path.name for path in FIXTURE_DIR.glob("*.json")}
+        self.assertEqual(actual, EXPECTED_FIXTURES)
+
+    def test_fixtures_have_expected_mapping_shape(self) -> None:
+        for path in sorted(FIXTURE_DIR.glob("*.json")):
+            with self.subTest(fixture=path.name):
+                payload = json.loads(path.read_text(encoding="utf-8"))
+
+                self.assertIsInstance(payload, list)
+                self.assertGreater(len(payload), 0)
+
+                for entry in payload:
+                    self.assertIsInstance(entry, dict)
+                    self.assertIsInstance(entry.get("section"), str)
+                    self.assertTrue(entry["section"].strip())
+                    self.assertIsInstance(entry.get("hyperlink"), str)
+                    self.assertTrue(entry["hyperlink"].strip())
+                    self.assertIn("cre_ids", entry)
+                    self.assertIsInstance(entry["cre_ids"], list)
+                    self.assertGreater(len(entry["cre_ids"]), 0)
+
+                    if "section_id" in entry:
+                        self.assertIsInstance(entry["section_id"], str)
+                        self.assertTrue(entry["section_id"].strip())
+
+                    for cre_id in entry["cre_ids"]:
+                        self.assertIsInstance(cre_id, str)
+                        self.assertTrue(cre_id.strip())
+                        self.assertRegex(cre_id, CRE_ID_PATTERN)

--- a/application/tests/owasp_mapping_fixtures_test.py
+++ b/application/tests/owasp_mapping_fixtures_test.py
@@ -30,6 +30,13 @@ class TestOwaspMappingFixtures(unittest.TestCase):
                 self.assertIsInstance(payload, list)
                 self.assertGreater(len(payload), 0)
 
+                known_section_ids = {
+                    entry["section_id"]
+                    for entry in payload
+                    if "section_id" in entry and isinstance(entry["section_id"], str)
+                }
+                seen_section_ids: set[str] = set()
+
                 for entry in payload:
                     self.assertIsInstance(entry, dict)
                     self.assertIsInstance(entry.get("section"), str)
@@ -43,6 +50,27 @@ class TestOwaspMappingFixtures(unittest.TestCase):
                     if "section_id" in entry:
                         self.assertIsInstance(entry["section_id"], str)
                         self.assertTrue(entry["section_id"].strip())
+                        self.assertNotIn(
+                            entry["section_id"],
+                            seen_section_ids,
+                            msg=f"Duplicate section_id {entry['section_id']} in {path.name}",
+                        )
+                        seen_section_ids.add(entry["section_id"])
+
+                    if "fallback_section_ids" in entry:
+                        self.assertIsInstance(entry["fallback_section_ids"], list)
+                        self.assertGreater(len(entry["fallback_section_ids"]), 0)
+                        for fallback_section_id in entry["fallback_section_ids"]:
+                            self.assertIsInstance(fallback_section_id, str)
+                            self.assertTrue(fallback_section_id.strip())
+                            self.assertIn(
+                                fallback_section_id,
+                                known_section_ids,
+                                msg=(
+                                    f"Fallback section id {fallback_section_id} "
+                                    f"in {path.name} is not a known section_id"
+                                ),
+                            )
 
                     for cre_id in entry["cre_ids"]:
                         self.assertIsInstance(cre_id, str)


### PR DESCRIPTION
## Summary

This PR is split out from #900 to make review smaller and more focused.

It adds test-only OWASP mapping fixtures for GSoC ETL validation by extracting the OWASP mapping JSON files into a dedicated test fixture location and adding focused validation coverage. The intent is to let reviewers assess the fixture data independently from production importer/runtime changes.

Issue reference:
- Related to #471
- Split from #900

## Problem Fixed

PR #900 grouped multiple different concerns into a single larger review, including:
- upstream sync retry logic
- OWASP mapping fixture data
- importer-related follow-up work

That made it harder to review the mapping fixture portion on its own.

For this part of the work, the useful standalone contribution is:
- preserving the OWASP mapping fixture JSON in a test-owned location
- validating that those fixtures are structurally usable for ETL work
- keeping this review separate from production parser decisions and runtime behavior

## Solution

This PR:
- moves OWASP mapping JSON into `application/tests/fixtures/owasp_mappings/`
- keeps the fixture set reviewable as test data only
- adds a focused validation test to ensure:
  - each fixture loads as valid JSON
  - each fixture has the expected list-of-mappings shape
  - required fields such as `section`, `hyperlink`, and `cre_ids` are present
  - `cre_ids` values are non-empty and structurally valid

Files in scope:
- `application/tests/fixtures/owasp_mappings/owasp_aisvs_1_0.json`
- `application/tests/fixtures/owasp_mappings/owasp_api_top10_2023.json`
- `application/tests/fixtures/owasp_mappings/owasp_cheatsheets_supplement.json`
- `application/tests/fixtures/owasp_mappings/owasp_kubernetes_top10_2022.json`
- `application/tests/fixtures/owasp_mappings/owasp_kubernetes_top10_2025.json`
- `application/tests/fixtures/owasp_mappings/owasp_llm_top10_2025.json`
- `application/tests/fixtures/owasp_mappings/owasp_top10_2025.json`
- `application/tests/owasp_mapping_fixtures_test.py`

## Tests

```bash
./venv/bin/python -m pytest application/tests/owasp_mapping_fixtures_test.py -q