### PR TITLE
Fix migration bootstrap failures on fresh Postgres

### DIFF
--- a/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
+++ b/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
@@ -1,7 +1,7 @@
 """add missing document_metadata column to node and cre
 
 Revision ID: b5ac48010165
-Revises: c7d8e9f0a1b2
+Revises: d4e5f6a7b8c9
 Create Date: 2026-07-24 22:19:01.724833
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "b5ac48010165"
-down_revision = "c7d8e9f0a1b2"
+down_revision = "d4e5f6a7b8c9"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
+++ b/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
@@ -1,0 +1,42 @@
+"""add missing document_metadata column to node and cre
+
+Revision ID: b5ac48010165
+Revises: c7d8e9f0a1b2
+Create Date: 2026-07-24 22:19:01.724833
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = 'b5ac48010165'
+down_revision = 'c7d8e9f0a1b2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Defensive: some environments (e.g. production) already have this column
+    # applied out-of-band without a corresponding migration ever being
+    # committed, so this must not assume a clean "column doesn't exist" state.
+    inspector = inspect(op.get_bind())
+    node_columns = {c["name"] for c in inspector.get_columns("node")}
+    cre_columns = {c["name"] for c in inspector.get_columns("cre")}
+
+    if "document_metadata" not in node_columns:
+        with op.batch_alter_table("node", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("document_metadata", sa.JSON(), nullable=True))
+
+    if "document_metadata" not in cre_columns:
+        with op.batch_alter_table("cre", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("document_metadata", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("cre", schema=None) as batch_op:
+        batch_op.drop_column("document_metadata")
+
+    with op.batch_alter_table("node", schema=None) as batch_op:
+        batch_op.drop_column("document_metadata")

--- a/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
+++ b/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
@@ -40,8 +40,11 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table("cre", schema=None) as batch_op:
-        batch_op.drop_column("document_metadata")
-
-    with op.batch_alter_table("node", schema=None) as batch_op:
-        batch_op.drop_column("document_metadata")
+    # Intentional no-op: upgrade() only adds this column where it was
+    # missing, so on environments where it pre-existed (e.g. production,
+    # applied out-of-band) this migration never created it. Unconditionally
+    # dropping it here would destroy that pre-existing data on downgrade.
+    # There is no reliable way to tell "did *this* migration add the
+    # column" apart from "did it already exist," so the safe choice is to
+    # leave the column alone rather than risk deleting real data.
+    pass

--- a/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
+++ b/migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py
@@ -5,14 +5,15 @@ Revises: c7d8e9f0a1b2
 Create Date: 2026-07-24 22:19:01.724833
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
 
 
 # revision identifiers, used by Alembic.
-revision = 'b5ac48010165'
-down_revision = 'c7d8e9f0a1b2'
+revision = "b5ac48010165"
+down_revision = "c7d8e9f0a1b2"
 branch_labels = None
 depends_on = None
 
@@ -27,11 +28,15 @@ def upgrade():
 
     if "document_metadata" not in node_columns:
         with op.batch_alter_table("node", schema=None) as batch_op:
-            batch_op.add_column(sa.Column("document_metadata", sa.JSON(), nullable=True))
+            batch_op.add_column(
+                sa.Column("document_metadata", sa.JSON(), nullable=True)
+            )
 
     if "document_metadata" not in cre_columns:
         with op.batch_alter_table("cre", schema=None) as batch_op:
-            batch_op.add_column(sa.Column("document_metadata", sa.JSON(), nullable=True))
+            batch_op.add_column(
+                sa.Column("document_metadata", sa.JSON(), nullable=True)
+            )
 
 
 def downgrade():


### PR DESCRIPTION

Fixes #994 — `flask db upgrade` fails when run against a genuinely fresh,
empty Postgres database, because no migration anywhere creates the
`document_metadata` column that the `Node` and `CRE` models require.

**Note on scope:** #994 originally reported three bugs. Two of them
(the `uq_pair` constraint collision, and the two unmerged migration
heads) were already fixed upstream independently before this PR was
ready — see `a55e380` (constraint fix) and `c7d8e9f0a1b2` (which merges
both heads while adding pgvector support). This PR delivers the one
remaining bug: the missing `document_metadata` column.

## The bug

`application/database/db.py` defines `document_metadata` as a real
column on both `Node` and `CRE` (mapped via `metadata_json`), but no
migration anywhere creates it. A fresh migration run crashes the first
time any code queries it:


## The fix

Adds `migrations/versions/b5ac48010165_add_missing_document_metadata_column_to_.py`,
which creates the column on both tables — defensively checking whether
it already exists first, since production likely has it applied
out-of-band already (a common way this kind of drift survives — someone
patches the live schema directly without the change ever making it back
into a migration file).

## Test plan

- [x] Dropped/recreated a fresh local Postgres database (pgvector-enabled)
- [x] Ran `flask db upgrade heads` end-to-end from empty — completes cleanly
- [x] `flask db heads` shows exactly 1 head (`b5ac48010165`)
- [x] Confirmed via `\d cre` / `\d node` in psql — `document_metadata`
      present on both tables
- [x] `black --check` passes on the new migration file
      
## Verification

Before Fix:

https://github.com/user-attachments/assets/53d275ad-f551-4331-8133-6ae6e11b882a

After Fix :       

https://github.com/user-attachments/assets/b9bad650-be38-4cf0-a945-20d4d5814f07

