### PR TITLE
fix: include FAQ and OpenAPI in Heroku slug

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,6 +1,13 @@
 cres/
 .devcontainer/
-docs/
+# Exclude docs bulk (RFCs, runbooks, roadmap) but keep runtime assets
+# served by Flask: GET /docs/faq.md and GET /rest/v1/openapi.yaml.
+# Note: `docs/` would block re-includes; use `docs/*` + negations instead.
+docs/*
+!docs/faq.md
+!docs/api/
+docs/api/*
+!docs/api/openapi.yaml
 application/tests
 application/frontend/src/test/basic-e2e.test.ts
 .github

--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -1718,3 +1718,25 @@ class TestMain(unittest.TestCase):
                 self.assertEqual(200, response.status_code)
                 body = json.loads(response.data.decode())
                 self.assertTrue(body["login"])
+
+    def test_faq_markdown_endpoint_serves_repo_faq(self) -> None:
+        """GET /docs/faq.md returns the committed FAQ markdown."""
+        with self.app.test_client() as client:
+            response = client.get("/docs/faq.md")
+            self.assertEqual(200, response.status_code)
+            body = response.data.decode()
+            self.assertIn("# OpenCRE FAQ", body)
+            self.assertIn("What is a CRE?", body)
+            self.assertTrue(
+                response.content_type.startswith("text/markdown"),
+                msg=f"unexpected content_type={response.content_type}",
+            )
+
+    def test_openapi_yaml_endpoint_serves_spec(self) -> None:
+        """GET /rest/v1/openapi.yaml returns the committed OpenAPI document."""
+        with self.app.test_client() as client:
+            response = client.get("/rest/v1/openapi.yaml")
+            self.assertEqual(200, response.status_code)
+            body = response.data.decode()
+            self.assertIn("openapi:", body)
+            self.assertIn("/rest/v1/", body)


### PR DESCRIPTION
## Summary
- Keep `docs/faq.md` and `docs/api/openapi.yaml` in the Heroku slug so `/docs/faq.md` and `/rest/v1/openapi.yaml` work on prod
- Add web tests covering both routes
- Root cause: `.slugignore` excluded all of `docs/`, breaking the in-app Docs page FAQ + Swagger UI after #968

## Test plan
- [x] Targeted unittest for FAQ + OpenAPI routes
- [x] `make lint`
- [ ] CI green
- [ ] After merge/deploy: `curl -I https://opencre.org/docs/faq.md` and `https://opencre.org/rest/v1/openapi.yaml` return 200

Made with [Cursor](https://cursor.com)