### PR TITLE
feat(frontend): resource-selection UI in MyOpenCRE (Part of #586)

### DIFF
--- a/application/frontend/src/components/ResourceSelector/ResourceSelector.test.tsx
+++ b/application/frontend/src/components/ResourceSelector/ResourceSelector.test.tsx
@@ -43,6 +43,7 @@ describe('ResourceSelector', () => {
       loading: false,
       saving: false,
       error: null,
+      loadError: false,
       save: jest.fn().mockResolvedValue(['ASVS']),
     });
     (global as any).fetch = standardsFetch(['ASVS', 'CWE', 'SAMM']);
@@ -77,6 +78,7 @@ describe('ResourceSelector', () => {
       loading: false,
       saving: false,
       error: null,
+      loadError: false,
       save: saveMock,
     });
     const { container, findByText, getByText } = render(<ResourceSelector />);
@@ -104,10 +106,26 @@ describe('ResourceSelector', () => {
       loading: false,
       saving: false,
       error: 'Could not save your standards. Please try again.',
+      loadError: false,
       save: jest.fn(),
     });
     const { findByText } = render(<ResourceSelector />);
     expect(await findByText(/could not save/i)).toBeTruthy();
+  });
+
+  it('blocks the picker (no Save) when the initial selection load failed', async () => {
+    // A failed load must not let an empty selection overwrite persisted data.
+    mockSel.mockReturnValue({
+      selected: [],
+      loading: false,
+      saving: false,
+      error: 'Could not load your saved standards.',
+      loadError: true,
+      save: jest.fn(),
+    });
+    const { findByText, queryByText } = render(<ResourceSelector />);
+    expect(await findByText(/could not load your saved standards/i)).toBeTruthy();
+    expect(queryByText('Save')).toBeNull();
   });
 
   it('renders a login prompt (not the checklist) when logged out', async () => {
@@ -120,6 +138,23 @@ describe('ResourceSelector', () => {
     });
     const { findByText, queryByText } = render(<ResourceSelector />);
     expect(await findByText(/log in/i)).toBeTruthy();
+    expect(queryByText('Save')).toBeNull();
+  });
+
+  it('shows an unavailable message (no picker) when logged out and login is disabled', async () => {
+    mockCaps.mockReturnValue({
+      capabilities: { myopencre: true, login: false },
+      loading: false,
+    });
+    mockUser.mockReturnValue({
+      user: null,
+      isLoggedIn: false,
+      loading: false,
+      login: jest.fn(),
+      logout: jest.fn(),
+    });
+    const { findByText, queryByText } = render(<ResourceSelector />);
+    expect(await findByText(/unavailable/i)).toBeTruthy();
     expect(queryByText('Save')).toBeNull();
   });
 

--- a/application/frontend/src/components/ResourceSelector/ResourceSelector.test.tsx
+++ b/application/frontend/src/components/ResourceSelector/ResourceSelector.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { useCapabilities } from '../../hooks/useCapabilities';
+import { useResourceSelection } from '../../hooks/useResourceSelection';
+import { useUser } from '../../hooks/useUser';
+import { ResourceSelector } from './ResourceSelector';
+
+jest.mock('../../hooks/useEnvironment', () => ({
+  useEnvironment: () => ({ name: 'test', apiUrl: '/rest/v1' }),
+}));
+jest.mock('../../hooks/useCapabilities');
+jest.mock('../../hooks/useUser');
+jest.mock('../../hooks/useResourceSelection');
+
+const mockCaps = useCapabilities as jest.Mock;
+const mockUser = useUser as jest.Mock;
+const mockSel = useResourceSelection as jest.Mock;
+
+function standardsFetch(list: string[]): jest.Mock {
+  return jest.fn().mockResolvedValue({
+    status: 200,
+    ok: true,
+    json: () => Promise.resolve(list),
+  });
+}
+
+describe('ResourceSelector', () => {
+  beforeEach(() => {
+    mockCaps.mockReturnValue({
+      capabilities: { myopencre: true, login: true },
+      loading: false,
+    });
+    mockUser.mockReturnValue({
+      user: 'u',
+      isLoggedIn: true,
+      loading: false,
+      login: jest.fn(),
+      logout: jest.fn(),
+    });
+    mockSel.mockReturnValue({
+      selected: ['ASVS'],
+      loading: false,
+      saving: false,
+      error: null,
+      save: jest.fn().mockResolvedValue(['ASVS']),
+    });
+    (global as any).fetch = standardsFetch(['ASVS', 'CWE', 'SAMM']);
+  });
+
+  // clearAllMocks (not resetAllMocks): keep the mock implementations across the
+  // async boundary so a fetch that resolves after a test can't crash a leaked
+  // render by making a mocked hook return undefined.
+  afterEach(() => jest.clearAllMocks());
+
+  it('fetches the full universe of standards with ?all=true', async () => {
+    render(<ResourceSelector />);
+    await waitFor(() => expect((global as any).fetch).toHaveBeenCalled());
+    const url = (global as any).fetch.mock.calls[0][0] as string;
+    expect(url).toContain('/standards?all=true');
+  });
+
+  it('pre-checks the standards in the current selection', async () => {
+    const { container, findByText } = render(<ResourceSelector />);
+    await findByText('Save');
+    const inputs = container.querySelectorAll('input[type="checkbox"]');
+    expect(inputs.length).toBe(3);
+    expect((inputs[0] as HTMLInputElement).checked).toBe(true); // ASVS (selected)
+    expect((inputs[1] as HTMLInputElement).checked).toBe(false); // CWE
+    expect((inputs[2] as HTMLInputElement).checked).toBe(false); // SAMM
+  });
+
+  it('toggling a checkbox and clicking Save persists the updated list', async () => {
+    const saveMock = jest.fn().mockResolvedValue(['ASVS', 'CWE']);
+    mockSel.mockReturnValue({
+      selected: ['ASVS'],
+      loading: false,
+      saving: false,
+      error: null,
+      save: saveMock,
+    });
+    const { container, findByText, getByText } = render(<ResourceSelector />);
+    await findByText('Save');
+    // semantic-ui-react <Checkbox> toggles when the event target is the input:
+    // click the CWE input directly (index 1 in the fixed standards order).
+    const inputs = container.querySelectorAll('input[type="checkbox"]');
+    fireEvent.click(inputs[1] as HTMLElement); // add CWE
+    fireEvent.click(getByText('Save'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const arg = (saveMock.mock.calls[0][0] as string[]).slice().sort();
+    expect(arg).toEqual(['ASVS', 'CWE']);
+  });
+
+  it('shows a success message after a successful save', async () => {
+    const { findByText, getByText } = render(<ResourceSelector />);
+    await findByText('Save');
+    fireEvent.click(getByText('Save'));
+    expect(await findByText(/saved/i)).toBeTruthy();
+  });
+
+  it('shows an error message when the hook reports an error', async () => {
+    mockSel.mockReturnValue({
+      selected: ['ASVS'],
+      loading: false,
+      saving: false,
+      error: 'Could not save your standards. Please try again.',
+      save: jest.fn(),
+    });
+    const { findByText } = render(<ResourceSelector />);
+    expect(await findByText(/could not save/i)).toBeTruthy();
+  });
+
+  it('renders a login prompt (not the checklist) when logged out', async () => {
+    mockUser.mockReturnValue({
+      user: null,
+      isLoggedIn: false,
+      loading: false,
+      login: jest.fn(),
+      logout: jest.fn(),
+    });
+    const { findByText, queryByText } = render(<ResourceSelector />);
+    expect(await findByText(/log in/i)).toBeTruthy();
+    expect(queryByText('Save')).toBeNull();
+  });
+
+  it('renders nothing when the MyOpenCRE capability is off', () => {
+    mockCaps.mockReturnValue({
+      capabilities: { myopencre: false, login: true },
+      loading: false,
+    });
+    const { container } = render(<ResourceSelector />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/application/frontend/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/application/frontend/src/components/ResourceSelector/ResourceSelector.tsx
@@ -13,7 +13,7 @@ export const ResourceSelector = () => {
   const { apiUrl } = useEnvironment();
   const { capabilities } = useCapabilities();
   const { isLoggedIn, loading: userLoading, login } = useUser();
-  const { selected, loading: selectionLoading, saving, error, save } = useResourceSelection();
+  const { selected, loading: selectionLoading, saving, error, loadError, save } = useResourceSelection();
 
   const [standards, setStandards] = useState<string[]>([]);
   const [standardsLoading, setStandardsLoading] = useState(true);
@@ -77,19 +77,35 @@ export const ResourceSelector = () => {
     return null;
   }
 
-  // Logged-out: prompt to sign in rather than showing a blank/broken picker.
-  if (capabilities && capabilities.login && !userLoading && !isLoggedIn) {
-    return (
-      <Message info>
-        <Message.Header>Log in to choose your standards</Message.Header>
-        <p>Sign in to pick which standards appear in your OpenCRE view.</p>
-        <Button primary onClick={login} content="Login" />
-      </Message>
-    );
+  // Wait for capabilities and auth state to settle before deciding.
+  if (!capabilities || userLoading) {
+    return <Loader active inline="centered" content="Loading your standards…" />;
   }
 
-  if (!capabilities || userLoading || selectionLoading || standardsLoading) {
+  // Anonymous users can never edit a selection — cover EVERY logged-out case,
+  // not only when the login capability is available.
+  if (!isLoggedIn) {
+    if (capabilities.login) {
+      return (
+        <Message info>
+          <Message.Header>Log in to choose your standards</Message.Header>
+          <p>Sign in to pick which standards appear in your OpenCRE view.</p>
+          <Button primary onClick={login} content="Login" />
+        </Message>
+      );
+    }
+    return <Message info>Choosing your standards requires signing in, which is unavailable here.</Message>;
+  }
+
+  // Logged in: wait for the selection and the standards universe to load.
+  if (selectionLoading || standardsLoading) {
     return <Loader active inline="centered" content="Loading your standards…" />;
+  }
+
+  // If the initial selection load failed we don't know the user's real
+  // selection — block editing/Save so an empty list can't overwrite it.
+  if (loadError) {
+    return <Message negative>Could not load your saved standards. Please refresh and try again.</Message>;
   }
 
   if (standardsError) {

--- a/application/frontend/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/application/frontend/src/components/ResourceSelector/ResourceSelector.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Checkbox, List, Loader, Message } from 'semantic-ui-react';
+
+import { useCapabilities } from '../../hooks/useCapabilities';
+import { useEnvironment } from '../../hooks/useEnvironment';
+import { useResourceSelection } from '../../hooks/useResourceSelection';
+import { useUser } from '../../hooks/useUser';
+
+// Lets a logged-in user pick which standards appear in their account view, and
+// persist it (Part of #586). Reuses useUser / useCapabilities / useEnvironment
+// and the useResourceSelection hook; renders with semantic-ui-react.
+export const ResourceSelector = () => {
+  const { apiUrl } = useEnvironment();
+  const { capabilities } = useCapabilities();
+  const { isLoggedIn, loading: userLoading, login } = useUser();
+  const { selected, loading: selectionLoading, saving, error, save } = useResourceSelection();
+
+  const [standards, setStandards] = useState<string[]>([]);
+  const [standardsLoading, setStandardsLoading] = useState(true);
+  const [standardsError, setStandardsError] = useState<string | null>(null);
+  const [checked, setChecked] = useState<string[]>([]);
+  const [saved, setSaved] = useState(false);
+
+  // Fetch the FULL universe of standards. ?all=true bypasses the per-user
+  // server-side filter (PR3); without it the picker could only ever show the
+  // user's already-selected standards and never offer new ones to add.
+  useEffect(() => {
+    let active = true;
+    fetch(`${apiUrl}/standards?all=true`, { method: 'GET' })
+      .then((res) => {
+        if (res.status === 200) {
+          return res.json();
+        }
+        throw new Error(`Unexpected /standards status: ${res.status}`);
+      })
+      .then((data) => {
+        if (active && Array.isArray(data)) {
+          setStandards(data);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setStandardsError('Could not load the list of standards.');
+        }
+        console.error('ResourceSelector: could not load standards', err);
+      })
+      .finally(() => {
+        if (active) {
+          setStandardsLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [apiUrl]);
+
+  // Initialise the local checkbox state from the saved selection once it loads.
+  useEffect(() => {
+    setChecked(selected);
+  }, [selected]);
+
+  const toggle = (name: string) => {
+    setSaved(false);
+    setChecked((prev) => (prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]));
+  };
+
+  const onSave = async () => {
+    setSaved(false);
+    const stored = await save(checked);
+    if (stored) {
+      setSaved(true);
+    }
+  };
+
+  // Feature gate: this belongs to MyOpenCRE.
+  if (capabilities && !capabilities.myopencre) {
+    return null;
+  }
+
+  // Logged-out: prompt to sign in rather than showing a blank/broken picker.
+  if (capabilities && capabilities.login && !userLoading && !isLoggedIn) {
+    return (
+      <Message info>
+        <Message.Header>Log in to choose your standards</Message.Header>
+        <p>Sign in to pick which standards appear in your OpenCRE view.</p>
+        <Button primary onClick={login} content="Login" />
+      </Message>
+    );
+  }
+
+  if (!capabilities || userLoading || selectionLoading || standardsLoading) {
+    return <Loader active inline="centered" content="Loading your standards…" />;
+  }
+
+  if (standardsError) {
+    return <Message negative>{standardsError}</Message>;
+  }
+
+  return (
+    <div className="resource-selector">
+      <p>Choose which standards appear in your view. OpenCRE is always included.</p>
+      {standards.length === 0 ? (
+        <Message info>No standards are available yet.</Message>
+      ) : (
+        <List>
+          {standards.map((name) => (
+            <List.Item key={name}>
+              <Checkbox label={name} checked={checked.includes(name)} onChange={() => toggle(name)} />
+            </List.Item>
+          ))}
+        </List>
+      )}
+      <Button primary loading={saving} disabled={saving} onClick={onSave} content="Save" />
+      {saved && !error && <Message positive>Your standards were saved.</Message>}
+      {error && <Message negative>{error}</Message>}
+    </div>
+  );
+};

--- a/application/frontend/src/hooks/index.ts
+++ b/application/frontend/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useEnvironment } from './useEnvironment';
 export { useLocationFromOutsideRoute } from './useLocationFromOutsideRoute';
 export { useCapabilities } from './useCapabilities';
 export { useUser } from './useUser';
+export { useResourceSelection } from './useResourceSelection';

--- a/application/frontend/src/hooks/useResourceSelection.test.ts
+++ b/application/frontend/src/hooks/useResourceSelection.test.ts
@@ -69,6 +69,16 @@ describe('useResourceSelection', () => {
     expect(getByTestId('error').textContent).toBe('Could not load your saved standards.');
   });
 
+  it('flags loadError=true on a 200 with a malformed body (no selected[])', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValueOnce(jsonResponse({ nope: true }, 200));
+
+    const { getByTestId } = render(React.createElement(Probe));
+
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+    expect(captured.loadError).toBe(true);
+    expect(getByTestId('selected').textContent).toBe(''); // persisted data untouched
+  });
+
   it('save() PUTs the selection with the right headers/body and reflects the stored list', async () => {
     const fetchMock = jest
       .fn()

--- a/application/frontend/src/hooks/useResourceSelection.test.ts
+++ b/application/frontend/src/hooks/useResourceSelection.test.ts
@@ -1,0 +1,84 @@
+import { act, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { useResourceSelection } from './useResourceSelection';
+
+jest.mock('./useEnvironment', () => ({
+  useEnvironment: () => ({ name: 'test', apiUrl: '/rest/v1' }),
+}));
+
+// Render the hook through a tiny probe component (react-testing-library v11 has
+// no renderHook) that exposes state to the DOM and a button to trigger save.
+type Captured = ReturnType<typeof useResourceSelection>;
+let captured: Captured;
+
+function Probe(): React.ReactElement {
+  captured = useResourceSelection();
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('span', { 'data-testid': 'loading' }, String(captured.loading)),
+    React.createElement('span', { 'data-testid': 'selected' }, captured.selected.join(',')),
+    React.createElement('span', { 'data-testid': 'error' }, captured.error ?? '')
+  );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('useResourceSelection', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('loads the current selection on mount', async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce(jsonResponse({ selected: ['ASVS', 'CWE'] }));
+    (global as any).fetch = fetchMock;
+
+    const { getByTestId } = render(React.createElement(Probe));
+
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+    expect(fetchMock).toHaveBeenCalledWith('/rest/v1/user/resources', { method: 'GET' });
+    expect(getByTestId('selected').textContent).toBe('ASVS,CWE');
+  });
+
+  it('treats 401 as anonymous / not-available (empty selection, no error)', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValueOnce(jsonResponse(null, 401));
+
+    const { getByTestId } = render(React.createElement(Probe));
+
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+    expect(getByTestId('selected').textContent).toBe('');
+    expect(getByTestId('error').textContent).toBe('');
+  });
+
+  it('save() PUTs the selection with the right headers/body and reflects the stored list', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ selected: [] })) // initial GET
+      .mockResolvedValueOnce(jsonResponse({ selected: ['ASVS', 'CWE'] })); // PUT echo
+    (global as any).fetch = fetchMock;
+
+    const { getByTestId } = render(React.createElement(Probe));
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+
+    let returned: string[] | null = null;
+    await act(async () => {
+      returned = await captured.save(['ASVS', 'CWE']);
+    });
+
+    expect(fetchMock).toHaveBeenLastCalledWith('/rest/v1/user/resources', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ selected: ['ASVS', 'CWE'] }),
+    });
+    expect(returned).toEqual(['ASVS', 'CWE']);
+    expect(getByTestId('selected').textContent).toBe('ASVS,CWE');
+  });
+});

--- a/application/frontend/src/hooks/useResourceSelection.test.ts
+++ b/application/frontend/src/hooks/useResourceSelection.test.ts
@@ -56,6 +56,17 @@ describe('useResourceSelection', () => {
     await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
     expect(getByTestId('selected').textContent).toBe('');
     expect(getByTestId('error').textContent).toBe('');
+    expect(captured.loadError).toBe(false); // 401 is not a load failure
+  });
+
+  it('flags loadError=true when the initial load fails (non-401)', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValueOnce(jsonResponse(null, 500));
+
+    const { getByTestId } = render(React.createElement(Probe));
+
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+    expect(captured.loadError).toBe(true);
+    expect(getByTestId('error').textContent).toBe('Could not load your saved standards.');
   });
 
   it('save() PUTs the selection with the right headers/body and reflects the stored list', async () => {

--- a/application/frontend/src/hooks/useResourceSelection.ts
+++ b/application/frontend/src/hooks/useResourceSelection.ts
@@ -26,33 +26,40 @@ export const useResourceSelection = (): ResourceSelectionState => {
 
   useEffect(() => {
     let active = true;
-    fetch(`${apiUrl}/user/resources`, { method: 'GET' })
-      .then((res) => {
-        if (res.status === 200) {
-          return res.json();
-        }
+
+    const load = async () => {
+      try {
+        const res = await fetch(`${apiUrl}/user/resources`, { method: 'GET' });
         if (res.status === 401) {
-          return null; // anonymous / feature not available — not an error
+          return; // anonymous / feature not available — not an error
         }
-        throw new Error(`Unexpected /user/resources status: ${res.status}`);
-      })
-      .then((data) => {
-        if (active && data && Array.isArray(data.selected)) {
+        if (res.status !== 200) {
+          throw new Error(`Unexpected /user/resources status: ${res.status}`);
+        }
+        const data = await res.json();
+        // Only accept a well-formed payload; a malformed 200 must not be treated
+        // as an (empty) selection that could later overwrite persisted data.
+        if (!data || !Array.isArray(data.selected)) {
+          throw new Error('Malformed /user/resources response: missing selected[]');
+        }
+        if (active) {
           setSelected(data.selected);
         }
-      })
-      .catch((err) => {
+      } catch (err) {
         if (active) {
           setError('Could not load your saved standards.');
           setLoadError(true);
         }
         console.error('useResourceSelection: could not load selection', err);
-      })
-      .finally(() => {
+      } finally {
         if (active) {
           setLoading(false);
         }
-      });
+      }
+    };
+
+    load();
+
     return () => {
       active = false;
     };

--- a/application/frontend/src/hooks/useResourceSelection.ts
+++ b/application/frontend/src/hooks/useResourceSelection.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+
+import { useEnvironment } from './useEnvironment';
+
+export type ResourceSelectionState = {
+  selected: string[];
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  save: (next: string[]) => Promise<string[] | null>;
+};
+
+// Per-user resource selection (Part of #586). Mirrors useUser's raw-fetch status
+// handling: 200 ok, 401 -> anonymous / not available, anything else -> error.
+export const useResourceSelection = (): ResourceSelectionState => {
+  const { apiUrl } = useEnvironment();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch(`${apiUrl}/user/resources`, { method: 'GET' })
+      .then((res) => {
+        if (res.status === 200) {
+          return res.json();
+        }
+        if (res.status === 401) {
+          return null; // anonymous / feature not available — not an error
+        }
+        throw new Error(`Unexpected /user/resources status: ${res.status}`);
+      })
+      .then((data) => {
+        if (active && data && Array.isArray(data.selected)) {
+          setSelected(data.selected);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setError('Could not load your saved standards.');
+        }
+        console.error('useResourceSelection: could not load selection', err);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [apiUrl]);
+
+  const save = async (next: string[]): Promise<string[] | null> => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiUrl}/user/resources`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ selected: next }),
+      });
+      if (!res.ok) {
+        throw new Error(`Unexpected PUT /user/resources status: ${res.status}`);
+      }
+      const data = await res.json();
+      const stored = data && Array.isArray(data.selected) ? data.selected : next;
+      setSelected(stored);
+      return stored;
+    } catch (err) {
+      setError('Could not save your standards. Please try again.');
+      console.error('useResourceSelection: could not save selection', err);
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return { selected, loading, saving, error, save };
+};

--- a/application/frontend/src/hooks/useResourceSelection.ts
+++ b/application/frontend/src/hooks/useResourceSelection.ts
@@ -7,6 +7,10 @@ export type ResourceSelectionState = {
   loading: boolean;
   saving: boolean;
   error: string | null;
+  // True only when the INITIAL load genuinely failed (network / unexpected
+  // status) — NOT for the 401 anonymous case. When true the selection is
+  // unknown, so callers must not let an empty list overwrite persisted data.
+  loadError: boolean;
   save: (next: string[]) => Promise<string[] | null>;
 };
 
@@ -18,6 +22,7 @@ export const useResourceSelection = (): ResourceSelectionState => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -39,6 +44,7 @@ export const useResourceSelection = (): ResourceSelectionState => {
       .catch((err) => {
         if (active) {
           setError('Could not load your saved standards.');
+          setLoadError(true);
         }
         console.error('useResourceSelection: could not load selection', err);
       })
@@ -77,5 +83,5 @@ export const useResourceSelection = (): ResourceSelectionState => {
     }
   };
 
-  return { selected, loading, saving, error, save };
+  return { selected, loading, saving, error, loadError, save };
 };

--- a/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.tsx
+++ b/application/frontend/src/pages/MyOpenCRE/MyOpenCRE.tsx
@@ -3,6 +3,7 @@ import './MyOpenCRE.scss';
 import React, { useRef, useState } from 'react';
 import { Button, Container, Form, Header, Message } from 'semantic-ui-react';
 
+import { ResourceSelector } from '../../components/ResourceSelector/ResourceSelector';
 import { useEnvironment } from '../../hooks';
 
 type RowValidationError = {
@@ -247,6 +248,11 @@ export const MyOpenCRE = () => {
         Start by downloading the CRE catalogue below, then map your standard's controls or sections to CRE IDs
         in the spreadsheet.
       </p>
+
+      <div className="myopencre-section myopencre-resources">
+        <Header as="h3">Your standards</Header>
+        <ResourceSelector />
+      </div>
 
       <div className="myopencre-section">
         <Button primary onClick={downloadCreCsv}>

--- a/application/frontend/src/setupTests.ts
+++ b/application/frontend/src/setupTests.ts
@@ -1,0 +1,5 @@
+// Setup for the jsdom component-test lane (Part of #586, PR4).
+// @testing-library/react (v11) auto-cleans the DOM after each test. No
+// @testing-library/jest-dom is present, so tests use core jest matchers against
+// Testing Library queries rather than jest-dom matchers.
+export {};

--- a/jest.component.config.js
+++ b/jest.component.config.js
@@ -1,0 +1,23 @@
+// Isolated jsdom component-test lane (Part of #586, PR4).
+//
+// This is deliberately NOT named jest.config.js: a bare `jest` (the existing
+// `test:e2e` / puppeteer lane) auto-discovers jest.config.js, so using a
+// distinct filename keeps that lane on its defaults. The new `test` script
+// points here explicitly via `--config`.
+//
+// testMatch is scoped to the frontend component/hook tests and testPathIgnore
+// excludes the puppeteer e2e (src/test/basic-e2e.test.ts).
+module.exports = {
+  testEnvironment: 'jsdom',
+  rootDir: '.',
+  roots: ['<rootDir>/application/frontend/src'],
+  testMatch: [
+    '<rootDir>/application/frontend/src/**/*.test.ts',
+    '<rootDir>/application/frontend/src/**/*.test.tsx',
+  ],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/application/frontend/src/test/'],
+  setupFilesAfterEnv: ['<rootDir>/application/frontend/src/setupTests.ts'],
+  moduleNameMapper: {
+    '\\.(scss|sass|css)$': 'identity-obj-proxy',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "prettier --write '**/*.tsx' '**/*.ts' '**/*.js'",
     "build": "webpack --config webpack.prod.js",
     "start": "webpack serve",
+    "test": "jest --config jest.component.config.js",
     "test:e2e": "jest",
     "postinstall": "del-cli node_modules/@types/react-dom/node_modules/@types && del-cli node_modules/webpack/types.d.ts && del-cli node_modules/@types/minimatch"
   },


### PR DESCRIPTION
## What & why
Final core piece of #586, building on the merged backend chain: user + selection
persistence (#980), the GET/PUT /rest/v1/user/resources API (#981), and server-side
filtering of /rest/v1/standards (#1001). This wires the frontend on top.
Frontend-only — no backend changes.


## Changes
- **`useResourceSelection` hook** — GET/PUT `/rest/v1/user/resources`, same
  raw-fetch/status handling as `useUser` (200 ok, 401 → anonymous, other → error);
  returns `{ selected, loading, save, saving, error }`.
- **`ResourceSelector` component** — fetches the full universe via
  `/rest/v1/standards?all=true` (must bypass the per-user filter, or the picker
  could never show unselected standards), renders a semantic-ui-react checkbox
  list pre-checked from the saved selection, with an explicit **Save** button and
  Loader / saved / error `<Message>` states. Prompts to log in when logged out;
  renders nothing when the MyOpenCRE capability is off.
- **MyOpenCRE page** — new "Your standards" section (no new route/nav; reuses the
  existing `capabilities.myopencre` gating).

Reuses `useUser` / `useCapabilities` / `useEnvironment` unchanged. react-router v5
+ semantic-ui-react only. No backend, migration, or auth-route changes.

## Tests / first jsdom component-test lane
This adds the repo's **first jsdom component-test lane**: `jest.component.config.js`
(+ `src/setupTests.ts`) and a new `yarn test` script, reusing `@testing-library/react`
+ `ts-jest` already in `package.json`. The existing `test:e2e` / puppeteer config is
**untouched** (no `jest.config.js` is introduced, so bare `jest` keeps its defaults),
and this lane is **not** wired into `make frontend` or CI yet.

10 tests: hook load/401/save-PUT-body; component `?all=true` fetch, pre-checked
selection, toggle+Save, success + error messages, logged-out prompt, myopencre-off gate.

## Verification (local)
- `yarn test` → 10 passed
- `yarn test:e2e --listTests` still lists `basic-e2e.test.ts` (e2e config unchanged)
- `make frontend` (webpack prod) builds clean
- `yarn lint` (prettier) applied
