### PR TITLE
Add CODEOWNERS for maintainer approval on contributor PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # With require_code_owner_reviews on main, a maintainer approval satisfies
 # merge requirements on contributor PRs. GitHub blocks authors from approving
 # their own PR as a code owner review.
-* @northdpole @robvanderveer
+* @northdpole @robvanderveer @Pa04rth @paoga87

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default code owners for all paths.
+# With require_code_owner_reviews on main, a maintainer approval satisfies
+# merge requirements on contributor PRs. GitHub blocks authors from approving
+# their own PR as a code owner review.
+* @northdpole @robvanderveer


### PR DESCRIPTION
## Summary

Branch protection on `main` has `require_code_owner_reviews: true` but the repo had no `.github/CODEOWNERS` file. That meant no approval could satisfy the code-owner requirement on contributor PRs, forcing `gh pr merge --admin`.

This adds default code owners so maintainer approval is sufficient to merge **other people's** PRs. GitHub blocks authors from self-approving as a code owner, so maintainer-authored PRs still need a second reviewer.

## Changes

- Add `.github/CODEOWNERS` with default owners: `@northdpole`, `@robvanderveer`, `@Pa04rth` (Parth Sohaney), `@paoga87` (Paola Garcia).

## Expected behavior after merge

| PR author | Approver | Merge allowed? |
|-----------|----------|----------------|
| Contributor | any listed CODEOWNER | Yes |
| Any CODEOWNER | self | No |
| Any CODEOWNER | different CODEOWNER | Yes |

## Test plan

- [ ] Merge this PR (needs another CODEOWNER — not self)
- [ ] On a contributor PR, verify a single CODEOWNER approval enables merge without `--admin`