### PR TITLE
cwe: remove prohibited vulnerability-mapping entries on refresh

### DIFF
--- a/application/tests/cwe_parser_test.py
+++ b/application/tests/cwe_parser_test.py
@@ -292,6 +292,42 @@ class TestCWEParser(unittest.TestCase):
 
         self.assertIn("611", imported_cwes)
         self.assertNotIn("9999", imported_cwes)
+        self.assertNotIn("16", imported_cwes)
+
+    @patch.object(requests, "get")
+    def test_register_CWE_removes_stale_prohibited_entries(self, mock_requests) -> None:
+        stale_category = self.collection.add_node(
+            defs.Standard(
+                name="CWE",
+                sectionID="16",
+                section="Configuration",
+                hyperlink="https://cwe.mitre.org/data/definitions/16.html",
+            )
+        )
+        self.collection.session.add(stale_category)
+        self.collection.session.commit()
+
+        tmpdir = mkdtemp()
+        tmpFile = os.path.join(tmpdir, "cwe.xml")
+        tmpzip = os.path.join(tmpdir, "cwe.zip")
+        with open(tmpFile, "w") as cx:
+            cx.write(self.CWE_prohibited_xml)
+        with zipfile.ZipFile(tmpzip, "w", zipfile.ZIP_DEFLATED) as zipf:
+            zipf.write(tmpFile, arcname="cwe.xml")
+
+        class fakeRequest:
+            def iter_content(self, chunk_size=None):
+                with open(tmpzip, "rb") as zipf:
+                    return [zipf.read()]
+
+        mock_requests.return_value = fakeRequest()
+
+        cwe.CWE().parse(
+            cache=self.collection,
+            ph=prompt_client.PromptHandler(database=self.collection),
+        )
+
+        self.assertEqual(self.collection.get_nodes(name="CWE", sectionID="16"), [])
 
     CWE_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <Weakness_Catalog Name="CWE" Version="4.10" Date="2023-01-31" xmlns="http://cwe.mitre.org/cwe-6"
@@ -773,9 +809,20 @@ class TestCWEParser(unittest.TestCase):
       <Weakness ID="611" Name="Improper Restriction of XML External Entity Reference" Abstraction="Base" Structure="Simple" Status="Draft">
          <Description>Allowed XXE entry.</Description>
       </Weakness>
-      <Weakness ID="9999" Name="Prohibited Example" Abstraction="Base" Structure="Simple" Status="PROHIBITED">
+      <Weakness ID="9999" Name="Prohibited Example" Abstraction="Base" Structure="Simple" Status="Draft">
          <Description>This entry should not be imported.</Description>
+         <Mapping_Notes>
+            <Usage>Prohibited</Usage>
+         </Mapping_Notes>
       </Weakness>
    </Weaknesses>
+   <Categories>
+      <Category ID="16" Name="Configuration" Status="Obsolete">
+         <Summary>Prohibited category entry.</Summary>
+         <Mapping_Notes>
+            <Usage>Prohibited</Usage>
+         </Mapping_Notes>
+      </Category>
+   </Categories>
 </Weakness_Catalog>
 """

--- a/application/tests/cwe_parser_test.py
+++ b/application/tests/cwe_parser_test.py
@@ -296,7 +296,7 @@ class TestCWEParser(unittest.TestCase):
 
     @patch.object(requests, "get")
     def test_register_CWE_removes_stale_prohibited_entries(self, mock_requests) -> None:
-        stale_category = self.collection.add_node(
+        self.collection.add_node(
             defs.Standard(
                 name="CWE",
                 sectionID="16",
@@ -304,8 +304,6 @@ class TestCWEParser(unittest.TestCase):
                 hyperlink="https://cwe.mitre.org/data/definitions/16.html",
             )
         )
-        self.collection.session.add(stale_category)
-        self.collection.session.commit()
 
         tmpdir = mkdtemp()
         tmpFile = os.path.join(tmpdir, "cwe.xml")

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import requests
 from typing import Dict, List
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from application.database import db
 from application.defs import cre_defs as defs
 import shutil
@@ -126,16 +127,27 @@ class CWE(ParserInterface):
             for link in entry_links:
                 cache.session.delete(link)
 
-            embeddings = cache.get_embeddings_for_doc(db.nodeFromDB(entry))
-            if embeddings:
-                cache.session.delete(embeddings)
+            # Delete all embeddings associated with this node
+            # Use node_id (the foreign key column) instead of node (which doesn't exist)
+            embeddings = (
+                cache.session.query(db.Embeddings)
+                .filter(db.Embeddings.node_id == entry.id)
+                .all()
+            )
+            for emb in embeddings:
+                cache.session.delete(emb)
+
             cache.session.delete(entry)
 
-        cache.session.commit()
-        logger.info(
-            "Deleted %s prohibited CWE entries from the local database",
-            len(entries),
-        )
+        try:
+            cache.session.commit()
+            logger.info(
+                "Deleted %s prohibited CWE entries from the local database",
+                len(entries),
+            )
+        except IntegrityError as e:
+            cache.session.rollback()
+            logger.error("Failed to delete prohibited CWE entries: %s", e)
 
     def link_cwe_to_capec_cre(
         self, cwe: defs.Standard, cache: db.Node_collection, capec_id: str

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 import requests
 from typing import Dict, List
+from sqlalchemy import func
 from application.database import db
 from application.defs import cre_defs as defs
 import shutil
@@ -69,6 +70,72 @@ class CWE(ParserInterface):
 
     def make_hyperlink(self, cwe_id: int):
         return f"https://cwe.mitre.org/data/definitions/{cwe_id}.html"
+
+    def iter_catalog_entries(self, section: Dict) -> List[Dict]:
+        if not section:
+            return []
+
+        entries = []
+        for collection in section.values():
+            if isinstance(collection, list):
+                entries.extend(entry for entry in collection if isinstance(entry, Dict))
+            elif isinstance(collection, Dict):
+                entries.append(collection)
+        return entries
+
+    def get_mapping_usage(self, entry: Dict) -> str:
+        mapping_notes = entry.get("Mapping_Notes")
+        if not isinstance(mapping_notes, Dict):
+            return ""
+        usage = mapping_notes.get("Usage", "")
+        return str(usage).strip().lower()
+
+    def is_prohibited_entry(self, entry: Dict) -> bool:
+        return (
+            str(entry.get("@Status", "")).strip().lower() == "prohibited"
+            or self.get_mapping_usage(entry) == "prohibited"
+        )
+
+    def collect_prohibited_cwe_ids(self, weakness_catalog: Dict) -> List[str]:
+        prohibited_ids = []
+        for section_name in ("Weaknesses", "Categories"):
+            for entry in self.iter_catalog_entries(weakness_catalog.get(section_name)):
+                if entry.get("@ID") and self.is_prohibited_entry(entry):
+                    prohibited_ids.append(str(entry["@ID"]))
+        return prohibited_ids
+
+    def delete_cwe_entries(self, cache: db.Node_collection, cwe_ids: List[str]) -> None:
+        if not cwe_ids:
+            return
+
+        entries = (
+            cache.session.query(db.Node)
+            .filter(
+                func.lower(db.Node.name) == self.name.lower(),
+                db.Node.section_id.in_(cwe_ids),
+            )
+            .all()
+        )
+        if not entries:
+            return
+
+        for entry in entries:
+            entry_links = (
+                cache.session.query(db.Links).filter(db.Links.node == entry.id).all()
+            )
+            for link in entry_links:
+                cache.session.delete(link)
+
+            embeddings = cache.get_embeddings_for_doc(db.nodeFromDB(entry))
+            if embeddings:
+                cache.session.delete(embeddings)
+            cache.session.delete(entry)
+
+        cache.session.commit()
+        logger.info(
+            "Deleted %s prohibited CWE entries from the local database",
+            len(entries),
+        )
 
     def link_cwe_to_capec_cre(
         self, cwe: defs.Standard, cache: db.Node_collection, capec_id: str
@@ -177,68 +244,72 @@ class CWE(ParserInterface):
         related_ids_by_cwe = {}
         with open(xml_file, "r") as xml:
             weakness_catalog = xmltodict.parse(xml.read()).get("Weakness_Catalog")
-        for _, weaknesses in weakness_catalog.get("Weaknesses").items():
-            for weakness in weaknesses:
-                statuses[weakness["@Status"]] = 1
-                cwe = None
-                if weakness["@Status"] in self.allowed_statuses:
-                    cwes = cache.get_nodes(self.name, sectionID=weakness["@ID"])
-                    if cwes:  # update the CWE in the database
-                        cwe = cwes[0]
-                        cwe.section = weakness["@Name"]
-                        cwe.hyperlink = self.make_hyperlink(weakness["@ID"])
-                        cache.add_node(
-                            cwe,
-                            comparison_skip_attributes=[
-                                "link",
-                                "section",
-                                "version",
-                                "subsection",
-                                "tags",
-                                "description",
-                            ],
-                        )
-                    else:  # we found something new
-                        cwe = defs.Standard(
-                            name="CWE",
-                            sectionID=weakness["@ID"],
-                            section=weakness["@Name"],
-                            hyperlink=self.make_hyperlink(weakness["@ID"]),
-                            tags=base_parser_defs.build_tags(
-                                family=base_parser_defs.Family.TAXONOMY,
-                                subtype=base_parser_defs.Subtype.RISK_LIST,
-                                audience=base_parser_defs.Audience.DEVELOPER,
-                                maturity=base_parser_defs.Maturity.STABLE,
-                                source="cwe",
-                                extra=[],
-                            ),
-                        )
-                    logger.debug(f"Registered CWE with id {cwe.sectionID}")
+        prohibited_ids = self.collect_prohibited_cwe_ids(weakness_catalog)
+        self.delete_cwe_entries(cache, prohibited_ids)
 
-                    if weakness.get("Related_Attack_Patterns") and os.environ.get(
-                        "CRE_LINK_CWE_THROUGH_CAPEC"
-                    ):
-                        for lst in weakness["Related_Attack_Patterns"].values():
-                            for capec_entry in lst:
-                                if isinstance(capec_entry, Dict):
-                                    for _, capec_id in capec_entry.items():
-                                        cwe = self.link_cwe_to_capec_cre(
-                                            cwe=cwe, cache=cache, capec_id=capec_id
-                                        )
-                                else:
-                                    id = lst["@CAPEC_ID"]
-                                    cwe = self.link_cwe_to_capec_cre(
-                                        cwe=cwe, cache=cache, capec_id=id
-                                    )
-                    else:
-                        logger.info(
-                            f"CWE '{cwe.sectionID}-{cwe.section}' does not have any related CAPEC attack patterns, skipping automated linking"
-                        )
-                    entries.append(cwe)
-                    entries_by_id[cwe.sectionID] = cwe
-                    related_ids_by_cwe[cwe.sectionID] = (
-                        self.collect_related_weakness_ids(weakness)
+        for weakness in self.iter_catalog_entries(weakness_catalog.get("Weaknesses")):
+            statuses[weakness["@Status"]] = 1
+            cwe = None
+            if self.is_prohibited_entry(weakness):
+                continue
+            if weakness["@Status"] in self.allowed_statuses:
+                cwes = cache.get_nodes(self.name, sectionID=weakness["@ID"])
+                if cwes:  # update the CWE in the database
+                    cwe = cwes[0]
+                    cwe.section = weakness["@Name"]
+                    cwe.hyperlink = self.make_hyperlink(weakness["@ID"])
+                    cache.add_node(
+                        cwe,
+                        comparison_skip_attributes=[
+                            "link",
+                            "section",
+                            "version",
+                            "subsection",
+                            "tags",
+                            "description",
+                        ],
                     )
+                else:  # we found something new
+                    cwe = defs.Standard(
+                        name="CWE",
+                        sectionID=weakness["@ID"],
+                        section=weakness["@Name"],
+                        hyperlink=self.make_hyperlink(weakness["@ID"]),
+                        tags=base_parser_defs.build_tags(
+                            family=base_parser_defs.Family.TAXONOMY,
+                            subtype=base_parser_defs.Subtype.RISK_LIST,
+                            audience=base_parser_defs.Audience.DEVELOPER,
+                            maturity=base_parser_defs.Maturity.STABLE,
+                            source="cwe",
+                            extra=[],
+                        ),
+                    )
+                logger.debug(f"Registered CWE with id {cwe.sectionID}")
+
+                if weakness.get("Related_Attack_Patterns") and os.environ.get(
+                    "CRE_LINK_CWE_THROUGH_CAPEC"
+                ):
+                    for lst in weakness["Related_Attack_Patterns"].values():
+                        for capec_entry in lst:
+                            if isinstance(capec_entry, Dict):
+                                for _, capec_id in capec_entry.items():
+                                    cwe = self.link_cwe_to_capec_cre(
+                                        cwe=cwe, cache=cache, capec_id=capec_id
+                                    )
+                            else:
+                                id = lst["@CAPEC_ID"]
+                                cwe = self.link_cwe_to_capec_cre(
+                                    cwe=cwe, cache=cache, capec_id=id
+                                )
+                else:
+                    logger.info(
+                        f"CWE '{cwe.sectionID}-{cwe.section}' does not have any related CAPEC attack patterns, skipping automated linking"
+                    )
+                entries.append(cwe)
+                entries_by_id[cwe.sectionID] = cwe
+                related_ids_by_cwe[cwe.sectionID] = self.collect_related_weakness_ids(
+                    weakness
+                )
 
         changed = True
         while changed:

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import requests
 from typing import Dict, List
 from sqlalchemy import func
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from application.database import db
 from application.defs import cre_defs as defs
 import shutil
@@ -145,7 +145,7 @@ class CWE(ParserInterface):
                 "Deleted %s prohibited CWE entries from the local database",
                 len(entries),
             )
-        except IntegrityError as e:
+        except SQLAlchemyError as e:
             cache.session.rollback()
             logger.error("Failed to delete prohibited CWE entries: %s", e)
 
@@ -309,9 +309,9 @@ class CWE(ParserInterface):
                                         cwe=cwe, cache=cache, capec_id=capec_id
                                     )
                             else:
-                                id = lst["@CAPEC_ID"]
+                                capec_id_value = lst["@CAPEC_ID"]
                                 cwe = self.link_cwe_to_capec_cre(
-                                    cwe=cwe, cache=cache, capec_id=id
+                                    cwe=cwe, cache=cache, capec_id=capec_id_value
                                 )
                 else:
                     logger.info(

--- a/application/utils/external_project_parsers/parsers/cwe.py
+++ b/application/utils/external_project_parsers/parsers/cwe.py
@@ -148,6 +148,7 @@ class CWE(ParserInterface):
         except SQLAlchemyError as e:
             cache.session.rollback()
             logger.error("Failed to delete prohibited CWE entries: %s", e)
+            raise RuntimeError("Failed to delete prohibited CWE entries") from e
 
     def link_cwe_to_capec_cre(
         self, cwe: defs.Standard, cache: db.Node_collection, capec_id: str

--- a/scripts/update-cwe.sh
+++ b/scripts/update-cwe.sh
@@ -15,9 +15,9 @@ fi
 
 source "$VENV_DIR/bin/activate"
 
-if ! python -c "import pytest" >/dev/null 2>&1; then
-  echo "Installing Python development dependencies"
-  pip install -r "$ROOT_DIR/requirements-dev.txt"
+if ! python -c "import requests" >/dev/null 2>&1; then
+  echo "Installing Python runtime dependencies"
+  pip install -r "$ROOT_DIR/requirements.txt"
 fi
 
 if [[ -f "$CACHE_FILE" ]]; then
@@ -29,5 +29,5 @@ export CRE_NO_NEO4J="${CRE_NO_NEO4J:-1}"
 export CRE_NO_GEN_EMBEDDINGS="${CRE_NO_GEN_EMBEDDINGS:-1}"
 
 echo "Importing latest MITRE CWE data into $CACHE_FILE"
-echo "CWE parser will skip entries whose vulnerability mapping is marked PROHIBITED"
+echo "CWE parser will skip entries marked PROHIBITED by either @Status attribute or Mapping_Notes -> Usage field, covering both weaknesses and categories."
 exec python "$ROOT_DIR/cre.py" --cwe_in --cache_file "$CACHE_FILE"

--- a/scripts/update-cwe.sh
+++ b/scripts/update-cwe.sh
@@ -29,5 +29,5 @@ export CRE_NO_NEO4J="${CRE_NO_NEO4J:-1}"
 export CRE_NO_GEN_EMBEDDINGS="${CRE_NO_GEN_EMBEDDINGS:-1}"
 
 echo "Importing latest MITRE CWE data into $CACHE_FILE"
-echo "CWE parser will import only allowed statuses and skip PROHIBITED entries"
+echo "CWE parser will skip entries whose vulnerability mapping is marked PROHIBITED"
 exec python "$ROOT_DIR/cre.py" --cwe_in --cache_file "$CACHE_FILE"

--- a/scripts/update-cwe.sh
+++ b/scripts/update-cwe.sh
@@ -15,10 +15,8 @@ fi
 
 source "$VENV_DIR/bin/activate"
 
-if ! python -c "import requests" >/dev/null 2>&1; then
-  echo "Installing Python runtime dependencies"
-  pip install -r "$ROOT_DIR/requirements.txt"
-fi
+echo "Installing Python runtime dependencies"
+pip install -r "$ROOT_DIR/requirements.txt"
 
 if [[ -f "$CACHE_FILE" ]]; then
   cp "$CACHE_FILE" "$BACKUP_FILE"


### PR DESCRIPTION
## Summary 
Follow-up to merged PR #939.

This PR fixes the remaining prohibited-CWE import gap by filtering against the upstream CWE vulnerability-mapping field (`Mapping_Notes -> Usage = Prohibited`) and removing stale prohibited CWE entries that may already exist in the local database.

A concrete example is `CWE-16`, which is still reachable on OpenCRE even though the upstream CWE entry marks its vulnerability mapping as `Prohibited`.

## Problem
PR #939 improved CWE filtering, but the current logic is still incomplete.

The merged code filters primarily from the XML `@Status` field on imported weaknesses. That misses entries whose import exclusion is driven by the CWE vulnerability-mapping metadata instead, especially:

- prohibited entries with `Mapping_Notes -> Usage = Prohibited`
- prohibited category entries such as `CWE-16`
- stale prohibited CWE rows already present in the database from earlier imports

As a result, prohibited CWE entries can remain visible after refresh.

## Fix
This PR updates the CWE parser to:

- treat `Mapping_Notes -> Usage = Prohibited` as the authoritative exclusion signal
- still skip explicitly prohibited status entries
- inspect both `Weaknesses` and `Categories`
- delete stale prohibited CWE rows already stored in the local database before completing the refresh

It also adds regression coverage for both:
- prohibited weakness entries
- stale prohibited category entries such as `CWE-16`

The refresh script message is updated as well so it reflects the actual filtering rule.

## Review Note For Maintainer

This is a small corrective follow-up to merged PR #939.

I verified that prohibited CWE entries can still remain visible after refresh because the current filter does not fully honor the upstream vulnerability-mapping field (`Mapping_Notes -> Usage = Prohibited`) and does not remove stale prohibited rows already present in the DB.

`CWE-16` is a concrete live example of that gap.

This PR keeps the scope narrow:
- filter prohibited entries using upstream mapping metadata
- remove stale prohibited CWE rows on refresh
- add regression coverage

Tested locally with:

```bash
/home/born/Important_Stuff/OpenCRE/venv/bin/python -m pytest application/tests/cwe_parser_test.py -k 'prohibited or register_CWE' -q