### PR TITLE
docs: clarify local contributor setup for upstream sync and MyOpenCRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,16 @@ Install dependencies:
 make install
 ```
 
-Download the latest CRE graph from upstream by running:
+Create the local schema and download the latest CRE graph from upstream:
 
 ```bash
+make migrate-upgrade
 make upstream-sync
 ```
+
+For contributors, this is the supported local data bootstrap path. You do
+**not** need access to the internal OpenCRE Google Sheet to work on the
+project.
 
 You can precompute local gap-analysis cache after imports with:
 
@@ -109,17 +114,31 @@ Notes:
 - `--csv` is required when using `--export`.
 - This mode exports report data from the OpenCRE API and does not mutate the local DB.
 
-To download a remote CRE spreadsheet locally you can run:
+If you need to review a remote spreadsheet locally, you can run:
 
 ```bash
 python cre.py --review --from_spreadsheet <google sheets url>
 ```
 
-To add a remote spreadsheet to your local database you can run:
+If you need to add a remote spreadsheet to your local database, you can run:
 
 ```bash
 python cre.py --add --from_spreadsheet <google sheets url>
 ```
+
+Those spreadsheet commands are not required for ordinary contribution and local
+development. If you want to import your own mappings locally, use MyOpenCRE or
+the CSV import endpoint with imports enabled:
+
+```bash
+export CRE_ALLOW_IMPORT=true
+make dev-flask
+```
+
+Then use:
+
+- `GET /rest/v1/cre_csv` to download a template
+- `POST /rest/v1/cre_csv_import` to upload your CSV
 
 To run the web application for development you can run:
 
@@ -239,8 +258,12 @@ xcode-select --install
 Sync upstream CRE data (requires internet access):
 
 ```bash
+make migrate-upgrade
 make upstream-sync
 ```
+
+You do not need Google Sheet access for this workflow. `make upstream-sync`
+pulls the public OpenCRE graph into your local database.
 
 Then start the local server:
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,8 @@ Notes:
 - `--csv` is required when using `--export`.
 - This mode exports report data from the OpenCRE API and does not mutate the local DB.
 
-If you need to review a remote spreadsheet locally, you can run:
-
-```bash
-python cre.py --review --from_spreadsheet <google sheets url>
-```
-
-If you need to add a remote spreadsheet to your local database, you can run:
+Maintainer-only: if you need to add a remote spreadsheet to your local
+database, you can run:
 
 ```bash
 python cre.py --add --from_spreadsheet <google sheets url>
@@ -132,13 +127,14 @@ the CSV import endpoint with imports enabled:
 
 ```bash
 export CRE_ALLOW_IMPORT=true
-make dev-flask
+make start-containers
 ```
 
 Then use:
 
 - `GET /rest/v1/cre_csv` to download a template
 - `POST /rest/v1/cre_csv_import` to upload your CSV
+- send the multipart file field as `cre_csv`
 
 To run the web application for development you can run:
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,15 @@ make start-containers
 Then use:
 
 - `GET /rest/v1/cre_csv` to download a template
-- `POST /rest/v1/cre_csv_import` to upload your CSV
+- `POST /rest/v1/cre_csv_import` to upload your CSV after starting the local API
 - send the multipart file field as `cre_csv`
+
+Example, once `make dev-flask` is running:
+
+```bash
+curl -X POST http://localhost:5000/rest/v1/cre_csv_import \
+  -F cre_csv=@my_mappings.csv
+```
 
 To run the web application for development you can run:
 

--- a/docs/developmentSetup.md
+++ b/docs/developmentSetup.md
@@ -109,7 +109,38 @@ If the tests pass, the project should be operational. You can run tests with
 
 ### Import the database
 
-You can run `make migrate-upgrade` first and then `make upstream-sync`
+For local development, you do **not** need access to the OpenCRE Google Sheet.
+That spreadsheet is part of the maintainer workflow for bulk standards imports.
+
+The supported contributor workflow is:
+
+1. create the local database schema
+2. sync the public OpenCRE graph from upstream
+3. import your own mappings locally through MyOpenCRE if needed
+
+Run:
+
+```bash
+make migrate-upgrade
+make upstream-sync
+```
+
+`make upstream-sync` downloads the OpenCRE graph from the public API into your
+local `standards_cache.sqlite`.
+
+If you want to map your own standard locally, enable imports and use MyOpenCRE
+or the CSV import endpoint:
+
+```bash
+export CRE_ALLOW_IMPORT=true
+make dev-flask
+```
+
+Then you can:
+
+- open the local MyOpenCRE UI
+- download a CSV template from `GET /rest/v1/cre_csv`
+- upload your CSV to `POST /rest/v1/cre_csv_import`
 
 ## Running locally
 

--- a/docs/developmentSetup.md
+++ b/docs/developmentSetup.md
@@ -141,6 +141,13 @@ Then you can:
 - open the local MyOpenCRE UI
 - download a CSV template from `GET /rest/v1/cre_csv`
 - upload your CSV to `POST /rest/v1/cre_csv_import`
+- send the multipart file field as `cre_csv`
+
+Maintainer-only spreadsheet import example:
+
+```bash
+python cre.py --add --from_spreadsheet <google sheets url>
+```
 
 ## Running locally
 

--- a/docs/developmentSetup.md
+++ b/docs/developmentSetup.md
@@ -140,8 +140,15 @@ Then you can:
 
 - open the local MyOpenCRE UI
 - download a CSV template from `GET /rest/v1/cre_csv`
-- upload your CSV to `POST /rest/v1/cre_csv_import`
+- upload your CSV to `POST /rest/v1/cre_csv_import` after starting the local API
 - send the multipart file field as `cre_csv`
+
+Example, once `make dev-flask` is running:
+
+```bash
+curl -X POST http://localhost:5000/rest/v1/cre_csv_import \
+  -F cre_csv=@my_mappings.csv
+```
 
 Maintainer-only spreadsheet import example:
 


### PR DESCRIPTION
## Summary
This PR updates the contributor documentation for issue #599  to clarify the supported local development workflow for OpenCRE.

In particular, it makes it explicit that contributors do not need access to the internal OpenCRE Google Sheet for normal local development, and that the supported bootstrap path is to create the local schema, sync from upstream, and optionally use local MyOpenCRE / CSV import when needed.

## Problem
The current setup documentation leaves a gap around how contributors should work locally when they do not have access to the internal OpenCRE spreadsheet workflow.

Because of that, it is easy to assume that Google Sheet access is required to get started, even though the supported contributor path is actually:

- create the local schema
- sync the public OpenCRE graph from upstream
- optionally import local mappings via MyOpenCRE / CSV import

That documentation gap is what issue `#599` is about.

## Solution
This PR clarifies the supported contributor workflow in the docs by:

- explicitly stating that Google Sheet access is not required for ordinary contribution
- documenting `make migrate-upgrade` followed by `make upstream-sync` as the standard local bootstrap path
- explaining that `make upstream-sync` pulls the public OpenCRE graph into the local database
- documenting the optional local import path using `CRE_ALLOW_IMPORT=true`, MyOpenCRE, and the CSV import endpoints
- reframing spreadsheet-based commands as optional / specialized rather than required for normal development

## Changed Files

Changed files:

- `README.md`
- `docs/developmentSetup.md`

This is a docs-only change. It does not modify runtime behavior, import logic, or database code.
