### PR TITLE
fix: mobile menu height fit-content (rebased #794)

### DIFF
--- a/application/frontend/src/scaffolding/Header/header.scss
+++ b/application/frontend/src/scaffolding/Header/header.scss
@@ -178,7 +178,7 @@
   top: 0;
   right: 0;
   width: 300px;
-  height: 100%;
+  height: fit-content;
   background-color: var(--background);
   border-left: 1px solid var(--border);
   padding: 1rem;


### PR DESCRIPTION
Rebased #794 onto current main. Main already had the mobile close button; this PR keeps the useful `height: fit-content` fix for the mobile menu panel.

Supersedes conflict resolution on #794.

Made with [Cursor](https://cursor.com)