### PR TITLE
Fix flaky gap-analysis tests connecting to real Redis instead of mock

### DIFF
--- a/application/tests/web_main_test.py
+++ b/application/tests/web_main_test.py
@@ -10,7 +10,6 @@ import tempfile
 from types import SimpleNamespace
 from unittest.mock import patch, Mock
 
-import redis
 import rq
 import os
 import networkx as nx
@@ -20,6 +19,7 @@ from application.tests.utils import data_gen
 from application.database import db
 from application.cmd import cre_main
 from application.utils import spreadsheet
+from application.utils import redis as app_redis
 from application.defs import cre_defs as defs
 from application.web import web_main
 from application.utils.gap_analysis import GAP_ANALYSIS_TIMEOUT
@@ -741,7 +741,7 @@ class TestMain(unittest.TestCase):
             self.assertEqual(404, response.status_code)
             mock_redirect.assert_called_once_with("CWE", "999")
 
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     @patch.object(db, "Node_collection")
     def test_gap_analysis_from_cache_full_response(
         self, db_mock, redis_conn_mock
@@ -762,7 +762,7 @@ class TestMain(unittest.TestCase):
     @patch.object(db, "Node_collection")
     @patch.object(rq.job.Job, "fetch")
     @patch.object(rq.Queue, "enqueue_call")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_gap_analysis_from_cache_job_id(
         self, redis_conn_mock, enqueue_call_mock, fetch_mock, db_mock
     ) -> None:
@@ -784,7 +784,7 @@ class TestMain(unittest.TestCase):
     @patch.object(db, "Node_collection")
     @patch.object(rq.job.Job, "fetch")
     @patch.object(rq.Queue, "enqueue_call")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_gap_analysis_returns_existing_inflight_job(
         self, redis_conn_mock, enqueue_call_mock, fetch_mock, db_mock
     ) -> None:
@@ -804,7 +804,7 @@ class TestMain(unittest.TestCase):
 
     @patch.object(db, "Node_collection")
     @patch.object(rq.Queue, "enqueue_call")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_gap_analysis_create_job_id(
         self, redis_conn_mock, enqueue_call_mock, db_mock
     ) -> None:
@@ -832,7 +832,7 @@ class TestMain(unittest.TestCase):
 
     @patch.object(db, "Node_collection")
     @patch.object(rq.Queue, "enqueue_call")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_map_analysis_non_material_sql_cache_triggers_job(
         self, redis_conn_mock, enqueue_call_mock, db_mock
     ) -> None:
@@ -852,7 +852,7 @@ class TestMain(unittest.TestCase):
 
     @patch.object(db, "Node_collection")
     @patch.object(db, "gap_analysis")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_gap_analysis_fallback_without_redis(
         self, redis_conn_mock, db_gap_analysis_mock, db_mock
     ) -> None:
@@ -872,7 +872,7 @@ class TestMain(unittest.TestCase):
 
     @patch.object(db, "Node_collection")
     @patch.object(db, "gap_analysis")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_gap_analysis_fallback_backend_failure_returns_503(
         self, redis_conn_mock, db_gap_analysis_mock, db_mock
     ) -> None:
@@ -893,7 +893,7 @@ class TestMain(unittest.TestCase):
 
     @patch.dict(os.environ, {"HEROKU": "True"}, clear=False)
     @patch.object(db, "Node_collection")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_gap_analysis_heroku_cache_miss_returns_404(
         self, redis_conn_mock, db_mock
     ) -> None:
@@ -909,7 +909,7 @@ class TestMain(unittest.TestCase):
 
     @patch.dict(os.environ, {"DYNO": "web.1"}, clear=False)
     @patch.object(db, "Node_collection")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_gap_analysis_dyno_cache_miss_returns_404(
         self, redis_conn_mock, db_mock
     ) -> None:
@@ -925,7 +925,7 @@ class TestMain(unittest.TestCase):
 
     @patch.dict(os.environ, {"HEROKU": "True"}, clear=False)
     @patch.object(db, "Node_collection")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     def test_map_analysis_opencre_heroku_cache_miss_returns_404(
         self, redis_conn_mock, db_mock
     ) -> None:
@@ -939,7 +939,7 @@ class TestMain(unittest.TestCase):
         db_mock.return_value.get_nodes.assert_not_called()
         redis_conn_mock.assert_not_called()
 
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     @patch.object(db, "Node_collection")
     def test_standards_from_db(self, node_mock, redis_conn_mock) -> None:
         expected = ["A", "B"]
@@ -1143,7 +1143,7 @@ class TestMain(unittest.TestCase):
         schedule_mock.assert_not_called()
 
     @patch.object(cre_main, "resource_name_ga_eligible_in_db")
-    @patch.object(redis, "from_url")
+    @patch.object(app_redis, "connect")
     @patch.object(db, "Node_collection")
     def test_ga_standards_filters_non_eligible(
         self, node_mock, redis_conn_mock, ga_eligible_mock


### PR DESCRIPTION
## Summary

Fixes #1009 — several tests in `web_main_test.py` covering
`/rest/v1/map_analysis` were silently connecting to a real local Redis
instance instead of the mock, causing flaky, order-dependent,
environment-dependent test failures.

## Root cause

The tests patched `redis.from_url` (the third-party library's URL-based
connection factory), but `application/utils/redis.py`'s `connect()`
function has three possible branches and takes a **different, unmocked**
one — `redis.StrictRedis(host=..., port=...)` — whenever `REDIS_HOST` and
`REDIS_PORT` environment variables are set. These are set by default for
anyone following this project's own documented local setup
(`.env.example` sets `REDIS_HOST=localhost` / `REDIS_PORT=6379`, loaded
automatically via `load_dotenv()` in `cre.py`). So the standard,
documented local dev setup silently defeated the mock for anyone running
these tests.

## The fix

Patch `application.utils.redis.connect` directly, at its actual point of
use in `web_main.py`, instead of patching one specific branch
(`redis.from_url`) of its internal implementation. This makes the tests
immune to which branch `connect()` takes based on environment variables —
there's now exactly one thing to mock, and it's the thing that's actually
called.

```python
# before
@patch.object(redis, "from_url")

# after
@patch.object(app_redis, "connect")
