### PR TITLE
fix: ship FAQ/OpenAPI without Heroku slugignore negations

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,13 +1,14 @@
 cres/
 .devcontainer/
-# Exclude docs bulk (RFCs, runbooks, roadmap) but keep runtime assets
-# served by Flask: GET /docs/faq.md and GET /rest/v1/openapi.yaml.
-# Note: `docs/` would block re-includes; use `docs/*` + negations instead.
-docs/*
-!docs/faq.md
-!docs/api/
-docs/api/*
-!docs/api/openapi.yaml
+# Heroku slugignore does not support gitignore-style ! negations.
+# Exclude heavy docs trees only; keep docs/faq.md and docs/api/openapi.yaml
+# for GET /docs/faq.md and GET /rest/v1/openapi.yaml on prod.
+docs/designs/
+docs/rfc/
+docs/roadmap/
+docs/runbooks/
+docs/gsoc_2026_module_b/
+docs/pull-model-compliance/
 application/tests
 application/frontend/src/test/basic-e2e.test.ts
 .github


### PR DESCRIPTION
## Summary
- **Root cause (from #998):** Heroku `.slugignore` does **not** honor gitignore-style `!` negations. PR #998 used `docs/*` + `!docs/faq.md` / `!docs/api/openapi.yaml`, which left an empty `docs/` on the dyno (Heroku v1009 / `d46245f5`), so FAQ and OpenAPI still 404.
- **Fix:** Replace negation-based excludes with **explicit directory excludes only** (`docs/designs/`, `docs/rfc/`, etc.). Keep `docs/faq.md` and `docs/api/openapi.yaml` by not listing them, so they ship in the slug for `GET /docs/faq.md` and `GET /rest/v1/openapi.yaml`.

## Test plan
- [ ] Confirm `.slugignore` has no `!` lines
- [ ] After merge/deploy: `heroku run -a opencreorg -- bash -lc 'ls -la docs/faq.md docs/api/openapi.yaml'`
- [ ] `curl` https://opencre.org/docs/faq.md → 200
- [ ] `curl` https://opencre.org/rest/v1/openapi.yaml → 200


Made with [Cursor](https://cursor.com)