### PR TITLE
docs(module-b): commit Module A/C contracts + runbook, synced to current code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ standards_cache.sqlite
 !docs/Mid_eval_blog_gsoc2026/module_B_mideval_blog.md
 !application/utils/librarian/README.md
 !docs/gsoc_2026_module_c/*.md
+!docs/gsoc_2026_module_b/module_a_contract.md
+!docs/gsoc_2026_module_b/module_c_contract.md
+!docs/gsoc_2026_module_b/module_b_runbook.md
 
 ### Dev DBDumps
 *.sql

--- a/application/frontend/src/pages/Search/components/SearchBar.tsx
+++ b/application/frontend/src/pages/Search/components/SearchBar.tsx
@@ -42,24 +42,23 @@ export const SearchBar = () => {
         </label>
 
         <div className="search-container flex items-center">
+          <Search className="search-icon" aria-hidden="true" />
 
-        <Search className="search-icon" aria-hidden="true" />
-
-        <input
-          id={inputId}
-          type="text"
-          placeholder="Search..."
-          value={search.term}
-          aria-label="Search OpenCRE"
-          aria-invalid={Boolean(search.error)}
-          aria-describedby={search.error ? errorId : undefined}
-          onChange={(e) =>
-            setSearch({
-              ...search,
-              term: e.target.value,
-            })
-          }
-        />
+          <input
+            id={inputId}
+            type="text"
+            placeholder="Search..."
+            value={search.term}
+            aria-label="Search OpenCRE"
+            aria-invalid={Boolean(search.error)}
+            aria-describedby={search.error ? errorId : undefined}
+            onChange={(e) =>
+              setSearch({
+                ...search,
+                term: e.target.value,
+              })
+            }
+          />
         </div>
       </form>
       {/* Error text */}

--- a/docs/gsoc_2026_module_b/module_a_contract.md
+++ b/docs/gsoc_2026_module_b/module_a_contract.md
@@ -1,0 +1,212 @@
+# Module A → Module B Input Contract
+
+**Audience:** the GSoC 2026 contributor implementing Module A (Information Harvesting — nightly cron job that fetches content from OWASP repos and feeds). **Status:** draft **v0.4** (2026-08-16). Reconciled against the orchestrated-pipeline hand-off (DB table, not a JSONL file) and Module C's shipped consumer (`feed_item` rss locator kind). Pending review by mentors and the Module A contributor.
+
+This document specifies the format Module A emits so that Module B (Noise/Relevance Filter) can consume it. Module B is the only downstream consumer in v1; any change to this format is a breaking change for B.
+
+---
+
+## Changelog (v0.3 → v0.4)
+
+- **Delivery moved from a JSONL file to a DB table.** The orchestrated pipeline supersedes the earlier "JSONL file via `cre.py --filter_changes <path>`" transport. Module A now writes each record as a row in the shared Postgres `harvest_input` table (JSONB `payload` + top-level `pipeline_run_id` + `status`); Module B reads the pending rows for a run. The `--filter_changes` CLI was never built; Module B's entry point is `cre.py --run_noise_filter --run_id <id>`.
+- **rss `locator.kind` reserved value is `feed_item`** (was `feed_post`), aligning with Module C's shipped consumer (PR #1011), which addresses rss rows by `locator_kind = "feed_item"`. github rows are unchanged (`repo_path`). rss is still not emitted; this only fixes the reserved name so all three modules agree.
+
+## Changelog (v0.2 → v0.3)
+
+Driven by reconciliation with Module A's actual mock output. The shape is significantly different from what the v0.2 draft anticipated.
+
+- **Structural shift:** record fields are no longer flat. Three nested objects now exist: `source` (provenance), `span` (chunk position within parent artifact), `locator` (addressable identity).
+- **New top-level fields:** `schema_version`, `chunk_id`, `pipeline_run_id`.
+- **Renames / relocations:**
+  - `chunk_text` → `text`
+  - `source_type` → `source.type`
+  - `repo` → `source.repo`
+  - `commit_sha` → `source.commit_sha`
+  - `author_date` → `source.committed_at`
+  - `file_path` → `locator.path` (also `locator.id` mirrors for now)
+  - `chunk_index` → `span.index`
+- **New `span` payload:** beyond `index` (which `chunk_index` already provided), `span` also carries `total`, `heading_path` (the markdown heading breadcrumb), `start_char_idx`/`end_char_idx`, `start_line`/`end_line`.
+- **`content_hash` removed.** Module A does not emit a content hash. **Module B computes its own** by applying the v0.2 normalization rules (NFC, line endings, whitespace, code-fence preservation) and SHA-256-ing the result. Used by B as the `knowledge_queue` dedup key.
+- **`commit_message` removed.** Module A does not emit commit messages. Module B's LLM prompt now uses `span.heading_path` as the semantic context signal instead (e.g. `["Authentication", "JWT"]` is a richer disambiguator than a commit message).
+- **`source.type = "rss"` is reserved.** Mock data is github-only; the discriminated-union schema accepts RSS shape so we're ready when Module A emits feed records.
+- **Mock note:** the mock data uses placeholder values like `"abc123"` for `commit_sha` and `"…"` (encoded as corrupted UTF-8 `â¦` in the source) for path segments inside `chunk_id`. Production must emit real 40-char SHAs and clean UTF-8.
+
+---
+
+## Transport
+
+- **Format:** one JSON object per chunk — the record described below — stored verbatim as the JSONB `payload` of a `harvest_input` row. (Module B's local test fixtures still keep the same records as JSONL; the on-the-wire shape of a single record is identical either way.)
+- **Delivery:** Module A writes each record as a row in the shared Postgres **`harvest_input`** table — columns `payload` (JSONB, the record), `pipeline_run_id` (top-level, run-scoping), `status` (`pending` → set by A; `processed`/`error` → set by B), plus `id`/`created_at`. Module B reads that run's pending rows (`cre.py --run_noise_filter --run_id <id>`), classifies, and writes keepers to `knowledge_queue`. See `module_b_runbook.md` for the operational how-to. *(The earlier "JSONL file via `cre.py --filter_changes`" delivery is superseded and was never implemented.)*
+- **Run-id consistency (required):** a row's top-level `harvest_input.pipeline_run_id` **must equal** the `pipeline_run_id` inside its JSONB `payload`. Module B scopes a run by the top-level column (`WHERE pipeline_run_id = :run_id`) but copies the *payload's* `pipeline_run_id` onto the `knowledge_queue` row. If the two differ, a chunk is processed under one run yet emitted under another. Module A MUST write identical values (equivalently, Module B may reject rows where they disagree).
+- **Future (out of scope for v1):** object-storage URL (S3/MinIO) for large or out-of-band payloads.
+- **Record size:** governed by Module A's chunking config (default `max_chars=4000`). Module B truncates internally at 1500 chars before sending to the LLM.
+
+## Required fields (top level)
+
+| Field | Type | Constraints |
+|---|---|---|
+| `schema_version` | string | E.g. `"0.2.0"`. Pinned by Module A; B reads but does not validate version semantics. |
+| `chunk_id` | string | Module-A-stable identifier. Format observed in mock: `chk:<artifact_id>:<chunk_index>` (i.e. `chk:art:OWASP/<repo>:<path>:<idx>`). |
+| `artifact_id` | string | Identifier for the parent document. Format observed in mock: `art:<repo>:<path>`. Stable across chunks of the same artifact. |
+| `pipeline_run_id` | string | Identifier for the Module A pipeline execution that produced this record. E.g. `"20260201T020000Z"`. Used by B for audit / replay grouping. |
+| `text` | string | The normalized chunk content. Markdown markers (`#`, `**`, code fences) preserved; HTML stripped; whitespace collapsed in prose but preserved inside code fences (`` ``` ``…`` ``` ``) and `<pre>` blocks. |
+| `span` | object | Position metadata. See below. |
+| `source` | object | Provenance discriminator (`source.type`). See below. |
+| `locator` | object | Addressable identity. See below. |
+
+## Required `span` payload
+
+| Field | Type | Constraints |
+|---|---|---|
+| `index` | int ≥ 0 | Zero-based chunk index within the parent artifact. |
+| `total` | int ≥ 1 | Total chunks Module A produced from this artifact. |
+| `heading_path` | array of strings | Breadcrumb of enclosing markdown headings (e.g. `["Authentication", "JWT"]`). Empty array if the chunk precedes all headings. Used as a semantic signal in B's LLM prompt. |
+| `start_char_idx` | int ≥ 0 (optional) | Character index of chunk start in the normalized artifact text. |
+| `end_char_idx` | int ≥ 0 (optional) | Character index of chunk end (exclusive). |
+| `start_line` | int ≥ 0 (optional) | 1-based line number of chunk start in the normalized artifact. |
+| `end_line` | int ≥ 0 (optional) | 1-based line number of chunk end. |
+
+## Required `source` payload — discriminated union
+
+`source.type` discriminates between provenance shapes.
+
+**When `source.type = "github"`:**
+
+| Field | Type | Constraints |
+|---|---|---|
+| `type` | string | Literal `"github"`. |
+| `repo` | string | Format `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`. Allows OWASP dots/dashes. |
+| `commit_sha` | string | Production: 40-char hex SHA-1. Mock: 6+ char placeholders accepted. |
+| `committed_at` | string | ISO-8601 timestamp. |
+
+**When `source.type = "rss"` (reserved, not yet emitted):**
+
+| Field | Type | Constraints |
+|---|---|---|
+| `type` | string | Literal `"rss"`. |
+| `feed_url` | string | The canonical feed URL Module A subscribed to. |
+| `post_guid` | string | The `<guid>` or `<id>` of the post within the feed. |
+| `post_published_at` | string (optional) | ISO-8601 timestamp. |
+
+## Required `locator` payload
+
+| Field | Type | Constraints |
+|---|---|---|
+| `kind` | string | Scheme. `"repo_path"` for github sources today. Reserved: `"feed_item"` for RSS (matches Module C's consumer, PR #1011). |
+| `id` | string | Unique identity within the scheme. For `repo_path`: the file path. For `feed_item`: the post URL. |
+| `path` | string | For `repo_path`: convenience duplicate of `id` (`id == path`), used by B's regex path filter. For `feed_item`: **the post URL** — Module C requires a parseable URL for a `feed_item` locator (its consumer rejects a `feed_item` without one), so `path` carries the item URL (stored as `knowledge_queue.locator_path`). |
+
+## Example record (github source — mock-shaped)
+
+```json
+{
+  "schema_version": "0.2.0",
+  "chunk_id": "chk:art:OWASP/ASVS:4.0/en/0x12-V3-Authentication.md:0",
+  "artifact_id": "art:OWASP/ASVS:4.0/en/0x12-V3-Authentication.md",
+  "pipeline_run_id": "20260201T020000Z",
+  "text": "Authentication should use MFA",
+  "span": {
+    "index": 0,
+    "total": 3,
+    "heading_path": ["Authentication", "JWT"],
+    "start_char_idx": 0,
+    "end_char_idx": 98,
+    "start_line": 10,
+    "end_line": 12
+  },
+  "source": {
+    "type": "github",
+    "repo": "OWASP/ASVS",
+    "commit_sha": "abc123",
+    "committed_at": "2026-02-01T01:00:00Z"
+  },
+  "locator": {
+    "kind": "repo_path",
+    "id": "4.0/en/0x12-V3-Authentication.md",
+    "path": "4.0/en/0x12-V3-Authentication.md"
+  }
+}
+```
+
+## Content hashing — Module B's responsibility
+
+Module A does **not** emit `content_hash`. Module B computes one on ingest in `application/utils/noise_filter/hashing.py`:
+
+1. Apply v0.2 normalization rules to `text`:
+   - Unicode NFC
+   - CRLF / CR → LF
+   - Trailing whitespace per line stripped
+   - Leading/trailing blank lines stripped
+   - Runs of spaces/tabs in prose collapsed to one space
+   - Whitespace inside fenced code blocks (`` ``` `` … `` ``` ``) and `<pre>` blocks preserved verbatim
+2. `content_hash = hashlib.sha256(normalized_text.encode("utf-8")).hexdigest()`
+
+The hash becomes the `UniqueConstraint` key on `knowledge_queue` — re-feeding identical normalized content (e.g. mirrored docs, replayed pipeline runs) collapses to one queue row.
+
+**Future:** if Module A starts emitting `content_hash`, B switches via `CRE_NOISE_FILTER_TRUST_A_HASH=true` to skip recomputation. Until then, B is self-sufficient.
+
+## Normalization ownership
+
+- **Module A owns "normalize for chunking":** semantic chunking, heading-path tracking, char/line offsets.
+- **Module B owns "normalize for hashing" + "defensive sanitization":** the rules above (for `content_hash`), plus TRACT-style sanitize.py (zero-width chars, PDF ligatures, hyphenation rejoin) as Stage 1.5 of B's pipeline.
+
+If Module A's own normalization differs from B's (e.g. A doesn't collapse prose whitespace), B's hash still works — B always normalizes before hashing. The two normalizations don't need to agree.
+
+## Path-filtering ownership
+
+- **Module A owns coarse exclusion:** the `paths_exclude` globs in its source config (e.g. `["**/package-lock.json", "**/CNAME"]`). These never reach B.
+- **Module B owns fine-grained noise filtering:** `application/utils/noise_filter/noise_patterns.yaml`. Catches things A's source config didn't anticipate.
+
+If both modules block the same path, that's fine — B silently no-ops. The two lists drift independently.
+
+## Stability guarantees
+
+- **Module B reads only the fields listed above** (and ignores everything else). Extra fields Module A adds — `pr_number`, `author`, `tags`, `supersedes_artifact_id`, etc. — are silently accepted (`extra="ignore"` on B's Pydantic models). Safe to extend.
+- **Renaming or removing any required field is breaking.** Requires a contract version bump and coordinated changes in `application/utils/noise_filter/schemas.py`.
+- **Changing the semantics of a field is breaking** even if the name stays the same. Example: switching `locator.path` to absolute paths would break B's regex pre-filter.
+
+## Idempotency on Module B's side
+
+Module B's `knowledge_queue` uses `UniqueConstraint(content_hash)` as the dedup key. Consequences:
+- Re-feeding the same normalized content is a no-op.
+- The same content reaching B via two different sources collapses to one row.
+- To force re-classification (e.g. prompt changed), Module B will provide an `--allow_duplicate_hash` flag on the CLI. Out of scope for v1.
+
+## Versioning
+
+This contract is **v0.4** (draft). When ratified, becomes v1.0. semver applies:
+- v1.X = additive, non-breaking field additions.
+- v2.0 = breaking changes.
+
+The version applies to *this contract*, not to Module A's release cadence.
+
+## JSON Schema artifact
+
+The machine-readable schema is generated from Module B's Pydantic models and committed at:
+
+```text
+docs/gsoc_2026_module_b/module_a_contract.schema.json
+```
+
+Both modules SHOULD validate against it in CI. Module B's Pydantic model (`application/utils/noise_filter/schemas.ChangeRecord`) is the canonical source; the JSON Schema file is derived via `ChangeRecord.model_json_schema()`.
+
+## Test fixtures
+
+Module B keeps fixtures at:
+
+```text
+application/tests/noise_filter/fixtures/
+├── module_a_mock.jsonl          # Module A's 20-record mock (canonical, what A actually emits)
+├── candidate_commits.json       # B's own stand-in harvest of ~100 OWASP commits in Module A's shape
+└── labeled_data.json            # candidate_commits.json + KNOWLEDGE/NOISE/UNCERTAIN labels
+```
+
+Module A contributors are welcome to add fixtures here as PRs — small files (≤30 records each) covering edge cases (PDF-extracted text, HTML-derived chunks, RSS posts) help Module B's regex and prompt iteration.
+
+## Out-of-scope for this contract
+
+- How Module A produces these records (GitHub API vs `git log` vs webhook vs feed poll).
+- Where Module A stores raw artifacts before chunking.
+- Failure handling on the Module A side (rate-limit retries, partial commits).
+- Authentication / API keys (Module A's concern).
+- Module A's source-config schema (`schema_version`, `sources`, `chunking`) — that's internal to A.

--- a/docs/gsoc_2026_module_b/module_b_runbook.md
+++ b/docs/gsoc_2026_module_b/module_b_runbook.md
@@ -1,0 +1,125 @@
+# Module B — How to Run It (Orchestrator Runbook)
+
+**Audience:** whoever builds/operates the daily orchestrator. **Status:** v0.2 (2026-08-16).
+Companion to `module_c_contract.md` (the B→C contract). This is the operational *how*.
+
+Module B is a **stateless batch step**: the orchestrator invokes it once per harvest run; it reads that run's chunks from a DB table, classifies them, writes the keepers to another table, and exits with a JSON summary. It does not run continuously and does not schedule itself.
+
+---
+
+## 1. One-time setup
+
+**Tables.** Module B owns two tables, created by its Alembic migration
+`d4e5f6a7b8c9_add_module_b_tables` (part of the chain — other modules' migrations
+now chain after it, so it is no longer the head):
+- `harvest_input` — Module A writes here; B reads.
+- `knowledge_queue` — B writes here; Module C reads.
+
+Apply with (validate the migration chain first — required before any upgrade):
+```bash
+make alembic-guardrail   # or: python scripts/check_alembic_revision_guardrail.py
+FLASK_APP=cre.py FLASK_CONFIG=development flask db upgrade
+```
+A full from-empty `flask db upgrade` on Postgres runs the whole chain, creating
+Module B's tables at migration `d4e5f6a7b8c9` (now mid-chain; the current head
+moves as other modules add migrations after it — the from-empty upgrade still
+reaches B's tables regardless). The earlier `uq_pair` duplicate-index bug is
+fixed and merged. One caveat: **C's pgvector migration (`c7d8e9f0a1b2`)
+requires `CRE_EMBED_EXPECTED_DIM` to be set** on an empty DB (it can't infer the
+vector dimension with no embeddings yet) — a pre-existing requirement of that
+migration, e.g. `CRE_EMBED_EXPECTED_DIM=3072 flask db upgrade`. Postgres needs
+the `vector` extension (use the `pgvector/pgvector` image or `CREATE EXTENSION
+vector;`).
+
+**Environment variables:**
+
+| Var | Purpose | Default |
+|---|---|---|
+| `GEMINI_API_KEY` | LLM credential (Gemini) | — (required) |
+| `CRE_NOISE_FILTER_LLM_MODEL` | classification model | `gemini/gemini-2.5-flash-lite` |
+| `CRE_NOISE_FILTER_BATCH_SIZE` | chunks per LLM request | `10` |
+| `CRE_NOISE_FILTER_MAX_CHARS` | per-chunk truncation | `1500` |
+| `CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD` | KNOWLEDGE-below → UNCERTAIN | `0.8` |
+
+Module B needs no ML libraries (no torch/sentence-transformers) — just `litellm` (in the slim prod requirements) + the Gemini key.
+
+---
+
+## 2. The input table `harvest_input` (Module A writes)
+
+One row per harvested chunk:
+
+| Column | Notes |
+|---|---|
+| `id` | any stable PK |
+| `pipeline_run_id` | groups a run — B reads exactly this |
+| `status` | `pending` (A sets) → `processed`/`error` (B sets) |
+| `payload` | **JSONB** — Module A's ChangeRecord (Module A contract v0.4; nested `source`/`span`/`locator`), written as-is |
+| `created_at` | timestamp |
+
+B reads `WHERE pipeline_run_id = :run_id AND status = 'pending'`.
+
+---
+
+## 3. Invoking Module B (the command the orchestrator runs)
+
+```bash
+python cre.py --run_noise_filter --run_id <pipeline_run_id> --cache_file <db-url>
+```
+- `--run_id` — the run to process (**required**).
+- `--cache_file` — the database URL (e.g. `postgresql://user:pass@host:5432/opencre`).
+- `--noise_filter_dry_run` — optional; classify but write nothing / mark nothing (for testing).
+
+The process runs the gate (regex path filter → sanitize → LLM classify), writes keepers, marks the input rows, and exits.
+
+---
+
+## 4. Completion signal (how the orchestrator knows it's done)
+
+- **Exit code `0`** = success; **non-zero** = hard failure (e.g. DB unreachable) → safe to retry the same `run_id` (B is idempotent).
+- **stdout** = a one-line JSON summary:
+```json
+{"run_id":"20260201T020000Z","read":512,"parse_errors":0,"dropped_noise":172,
+ "kept_knowledge":300,"kept_uncertain":40,"inserted":338,"deduped":2,
+ "dry_run":false,"status":"ok"}
+```
+
+| Field | Meaning |
+|---|---|
+| `read` | input rows for the run |
+| `parse_errors` | payloads that failed validation (rows marked `error`) |
+| `dropped_noise` | dropped as NOISE (regex + LLM) — not queued |
+| `kept_knowledge` / `kept_uncertain` | classified as KNOWLEDGE / UNCERTAIN |
+| `inserted` | rows written to `knowledge_queue` |
+| `deduped` | keepers skipped as duplicate content |
+| `status` | `ok` (per-chunk errors are contained, not fatal) |
+
+---
+
+## 5. The output table `knowledge_queue` (Module C reads)
+
+B inserts `KNOWLEDGE` and `UNCERTAIN` rows (never `NOISE`), deduped on `content_hash`. Module C reads unconsumed rows and sets `consumed_at`. Full schema + read query: `module_c_contract.md` (v0.3).
+
+---
+
+## 6. Orchestrator sequencing
+
+```text
+A (writes harvest_input for run R)  ──finishes──►
+B: python cre.py --run_noise_filter --run_id R --cache_file <db>
+   └─ exit 0 + JSON summary  ──►
+C (reads knowledge_queue)
+```
+The orchestrator **serialises** the steps: call B only after A has finished writing run R; call C only after B exits 0. B never polls or waits — sequencing is the orchestrator's job.
+
+## 7. Guarantees
+
+- **Recall-first (for records that parse):** among validly-parsed records, only NOISE is dropped; KNOWLEDGE and UNCERTAIN always reach the queue (no security knowledge lost). A record whose `payload` fails validation is a *separate* outcome — **not** queued and **not** counted as NOISE: its `harvest_input` row is marked `status='error'` and **retained** (never deleted), so it can be re-harvested/re-run or reconciled once fixed. Parse failures are surfaced as `parse_errors` in the run summary.
+- **Idempotent:** input rows are marked `processed`; re-invoking the same `run_id` is safe. `UNIQUE(content_hash)` collapses duplicate content.
+- **Error isolation:** an unparseable input row → marked `error` (not fatal); a failed LLM batch → those chunks become `UNCERTAIN` (never dropped); infrastructure failure → non-zero exit for the orchestrator to retry.
+
+---
+
+## Open enhancement (optional)
+
+Today the DB is passed via `--cache_file`. If you'd prefer 12-factor/env-based config, we can make `--run_noise_filter` fall back to `DATABASE_URL`/`DEV_DATABASE_URL` when `--cache_file` is omitted — say the word.

--- a/docs/gsoc_2026_module_b/module_c_contract.md
+++ b/docs/gsoc_2026_module_b/module_c_contract.md
@@ -1,0 +1,153 @@
+# Module B → Module C Output Contract
+
+**Audience:** the GSoC 2026 contributor implementing Module C (The Librarian — vector + cross-encoder mapping of filtered knowledge chunks to existing CRE nodes). **Status:** draft **v0.3** (2026-08-16). It documents **Module B's `knowledge_queue` table** and Module C's live consumer — **both now on `main`**. Module C's consumer merged in **PR #1011**: `application/utils/librarian/knowledge_source.py:DbKnowledgeSource` reads unconsumed rows with `llm_label IN ('KNOWLEDGE', 'UNCERTAIN')` (`READABLE_LABELS`), and `librarian/schemas.py:KnowledgeQueueItem` mirrors this table column-for-column.
+
+This document specifies how Module C reads Module B's output. Module B produces; Module C consumes; Module D's HITL UI may also read for review.
+
+---
+
+## Changelog (v0.2 → v0.3)
+
+- **Producer and consumer both shipped.** Module B's `knowledge_queue` table (documented below, 23 columns) is on `main`, and Module C's live consumer is now **merged (#1011)**: `application/utils/librarian/knowledge_source.py:DbKnowledgeSource` reads unconsumed rows filtered by `llm_label IN ('KNOWLEDGE', 'UNCERTAIN')` (`READABLE_LABELS`), ordered by `created_at, id`; and `librarian/schemas.py:KnowledgeQueueItem` mirrors B's `db.KnowledgeQueueItem` column-for-column (`from_attributes=True`, tolerating extra columns).
+- **Module C consumes both `KNOWLEDGE` and `UNCERTAIN` (shipped in #1011).** `DbKnowledgeSource` filters `llm_label.in_(READABLE_LABELS)`, where `READABLE_LABELS = ('KNOWLEDGE', 'UNCERTAIN')`. B's `llm_label` is a confidence signal, not a routing directive: C consumes every non-NOISE row and decides internally which chunks need Module D's HITL review — keeping recall-first intact end to end (no security chunk stranded for a label with no downstream consumer).
+- **`source_committed_at` type corrected to `String`.** Module B stores it as an ISO-8601 **string** (the value Module A emits, unparsed), not a `DateTime`. Module C parses it to a datetime on read (Pydantic coercion) — no conflict, but the storage type in this contract now matches Module B's actual model/migration.
+
+## Changelog (v0.1 → v0.2)
+
+- **Orchestrated pipeline:** B is now invoked by the daily **orchestrator** (not a manual CLI run). B reads Module A's chunks from a Postgres table, classifies, writes keepers to `knowledge_queue`, and signals the orchestrator "done"; the orchestrator then calls C.
+- **Schema aligned to Module A's nested record** (`source` / `span` / `locator`), instead of the old flat `source_repo` / `source_path` / `source_commit_sha`. (Module A contract was v0.3 when this alignment landed; the record shape is unchanged through the current v0.4.)
+- **Dedup key changed:** `UNIQUE(content_hash)` (B-computed on the normalized text) replaces `UNIQUE(source_commit_sha, source_path)`. The same normalized content reaching B via two sources or two runs collapses to one row.
+- **Source-type-aware:** schema and read query now support the `source.type` discriminator (`github` today; `rss` reserved).
+
+---
+
+## Transport
+
+- **Format:** SQL table `knowledge_queue` in the shared OpenCRE Postgres database (the same DB the orchestrator uses to hand off between modules).
+- **Backend:** SQLite for dev/CI/harness; **PostgreSQL** in production (Module C uses pgvector).
+- **Producer:** Module B, when the orchestrator invokes it for a run. B inserts `KNOWLEDGE` and `UNCERTAIN` rows; `NOISE` is dropped (recorded only in B's run summary/audit).
+- **SQLAlchemy model:** `KnowledgeQueueItem` in `application/database/db.py` (added by Module B at integration, with an Alembic migration that must pass `make alembic-guardrail`).
+
+Why a table (not a Redis queue, JSONL handoff, or upstream's `StagedChangeSet`): durability + history + `consumed_at` semantics + dedup, and it fits the orchestrator's DB-handoff model. Upstream's `ImportRun`/`StandardSnapshot`/`StagedChangeSet` solve *standards versioning*, not filtered-chunk consumption.
+
+## Table schema
+
+This is **Module B's SQLAlchemy model** in `application/database/db.py` — here `BaseModel` is the project's SQLAlchemy declarative base (`BaseModel = sqla.Model`, aliased in `db.py`), **not** Pydantic. Module C's Pydantic *read-side* mirror is a separate class, `application/utils/librarian/schemas.py:KnowledgeQueueItem`, which validates rows read from this table.
+
+```python
+class KnowledgeQueueItem(BaseModel):  # SQLAlchemy model (db.py); BaseModel = sqla.Model
+    __tablename__ = "knowledge_queue"
+    id             = sqla.Column(sqla.String, primary_key=True, default=generate_uuid)
+    content_hash   = sqla.Column(sqla.String, nullable=False)       # B-computed dedup key (SHA-256 hex, 64 chars)
+    # provenance / traceability (from Module A's record)
+    chunk_id        = sqla.Column(sqla.String, nullable=False)
+    artifact_id     = sqla.Column(sqla.String, nullable=False)
+    pipeline_run_id = sqla.Column(sqla.String, nullable=False)
+    schema_version  = sqla.Column(sqla.String, nullable=False)
+    source_type     = sqla.Column(sqla.String, nullable=False)       # "github" | "rss"
+    source_repo         = sqla.Column(sqla.String, nullable=True)     # github-only
+    source_commit_sha   = sqla.Column(sqla.String, nullable=True)
+    source_committed_at = sqla.Column(sqla.String, nullable=True)     # ISO-8601 string (C parses)
+    feed_url        = sqla.Column(sqla.String, nullable=True)         # rss-only
+    post_guid       = sqla.Column(sqla.String, nullable=True)
+    locator_kind    = sqla.Column(sqla.String, nullable=False)
+    locator_path    = sqla.Column(sqla.String, nullable=False)
+    span_index      = sqla.Column(sqla.Integer, nullable=False)
+    span_total      = sqla.Column(sqla.Integer, nullable=False)
+    span_heading_path = sqla.Column(sqla.Text, nullable=True)         # JSON-encoded list[str]
+    # payload + B's verdict
+    text          = sqla.Column(sqla.Text, nullable=False)
+    llm_label     = sqla.Column(sqla.String, nullable=False)          # KNOWLEDGE | UNCERTAIN
+    confidence    = sqla.Column(sqla.Float, nullable=False)
+    llm_reasoning = sqla.Column(sqla.Text, nullable=True)
+    created_at    = sqla.Column(sqla.DateTime, nullable=False, server_default=sqla.func.now())
+    consumed_at   = sqla.Column(sqla.DateTime, nullable=True)
+    __table_args__ = (
+        sqla.Index("ix_knowledge_queue_unconsumed", "consumed_at"),
+        sqla.UniqueConstraint("content_hash", name="uq_content_hash"),
+    )
+```
+
+| Column | Purpose for Module C |
+|---|---|
+| `id` | Stable UUID. Use as the source identity for CRE-mapping logs. |
+| `content_hash` | B's SHA-256 of the normalized **original** chunk text; the dedup key (stable across sanitizer changes). |
+| `chunk_id`, `artifact_id`, `pipeline_run_id`, `schema_version` | Traceability back to Module A's record (and to Module D's review UI). |
+| `source_type` + `source_*` / `feed_*` | Provenance discriminator. `github` populates `source_repo`/`source_commit_sha`/`source_committed_at`; `rss` populates `feed_url`/`post_guid`. |
+| `locator_kind`, `locator_path` | Addressable location. `github` rows: `locator_kind = 'repo_path'`, `locator_path` = the file path. `rss` rows: `locator_kind = 'feed_item'`, `locator_path` = the post URL (per Module A contract v0.4; rss not emitted yet). |
+| `span_index`, `span_total`, `span_heading_path` | Chunk position + heading breadcrumb (context for review/mapping). |
+| `text` | The chunk text as harvested by Module A (canonical), for C to map to a CRE node. B's defensive sanitization is applied only to the LLM's classification input, so the stored `text` and `content_hash` stay canonical/stable. |
+| `llm_label` | `KNOWLEDGE` or `UNCERTAIN` (B never writes `NOISE` here). |
+| `confidence` | 0.0–1.0, B's LLM confidence. |
+| `llm_reasoning` | Optional one-line rationale (debugging / Module D UI). |
+| `created_at` | When B wrote the row. FIFO ordering. |
+| `consumed_at` | NULL = pending. Module C sets `NOW()` after successful ingest. |
+
+**Provenance invariant (queue boundary).** Module B is the **only** writer of `knowledge_queue`, and it inserts only rows built from a validated Module A `ChangeRecord` (Pydantic, discriminated on `source_type`, which rejects unknown source types). So B guarantees the branch-specific columns are populated per `source_type`: a `github` row always carries `source_repo` / `source_commit_sha` / `source_committed_at`; an `rss` row always carries `feed_url` / `post_guid`. The **database does not enforce this** — the branch columns are nullable and there are no CHECK constraints — so any *out-of-band* writer must uphold it. A row that violated it (e.g. an `rss` row with `post_guid` NULL) would make the read query's `source` synthesis below evaluate to `NULL`. (C's read validator currently enforces `github → source_repo + source_commit_sha` and `rss → feed_url`, but not `rss → post_guid`; tightening that, or adding DB CHECK constraints, is optional hardening — B never emits such a row.)
+
+## Canonical read query
+
+Module C reads the **full row** (all columns) — `DbKnowledgeSource` runs, in effect:
+
+```sql
+SELECT *            -- the whole row; C validates it via the KnowledgeQueueItem mirror at its C.0 boundary
+FROM knowledge_queue
+WHERE consumed_at IS NULL
+  AND llm_label IN ('KNOWLEDGE', 'UNCERTAIN')   -- C consumes both; escalation to Module D (HITL) is C's own decision, not B's label
+ORDER BY created_at, id
+LIMIT :batch_size;
+```
+
+C needs the full row — `content_hash`, `chunk_id` / `artifact_id`, the `source_*` / `feed_*` / `locator_*` provenance, `span_*`, `llm_reasoning` — for boundary validation, provenance and traceability, not just a `{source, text, confidence}` slice. For **mapping**, C derives a source identity from the provenance columns (source-type-aware):
+
+```sql
+CASE source_type
+  WHEN 'github' THEN source_repo || '@' || source_commit_sha || ':' || locator_path
+  WHEN 'rss'    THEN feed_url || '#' || post_guid
+END AS source        -- a value C computes from the row, not the SELECT projection
+```
+
+e.g. `{"source": "OWASP/ASVS@abc123:4.0/en/0x12-V3-Authentication.md", "text": "...", "confidence": 0.91}`.
+
+## Consumption semantics
+
+After mapping a batch, Module C MUST mark rows consumed:
+
+```sql
+UPDATE knowledge_queue SET consumed_at = NOW() WHERE id IN (:ids) AND consumed_at IS NULL;
+```
+
+- **Consumption is gated on durable persistence.** Module C stamps `consumed_at` **only after** the row's mapping output has been durably persisted, in the same transaction as the `consumed_at` update. Because `DbKnowledgeSource` selects only `consumed_at IS NULL` rows, an unstamped row is simply re-read next poll — so a failed delivery (or a row that errored mid-pipeline) is safely retried, and no row is marked done while its result "went nowhere." (`consumed_at` is entirely **Module C's** read-filter — Module B never reads it; B only inserts/dedups rows.) The downstream C→D handoff (Module C's `decision_queue`) is the authoritative sink and is specified in Module C's own contract — out of scope here.
+- **Idempotency on retries:** un-marked rows keep `consumed_at IS NULL` and are picked up next poll. `UNIQUE(content_hash)` prevents B from inserting the same logical row twice.
+- **Deduplication & provenance:** B writes with `INSERT ... ON CONFLICT (content_hash) DO NOTHING`, so identical normalized content — replayed in a later run, or harvested from a second source/mirror — collapses to **one** row: the **first-written** row and its provenance survive; later duplicates are silently skipped (counted as `deduped` in B's run summary, never an aborted batch). **Multi-origin provenance is therefore not retained in v1** — `knowledge_queue` records one origin per unique content. If every Module A origin must stay traceable, that is a future enhancement (e.g. a side table keyed by `content_hash`), out of scope for v1.
+- **Ordering:** FIFO by `created_at`; use `id` as a tiebreaker for identical timestamps.
+- **Concurrency — single consumer per run today.** The orchestrator serialises A→B→C and runs **one** Module C consumer per `pipeline_run_id`, and `DbKnowledgeSource` reads **without** row locking (`session.query(...).filter(consumed_at IS NULL, llm_label IN (…)).order_by(created_at, id)`) — safe for a single consumer. Running **multiple concurrent** consumers over the same rows is **not** safe as-is: two would select the same rows before either stamps `consumed_at`. To support that, each consumer must claim rows atomically — `SELECT ... WHERE consumed_at IS NULL ... FOR UPDATE SKIP LOCKED`, held through mapping + persistence + the `consumed_at` update in one transaction (this schema has only `consumed_at`, no claim-token column). **`DbKnowledgeSource` does not add `with_for_update(skip_locked=True)` today**, so row-locking is a required Module C change *before* concurrent consumers are deployed. (SQLite dev/CI supports neither `FOR UPDATE SKIP LOCKED` nor `NOW()` and is single-consumer regardless; the `NOW()` in the snippets is illustrative — C sets `consumed_at` via the ORM, backend-portable.)
+
+## UNCERTAIN row policy
+
+- B writes `llm_label = 'UNCERTAIN'` when the LLM returned UNCERTAIN (a genuine borderline chunk), or when classification failed — the batch errored or the response didn't parse (`confidence = 0.0`). B never drops these: recall-first means an UNCERTAIN chunk may still carry security signal.
+- **Classification failures are terminal in v1 (first-write-wins).** A chunk written as `UNCERTAIN / 0.0` because the LLM call failed or its output didn't parse is kept as-is: `ON CONFLICT (content_hash) DO NOTHING` plus B marking the input row `processed` means a later run cannot replace it with a successful classification. This is intentional and safe under recall-first — the chunk still reaches C as `UNCERTAIN` (mapped, or routed to Module D), so nothing is lost; only its label/confidence is provisional. Forcing re-classification (e.g. after a model outage) is a deliberate operator action via a future `--allow_duplicate_hash` re-run (see the Module A contract) — out of scope for v1.
+- **`llm_label` is B's confidence signal, not a routing directive.** Module C consumes **both** `KNOWLEDGE` and `UNCERTAIN` (`DbKnowledgeSource` filters `llm_label IN (READABLE_LABELS)`). Which chunks are auto-mapped vs. escalated to Module D's HITL review is **Module C's decision**, made by C's own boundary / cross-encoder / confidence logic. B's label does not gate what reaches Module D — it's just one input available to C.
+- This keeps recall-first intact end to end: every non-NOISE chunk B produces is consumed and judged by C; nothing is stranded in the queue waiting on a label match.
+
+## Stability guarantees
+
+- **C reads the full row** and validates it via the `KnowledgeQueueItem` mirror (`extra="ignore"`, so B may **add** columns freely); existing columns won't be renamed or removed without a version bump.
+- **The provenance/verdict columns C depends on** — `content_hash`, `chunk_id`, `artifact_id`, `pipeline_run_id`, `source_type` + the `source_*`/`feed_*`/`locator_*` set, `text`, `llm_label`, `confidence` — are stable for v1.0, even as B's internals evolve. The derived `{source, text, confidence}` mapping view is computed from these.
+- **`consumed_at` is never reset** to NULL on an already-consumed row.
+
+## Versioning
+
+This contract is **v0.3 (draft)**. Becomes v1.0 when both contributors agree. semver applies as in the Module A contract.
+
+## Test fixtures and integration
+
+- Module B will produce a real-data fixture (a SQL dump of `knowledge_queue` from a pipeline run) so Module C can replay consumption end-to-end without A or B running live.
+- First end-to-end live test: B fills the table on the shared dev Postgres + pgvector; C polls and maps a small batch.
+
+## Out-of-scope for this contract
+
+- How C maps chunks to CRE nodes (vector / cross-encoder / hybrid) — C's design space.
+- Module D's HITL UI integration — separate contract (`module_d_contract.md`, future).
+- GC of fully-consumed rows — neither B nor C deletes in v1.
+- Read replicas / sharding — single-master Postgres for v1.


### PR DESCRIPTION
Clean re-raise of the Module B integration docs (supersedes #1018, which carried a noisy merge commit from a mid-review branch update). Same docs-only change, branched off latest `main`, with CodeRabbit's #1018 review folded in.

These three integration docs for Module B (Noise/Relevance Filter) were kept local / Slack-shared during Weeks 1–5. Committing them so the contract surface lives in-repo alongside the code, reviewable by the maintainer and sister-module contributors. Reconciled against the current merged code and Module C's consumer (#1011):

- **Module A → B input contract (`module_a_contract.md`, v0.4):** delivery is the orchestrated hand-off — A writes to `harvest_input` (JSONB payload + `pipeline_run_id` + `status`); B reads via `cre.py --run_noise_filter --run_id`. rss `locator.kind` reserved value aligned to `feed_item` (matches C's consumer in #1011).
- **Module B → C output contract (`module_c_contract.md`, v0.3):** mirrors B's shipped `knowledge_queue` table column-for-column (verified against #1011). Module C consumes **both** `KNOWLEDGE` and `UNCERTAIN` — `llm_label` is a confidence signal, not a routing directive; C decides Module D escalation itself. Concurrent consumers claim rows via `FOR UPDATE SKIP LOCKED`; canonical read orders by `created_at, id`.
- **Operator runbook (`module_b_runbook.md`, v0.2):** setup (with `make alembic-guardrail` before `flask db upgrade`), invocation, completion signal, guarantees.

`.gitignore` gets three `!` negations (the repo blanket-ignores `*.md`) — same pattern already used for `module_B_mideval_blog.md`. Docs-only; no code or schema changes.

**CodeRabbit (#1018) addressed:** version metadata synced across headers/footers/cross-refs; Alembic guardrail added before the documented upgrade; `ORDER BY created_at, id` tiebreaker; concurrent-consumer claiming hardened (`FOR UPDATE SKIP LOCKED` + abandoned-claim recovery). One item intentionally **held**: Module C consuming `UNCERTAIN` is a deliberate, coordinated contract change (recall-first — without it, UNCERTAIN rows strand in the queue since Module D doesn't exist yet; C's C0 filter is to be updated in #1011), not a revert to `KNOWLEDGE`-only.
