### PR TITLE
Remove stale Same link type filter from force graph UI

### DIFF
--- a/application/frontend/src/pages/Explorer/visuals/force-graph/forceGraph.tsx
+++ b/application/frontend/src/pages/Explorer/visuals/force-graph/forceGraph.tsx
@@ -19,7 +19,7 @@ interface DropdownOption {
 
 export const ExplorerForceGraph = () => {
   const [graphData, setGraphData] = useState();
-  const [ignoreTypes, setIgnoreTypes] = useState(['same']);
+  const [ignoreTypes, setIgnoreTypes] = useState<string[]>([]);
   const [maxCount, setMaxCount] = useState(0);
   const [maxNodeSize, setMaxNodeSize] = useState(0);
   const {
@@ -376,8 +376,6 @@ export const ExplorerForceGraph = () => {
         return 'skyblue';
       case 'linked to':
         return 'gray';
-      case 'same':
-        return 'red';
       default:
         return 'white';
     }
@@ -473,8 +471,6 @@ export const ExplorerForceGraph = () => {
         checked={!ignoreTypes.includes('linked to')}
         onChange={() => toggleLinks('linked to')}
       />
-      {' | '}
-      <Checkbox label="Same" checked={!ignoreTypes.includes('same')} onChange={() => toggleLinks('same')} />
 
       <div style={{ marginBottom: '10px', marginTop: '10px', marginLeft: '10px' }}>
         <Dropdown


### PR DESCRIPTION
## Summary
- Removes the obsolete "Same" link-type checkbox from the Explorer force graph filter bar
- Clears the default `ignoreTypes` entry for `same` (no longer emitted after #553)
- Drops the dead `same` case from `getLinkColor`

Fixes #34

## Test plan
- [x] `make lint` (prettier on `forceGraph.tsx`)
- [ ] CI green
- [ ] Manual: Explorer force graph shows Contains / Related / Linked To filters only


Made with [Cursor](https://cursor.com)