### PR TITLE
feat(module-b): retry infrastructure-failed chunks instead of pinning them UNCERTAIN

### DIFF
--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -893,6 +893,8 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
         return
 
     if getattr(args, "run_noise_filter", False):
+        import sys
+
         from application import sqla
         from application.utils.noise_filter.pipeline import run_noise_filter
 
@@ -904,6 +906,12 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
             dry_run=getattr(args, "noise_filter_dry_run", False),
         )
         print(summary.to_json())
+        if summary.status == "degraded":
+            # A whole run of infrastructure failures. The classified rows are
+            # already committed (idempotent) and the failed ones stay `pending`,
+            # so exit non-zero to have the orchestrator retry -- a retry then
+            # re-processes only the pending rows.
+            sys.exit(1)
         return
 
     if args.add and getattr(args, "from_ai_exchange_csv", None):

--- a/application/cmd/cre_main.py
+++ b/application/cmd/cre_main.py
@@ -907,10 +907,11 @@ def run(args: argparse.Namespace) -> None:  # pragma: no cover
         )
         print(summary.to_json())
         if summary.status == "degraded":
-            # A whole run of infrastructure failures. The classified rows are
-            # already committed (idempotent) and the failed ones stay `pending`,
-            # so exit non-zero to have the orchestrator retry -- a retry then
-            # re-processes only the pending rows.
+            # The infra-failure ratio reached CRE_NOISE_FILTER_FAILURE_THRESHOLD
+            # (default 1.0 = the whole classified batch failed). The classified
+            # rows are already committed (idempotent) and the failed ones stay
+            # `pending`, so exit non-zero to have the orchestrator retry -- a
+            # retry then re-processes only the pending rows.
             sys.exit(1)
         return
 

--- a/application/tests/noise_filter/config_loader_test.py
+++ b/application/tests/noise_filter/config_loader_test.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from application.utils.noise_filter.config_loader import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_CONFIDENCE_THRESHOLD,
+    DEFAULT_FAILURE_THRESHOLD,
     DEFAULT_LLM_MODEL,
     DEFAULT_MAX_CHARS,
     NoiseFilterConfig,
@@ -26,6 +27,7 @@ _ENV_KEYS = (
     "CRE_NOISE_FILTER_BATCH_SIZE",
     "CRE_NOISE_FILTER_MAX_CHARS",
     "CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD",
+    "CRE_NOISE_FILTER_FAILURE_THRESHOLD",
 )
 
 
@@ -40,6 +42,7 @@ class LoadConfigTests(unittest.TestCase):
         self.assertEqual(cfg.batch_size, DEFAULT_BATCH_SIZE)
         self.assertEqual(cfg.max_chars, DEFAULT_MAX_CHARS)
         self.assertEqual(cfg.confidence_threshold, DEFAULT_CONFIDENCE_THRESHOLD)
+        self.assertEqual(cfg.failure_threshold, DEFAULT_FAILURE_THRESHOLD)
 
     def test_env_overrides_applied(self) -> None:
         overrides = {
@@ -47,6 +50,7 @@ class LoadConfigTests(unittest.TestCase):
             "CRE_NOISE_FILTER_BATCH_SIZE": "5",
             "CRE_NOISE_FILTER_MAX_CHARS": "800",
             "CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD": "0.6",
+            "CRE_NOISE_FILTER_FAILURE_THRESHOLD": "0.5",
         }
         with patch.dict(os.environ, overrides):
             cfg = load_config()
@@ -54,6 +58,7 @@ class LoadConfigTests(unittest.TestCase):
         self.assertEqual(cfg.batch_size, 5)
         self.assertEqual(cfg.max_chars, 800)
         self.assertEqual(cfg.confidence_threshold, 0.6)
+        self.assertEqual(cfg.failure_threshold, 0.5)
 
 
 class InvariantTests(unittest.TestCase):
@@ -77,6 +82,14 @@ class InvariantTests(unittest.TestCase):
     def test_confidence_below_zero_raises(self) -> None:
         with self.assertRaises(ValueError):
             NoiseFilterConfig(confidence_threshold=-0.1)
+
+    def test_failure_threshold_above_one_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            NoiseFilterConfig(failure_threshold=1.5)
+
+    def test_failure_threshold_below_zero_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            NoiseFilterConfig(failure_threshold=-0.1)
 
 
 if __name__ == "__main__":

--- a/application/tests/noise_filter/llm_classifier_test.py
+++ b/application/tests/noise_filter/llm_classifier_test.py
@@ -13,12 +13,17 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from application.utils.noise_filter.config_loader import NoiseFilterConfig
-from application.utils.noise_filter.llm_classifier import LLMClassifier
+from application.utils.noise_filter.llm_classifier import (
+    LLM_CALL_FAILED,
+    MALFORMED_OUTPUT,
+    LLMClassifier,
+    is_infra_failure,
+)
 from application.utils.noise_filter.prompts import (
     FEW_SHOT_EXAMPLES,
     SYSTEM_PROMPT_WITH_EXAMPLES,
 )
-from application.utils.noise_filter.schemas import ChangeRecord
+from application.utils.noise_filter.schemas import ChangeRecord, ClassifyResult
 
 
 # --- Helpers --------------------------------------------------------------
@@ -315,6 +320,38 @@ class TruncationTests(unittest.TestCase):
         clf.classify_batch([_record(text="A" * 500)])
         self.assertIn("…[truncated]", captured["user"])
         self.assertNotIn("A" * 100, captured["user"])  # full text not sent
+
+
+class InfraFailureHelperTests(unittest.TestCase):
+    def test_only_llm_call_failed_is_an_infra_failure(self) -> None:
+        self.assertTrue(
+            is_infra_failure(
+                ClassifyResult(
+                    label="UNCERTAIN", confidence=0.0, reasoning=LLM_CALL_FAILED
+                )
+            )
+        )
+        # unparseable output is NOT infra -- it is persisted, not retried
+        self.assertFalse(
+            is_infra_failure(
+                ClassifyResult(
+                    label="UNCERTAIN", confidence=0.0, reasoning=MALFORMED_OUTPUT
+                )
+            )
+        )
+        # a genuine model UNCERTAIN verdict is not an infra failure
+        self.assertFalse(
+            is_infra_failure(
+                ClassifyResult(
+                    label="UNCERTAIN", confidence=0.4, reasoning="borderline"
+                )
+            )
+        )
+        self.assertFalse(
+            is_infra_failure(
+                ClassifyResult(label="KNOWLEDGE", confidence=0.9, reasoning=None)
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/application/tests/noise_filter/llm_classifier_test.py
+++ b/application/tests/noise_filter/llm_classifier_test.py
@@ -323,15 +323,29 @@ class TruncationTests(unittest.TestCase):
 
 
 class InfraFailureHelperTests(unittest.TestCase):
-    def test_only_llm_call_failed_is_an_infra_failure(self) -> None:
+    def test_infra_flag_is_trusted_not_from_reasoning(self) -> None:
+        # is_infra_failure reads the trusted `retryable` flag, set only by B's
+        # own exception path -- never the model-controlled `reasoning` string.
         self.assertTrue(
+            is_infra_failure(
+                ClassifyResult(
+                    label="UNCERTAIN",
+                    confidence=0.0,
+                    reasoning=LLM_CALL_FAILED,
+                    retryable=True,
+                )
+            )
+        )
+        # `reasoning` says llm_call_failed but the result was NOT flagged retryable
+        # (e.g. built from model output) -> not an infra failure
+        self.assertFalse(
             is_infra_failure(
                 ClassifyResult(
                     label="UNCERTAIN", confidence=0.0, reasoning=LLM_CALL_FAILED
                 )
             )
         )
-        # unparseable output is NOT infra -- it is persisted, not retried
+        # unparseable output is persisted, not retried
         self.assertFalse(
             is_infra_failure(
                 ClassifyResult(
@@ -339,19 +353,32 @@ class InfraFailureHelperTests(unittest.TestCase):
                 )
             )
         )
-        # a genuine model UNCERTAIN verdict is not an infra failure
-        self.assertFalse(
-            is_infra_failure(
-                ClassifyResult(
-                    label="UNCERTAIN", confidence=0.4, reasoning="borderline"
-                )
+
+    def test_parsed_model_output_cannot_become_retryable(self) -> None:
+        # A schema-valid model response that sets reasoning="llm_call_failed"
+        # (and even an extra "retryable": true) must NOT become an infra failure:
+        # the parser only reads label/confidence/reasoning, so `retryable` stays
+        # False and the row is persisted normally.
+        clf = _classifier()
+        clf._litellm = Mock(
+            completion=lambda **kw: _resp(
+                {
+                    "results": [
+                        {
+                            "index": 0,
+                            "label": "KNOWLEDGE",
+                            "confidence": 0.9,
+                            "reasoning": LLM_CALL_FAILED,
+                            "retryable": True,
+                        }
+                    ]
+                }
             )
         )
-        self.assertFalse(
-            is_infra_failure(
-                ClassifyResult(label="KNOWLEDGE", confidence=0.9, reasoning=None)
-            )
-        )
+        (out,) = clf.classify_batch([_record()])
+        self.assertEqual(out.label, "KNOWLEDGE")
+        self.assertFalse(out.retryable)
+        self.assertFalse(is_infra_failure(out))
 
 
 if __name__ == "__main__":

--- a/application/tests/noise_filter/pipeline_test.py
+++ b/application/tests/noise_filter/pipeline_test.py
@@ -11,6 +11,10 @@ import unittest
 from application import create_app, sqla
 from application.database.db import HarvestInput, KnowledgeQueueItem
 from application.utils.noise_filter.hashing import compute_content_hash
+from application.utils.noise_filter.llm_classifier import (
+    LLM_CALL_FAILED,
+    MALFORMED_OUTPUT,
+)
 from application.utils.noise_filter.pipeline import run_noise_filter
 from application.utils.noise_filter.schemas import ClassifyResult
 
@@ -46,6 +50,16 @@ class _FakeClassifier:
 
 def _v(label, conf=0.9):
     return ClassifyResult(label=label, confidence=conf, reasoning="r")
+
+
+def _infra():
+    """The fallback verdict B emits when the LLM call itself fails (retryable)."""
+    return ClassifyResult(label="UNCERTAIN", confidence=0.0, reasoning=LLM_CALL_FAILED)
+
+
+def _malformed():
+    """The fallback verdict for unparseable model output (persisted, not retried)."""
+    return ClassifyResult(label="UNCERTAIN", confidence=0.0, reasoning=MALFORMED_OUTPUT)
 
 
 class PipelineTests(unittest.TestCase):
@@ -140,6 +154,54 @@ class PipelineTests(unittest.TestCase):
         # nothing written, no rows marked processed
         self.assertEqual(KnowledgeQueueItem.query.count(), 0)
         self.assertEqual(HarvestInput.query.filter_by(status="pending").count(), 2)
+
+    def test_infra_failure_leaves_row_pending(self) -> None:
+        # One chunk classifies, the other hit an LLM-call failure. The failed one
+        # is not written and its row stays `pending` for a retry; the run is still
+        # "ok" because not the whole batch failed (rate 0.5 < threshold 1.0).
+        self._add(_payload("document/auth.md"))  # -> KNOWLEDGE
+        self._add(_payload("document/xss.md"))  # -> infra failure
+        clf = _FakeClassifier([_v("KNOWLEDGE"), _infra()])
+
+        s = run_noise_filter(sqla.session, "run1", classifier=clf)
+
+        self.assertEqual(s.retry_pending, 1)
+        self.assertEqual(s.kept_knowledge, 1)
+        self.assertEqual(s.inserted, 1)
+        self.assertEqual(s.status, "ok")
+        self.assertEqual(KnowledgeQueueItem.query.count(), 1)
+        # exactly one row still pending (the infra-failed one); the other processed
+        self.assertEqual(HarvestInput.query.filter_by(status="pending").count(), 1)
+        self.assertEqual(HarvestInput.query.filter_by(status="processed").count(), 1)
+
+    def test_total_infra_failure_is_degraded(self) -> None:
+        # Every classified chunk failed -> status degraded (rate 1.0), nothing
+        # written, both rows left pending for the orchestrator to retry.
+        self._add(_payload("document/auth.md"))
+        self._add(_payload("document/xss.md"))
+        clf = _FakeClassifier([_infra(), _infra()])
+
+        s = run_noise_filter(sqla.session, "run1", classifier=clf)
+
+        self.assertEqual(s.retry_pending, 2)
+        self.assertEqual(s.status, "degraded")
+        self.assertEqual(s.inserted, 0)
+        self.assertEqual(KnowledgeQueueItem.query.count(), 0)
+        self.assertEqual(HarvestInput.query.filter_by(status="pending").count(), 2)
+
+    def test_malformed_output_is_persisted_not_retried(self) -> None:
+        # Unparseable output is a genuine UNCERTAIN row: written and finalized,
+        # never left pending (retrying junk would loop forever).
+        self._add(_payload("document/auth.md"))
+        clf = _FakeClassifier([_malformed()])
+
+        s = run_noise_filter(sqla.session, "run1", classifier=clf)
+
+        self.assertEqual(s.retry_pending, 0)
+        self.assertEqual(s.kept_uncertain, 1)
+        self.assertEqual(s.inserted, 1)
+        self.assertEqual(s.status, "ok")
+        self.assertEqual(HarvestInput.query.filter_by(status="pending").count(), 0)
 
     def test_sanitize_is_llm_input_only(self) -> None:
         # The "ﬀ" ligature is sanitized to "ff" for the LLM, but the queue keeps

--- a/application/tests/noise_filter/pipeline_test.py
+++ b/application/tests/noise_filter/pipeline_test.py
@@ -10,6 +10,7 @@ import unittest
 
 from application import create_app, sqla
 from application.database.db import HarvestInput, KnowledgeQueueItem
+from application.utils.noise_filter.config_loader import NoiseFilterConfig
 from application.utils.noise_filter.hashing import compute_content_hash
 from application.utils.noise_filter.llm_classifier import (
     LLM_CALL_FAILED,
@@ -54,7 +55,9 @@ def _v(label, conf=0.9):
 
 def _infra():
     """The fallback verdict B emits when the LLM call itself fails (retryable)."""
-    return ClassifyResult(label="UNCERTAIN", confidence=0.0, reasoning=LLM_CALL_FAILED)
+    return ClassifyResult(
+        label="UNCERTAIN", confidence=0.0, reasoning=LLM_CALL_FAILED, retryable=True
+    )
 
 
 def _malformed():
@@ -188,6 +191,30 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual(s.inserted, 0)
         self.assertEqual(KnowledgeQueueItem.query.count(), 0)
         self.assertEqual(HarvestInput.query.filter_by(status="pending").count(), 2)
+
+    def test_clean_run_not_degraded_at_threshold_zero(self) -> None:
+        # A `failure_threshold` of 0.0 must NOT degrade a clean run: with no infra
+        # failures there is nothing to retry, so status stays `ok`.
+        self._add(_payload("document/auth.md"))
+        clf = _FakeClassifier([_v("KNOWLEDGE")])
+        cfg = NoiseFilterConfig(failure_threshold=0.0)
+
+        s = run_noise_filter(sqla.session, "run1", config=cfg, classifier=clf)
+
+        self.assertEqual(s.retry_pending, 0)
+        self.assertEqual(s.status, "ok")
+
+    def test_one_infra_failure_degraded_at_threshold_zero(self) -> None:
+        # At threshold 0.0 a single infra failure is enough to degrade the run.
+        self._add(_payload("document/auth.md"))
+        self._add(_payload("document/xss.md"))
+        clf = _FakeClassifier([_v("KNOWLEDGE"), _infra()])
+        cfg = NoiseFilterConfig(failure_threshold=0.0)
+
+        s = run_noise_filter(sqla.session, "run1", config=cfg, classifier=clf)
+
+        self.assertEqual(s.retry_pending, 1)
+        self.assertEqual(s.status, "degraded")
 
     def test_malformed_output_is_persisted_not_retried(self) -> None:
         # Unparseable output is a genuine UNCERTAIN row: written and finalized,

--- a/application/utils/noise_filter/config_loader.py
+++ b/application/utils/noise_filter/config_loader.py
@@ -24,6 +24,12 @@ DEFAULT_LLM_MODEL = "gemini/gemini-2.5-flash-lite"
 DEFAULT_BATCH_SIZE = 10
 DEFAULT_MAX_CHARS = 1500
 DEFAULT_CONFIDENCE_THRESHOLD = 0.8
+# Fraction of a run's classified chunks that must be *infrastructure* failures
+# (the LLM call itself failed) for the run to report status="degraded" and exit
+# non-zero, so the orchestrator retries the whole run. Default 1.0 = only a total
+# wipeout (every classified chunk failed) is degraded; smaller failures leave
+# their rows `pending` for a natural retry and still exit 0.
+DEFAULT_FAILURE_THRESHOLD = 1.0
 
 
 @dataclass(frozen=True)
@@ -34,6 +40,7 @@ class NoiseFilterConfig:
     batch_size: int = DEFAULT_BATCH_SIZE
     max_chars: int = DEFAULT_MAX_CHARS
     confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD
+    failure_threshold: float = DEFAULT_FAILURE_THRESHOLD
 
     def __post_init__(self) -> None:
         """Fail fast on invalid settings, regardless of construction path.
@@ -50,6 +57,11 @@ class NoiseFilterConfig:
             raise ValueError(
                 f"confidence_threshold must be in [0.0, 1.0], got "
                 f"{self.confidence_threshold}"
+            )
+        if not 0.0 <= self.failure_threshold <= 1.0:
+            raise ValueError(
+                f"failure_threshold must be in [0.0, 1.0], got "
+                f"{self.failure_threshold}"
             )
 
 
@@ -69,12 +81,19 @@ def load_config() -> NoiseFilterConfig:
                 str(DEFAULT_CONFIDENCE_THRESHOLD),
             )
         ),
+        failure_threshold=float(
+            os.environ.get(
+                "CRE_NOISE_FILTER_FAILURE_THRESHOLD",
+                str(DEFAULT_FAILURE_THRESHOLD),
+            )
+        ),
     )
 
 
 __all__ = [
     "DEFAULT_BATCH_SIZE",
     "DEFAULT_CONFIDENCE_THRESHOLD",
+    "DEFAULT_FAILURE_THRESHOLD",
     "DEFAULT_LLM_MODEL",
     "DEFAULT_MAX_CHARS",
     "NoiseFilterConfig",

--- a/application/utils/noise_filter/llm_classifier.py
+++ b/application/utils/noise_filter/llm_classifier.py
@@ -79,12 +79,24 @@ def _uncertain(reason: str) -> ClassifyResult:
     return ClassifyResult(label="UNCERTAIN", confidence=0.0, reasoning=reason)
 
 
-def is_infra_failure(result: ClassifyResult) -> bool:
-    """True if `result` is the LLM-call-failed fallback (an infrastructure error),
-    as opposed to a genuine UNCERTAIN verdict or unparseable output. The pipeline
-    uses this to leave such chunks' input rows `pending` for a later retry.
+def _infra_failure() -> ClassifyResult:
+    """Fallback for an LLM-call (infrastructure) failure. `retryable=True` is set
+    here and *only* here -- the parser never sets it -- so the pipeline can trust
+    it to leave the chunk's input row `pending` for a retry.
     """
-    return result.reasoning == LLM_CALL_FAILED
+    return ClassifyResult(
+        label="UNCERTAIN", confidence=0.0, reasoning=LLM_CALL_FAILED, retryable=True
+    )
+
+
+def is_infra_failure(result: ClassifyResult) -> bool:
+    """True if `result` came from B's LLM-call-failure path -- read from the
+    *trusted* `retryable` flag, not the model-controlled `reasoning` string, so a
+    model response that happens to say "llm_call_failed" can never be mistaken for
+    an infrastructure failure. The pipeline uses this to leave such chunks' input
+    rows `pending` for a later retry.
+    """
+    return result.retryable
 
 
 def _batches(seq: list[Any], size: int) -> Iterator[list[Any]]:
@@ -190,7 +202,7 @@ class LLMClassifier:
                 len(batch),
                 e,
             )
-            return [_uncertain(LLM_CALL_FAILED) for _ in batch]
+            return [_infra_failure() for _ in batch]
         return self._parse(text, len(batch))
 
     def _call_llm(self, messages: list[dict]) -> str:

--- a/application/utils/noise_filter/llm_classifier.py
+++ b/application/utils/noise_filter/llm_classifier.py
@@ -64,9 +64,27 @@ CLASSIFY_RESPONSE_SCHEMA = {
 _TRUNCATION_NOTE = " …[truncated]"
 
 
+# Reasons the fallback path marks a chunk UNCERTAIN -- B's own signals, not the
+# model's verdict. LLM_CALL_FAILED is an *infrastructure* failure (the call raised
+# after retries: rate limit, network, auth); the pipeline leaves those input rows
+# `pending` for a later retry rather than finalizing them. MALFORMED_OUTPUT means
+# the model responded but the output couldn't be parsed -- retrying tends to
+# reproduce it, so it is persisted as UNCERTAIN, not retried.
+LLM_CALL_FAILED = "llm_call_failed"
+MALFORMED_OUTPUT = "malformed_output"
+
+
 def _uncertain(reason: str) -> ClassifyResult:
     """Build the fallback verdict used when the LLM output can't be trusted."""
     return ClassifyResult(label="UNCERTAIN", confidence=0.0, reasoning=reason)
+
+
+def is_infra_failure(result: ClassifyResult) -> bool:
+    """True if `result` is the LLM-call-failed fallback (an infrastructure error),
+    as opposed to a genuine UNCERTAIN verdict or unparseable output. The pipeline
+    uses this to leave such chunks' input rows `pending` for a later retry.
+    """
+    return result.reasoning == LLM_CALL_FAILED
 
 
 def _batches(seq: list[Any], size: int) -> Iterator[list[Any]]:
@@ -172,7 +190,7 @@ class LLMClassifier:
                 len(batch),
                 e,
             )
-            return [_uncertain("llm_call_failed") for _ in batch]
+            return [_uncertain(LLM_CALL_FAILED) for _ in batch]
         return self._parse(text, len(batch))
 
     def _call_llm(self, messages: list[dict]) -> str:
@@ -225,7 +243,7 @@ class LLMClassifier:
         raise RuntimeError("unreachable: retry loop exited unexpectedly")
 
     def _parse(self, text: str, n: int) -> list[ClassifyResult]:
-        verdicts = [_uncertain("malformed_output") for _ in range(n)]
+        verdicts = [_uncertain(MALFORMED_OUTPUT) for _ in range(n)]
         try:
             data = json.loads(text)
             results = data.get("results", []) if isinstance(data, dict) else []
@@ -254,5 +272,8 @@ class LLMClassifier:
 
 __all__ = [
     "CLASSIFY_RESPONSE_SCHEMA",
+    "LLM_CALL_FAILED",
+    "MALFORMED_OUTPUT",
     "LLMClassifier",
+    "is_infra_failure",
 ]

--- a/application/utils/noise_filter/pipeline.py
+++ b/application/utils/noise_filter/pipeline.py
@@ -153,12 +153,17 @@ def run_noise_filter(
     summary.dropped_noise += sum(1 for _, v, _ in triples if v.label == "NOISE")
     summary.retry_pending = len(retry_rows)
 
-    # Degraded only when the whole classified batch was infra failures (rate >=
-    # failure_threshold, default 1.0) -- the CLI turns this into a non-zero exit
-    # so the orchestrator retries the run. A partial failure stays "ok": the good
-    # rows are committed and the failed ones wait `pending` for a natural retry.
+    # Degraded when the infra-failure ratio reaches `failure_threshold`: at the
+    # default 1.0 that means the *whole* classified batch failed, but a lower
+    # threshold degrades a partial failure too. Requires at least one failure, so
+    # a clean run is never degraded (even at threshold 0.0). The CLI turns this
+    # into a non-zero exit so the orchestrator retries the run; a run that stays
+    # "ok" still commits its good rows and leaves any failures `pending`.
     classified = len(survivors)
-    if classified and summary.retry_pending / classified >= config.failure_threshold:
+    if (
+        summary.retry_pending
+        and summary.retry_pending / classified >= config.failure_threshold
+    ):
         summary.status = "degraded"
 
     if dry_run:

--- a/application/utils/noise_filter/pipeline.py
+++ b/application/utils/noise_filter/pipeline.py
@@ -3,11 +3,13 @@
 This is the entry point the orchestrator invokes (via the CLI in cre.py). For a
 given `pipeline_run_id` it reads Module A's pending rows from `harvest_input`,
 runs the three-stage gate (regex -> sanitize -> LLM classifier), writes the
-keepers to `knowledge_queue` (deduped), marks the input rows processed, and
-returns a RunSummary the CLI prints as JSON for the orchestrator to consume.
+keepers to `knowledge_queue` (deduped), marks handled input rows `processed`
+(leaving infrastructure-failed ones `pending` for a later retry), and returns a
+RunSummary the CLI prints as JSON for the orchestrator to consume.
 
 Recall-first is preserved end to end: only NOISE is dropped; KNOWLEDGE and
-UNCERTAIN always reach the queue.
+UNCERTAIN always reach the queue. An LLM-call failure never finalizes a chunk as
+a low-confidence verdict -- the row waits `pending` and is retried instead.
 """
 
 from __future__ import annotations
@@ -22,11 +24,14 @@ from pydantic import ValidationError
 from application.database.db import HarvestInput
 from application.utils.noise_filter.config_loader import NoiseFilterConfig, load_config
 from application.utils.noise_filter.hashing import compute_content_hash
-from application.utils.noise_filter.llm_classifier import LLMClassifier
+from application.utils.noise_filter.llm_classifier import (
+    LLMClassifier,
+    is_infra_failure,
+)
 from application.utils.noise_filter.queue_writer import write_verdicts
 from application.utils.noise_filter.regex_filter import RegexFilter
 from application.utils.noise_filter.sanitize import sanitize_text
-from application.utils.noise_filter.schemas import ChangeRecord
+from application.utils.noise_filter.schemas import ChangeRecord, ClassifyResult
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +48,7 @@ class RunSummary:
     kept_uncertain: int = 0
     inserted: int = 0
     deduped: int = 0
+    retry_pending: int = 0  # infra-failed chunks left `pending` for a later retry
     dry_run: bool = False
     status: str = "ok"
 
@@ -105,15 +111,16 @@ def run_noise_filter(
                 e.errors(include_input=False),
             )
 
-    # Stage 1: regex path filter (dropped = NOISE). Survivors get Stage 1.5 sanitize.
+    # Stage 1: regex path filter (dropped = NOISE). Survivors keep their input
+    # row so an infra failure can leave that row `pending` for a later retry.
     regex = RegexFilter()
-    survivors: list[ChangeRecord] = []
-    for _row, record in parsed:
+    survivors: list[tuple[HarvestInput, ChangeRecord]] = []
+    for row, record in parsed:
         is_noise, _reason = regex.is_noise_record(record)
         if is_noise:
             summary.dropped_noise += 1
         else:
-            survivors.append(record)
+            survivors.append((row, record))
 
     # Stage 1.5 + Stage 2: sanitization is for the classifier's eyes only. We
     # hash and persist the ORIGINAL (canonical) text so the dedup key stays
@@ -121,19 +128,38 @@ def run_noise_filter(
     # sanitized copy reaches the LLM. Require exactly one verdict per survivor --
     # a misaligned classifier must fail loudly rather than let zip() truncate.
     classifier = classifier or LLMClassifier(config)
-    verdicts = classifier.classify_batch([_sanitized(rec) for rec in survivors])
+    verdicts = classifier.classify_batch([_sanitized(rec) for _row, rec in survivors])
     if len(verdicts) != len(survivors):
         raise RuntimeError(
             f"classifier returned {len(verdicts)} verdicts for "
             f"{len(survivors)} chunks; refusing to write a partial batch"
         )
 
-    triples = [
-        (rec, v, compute_content_hash(rec.text)) for rec, v in zip(survivors, verdicts)
-    ]
+    # An *infrastructure* failure (the LLM call itself failed) never really
+    # classified the chunk. Rather than write a conf-0.0 UNCERTAIN row that
+    # ON CONFLICT would then pin forever, leave that input row `pending` so a
+    # later run retries it. Everything else -- genuine KNOWLEDGE/UNCERTAIN/NOISE,
+    # or unparseable output -- is finalized.
+    retry_rows: list[HarvestInput] = []
+    triples: list[tuple[ChangeRecord, ClassifyResult, str]] = []
+    for (row, record), verdict in zip(survivors, verdicts):
+        if is_infra_failure(verdict):
+            retry_rows.append(row)
+        else:
+            triples.append((record, verdict, compute_content_hash(record.text)))
+
     summary.kept_knowledge = sum(1 for _, v, _ in triples if v.label == "KNOWLEDGE")
     summary.kept_uncertain = sum(1 for _, v, _ in triples if v.label == "UNCERTAIN")
     summary.dropped_noise += sum(1 for _, v, _ in triples if v.label == "NOISE")
+    summary.retry_pending = len(retry_rows)
+
+    # Degraded only when the whole classified batch was infra failures (rate >=
+    # failure_threshold, default 1.0) -- the CLI turns this into a non-zero exit
+    # so the orchestrator retries the run. A partial failure stays "ok": the good
+    # rows are committed and the failed ones wait `pending` for a natural retry.
+    classified = len(survivors)
+    if classified and summary.retry_pending / classified >= config.failure_threshold:
+        summary.status = "degraded"
 
     if dry_run:
         return summary
@@ -142,9 +168,13 @@ def run_noise_filter(
     summary.inserted = write.inserted
     summary.deduped = write.deduped
 
-    # Mark input rows so a re-run doesn't reprocess them.
+    # Finalize every row except the infra-failed ones: NOISE-dropped and
+    # classified rows become `processed`; infra-failed rows stay `pending` for a
+    # retry; parse-failed rows are `error`.
+    pending_ids = {row.id for row in retry_rows}
     for row, _ in parsed:
-        row.status = "processed"
+        if row.id not in pending_ids:
+            row.status = "processed"
     for row in failed:
         row.status = "error"
     session.commit()

--- a/application/utils/noise_filter/schemas.py
+++ b/application/utils/noise_filter/schemas.py
@@ -162,6 +162,12 @@ class ClassifyResult(BaseModel):
     label: Literal["KNOWLEDGE", "NOISE", "UNCERTAIN"]
     confidence: float = Field(ge=0.0, le=1.0)
     reasoning: Optional[str] = None
+    # B-internal, never set from model output: True only when B's own exception
+    # path built this result (the LLM call itself failed). The parser passes only
+    # label/confidence/reasoning to model_validate, so a model response cannot set
+    # it -- making it a *trusted* signal that the chunk was not really classified
+    # and should be retried (left pending), not persisted.
+    retryable: bool = False
 
 
 class QueuePayload(BaseModel):

--- a/docs/gsoc_2026_module_b/module_b_runbook.md
+++ b/docs/gsoc_2026_module_b/module_b_runbook.md
@@ -40,6 +40,7 @@ vector;`).
 | `CRE_NOISE_FILTER_BATCH_SIZE` | chunks per LLM request | `10` |
 | `CRE_NOISE_FILTER_MAX_CHARS` | per-chunk truncation | `1500` |
 | `CRE_NOISE_FILTER_CONFIDENCE_THRESHOLD` | KNOWLEDGE-below → UNCERTAIN | `0.8` |
+| `CRE_NOISE_FILTER_FAILURE_THRESHOLD` | fraction of a run's classified chunks that must be infra failures to mark the run `degraded` (→ non-zero exit) | `1.0` |
 
 Module B needs no ML libraries (no torch/sentence-transformers) — just `litellm` (in the slim prod requirements) + the Gemini key.
 
@@ -76,12 +77,12 @@ The process runs the gate (regex path filter → sanitize → LLM classify), wri
 
 ## 4. Completion signal (how the orchestrator knows it's done)
 
-- **Exit code `0`** = success; **non-zero** = hard failure (e.g. DB unreachable) → safe to retry the same `run_id` (B is idempotent).
+- **Exit code `0`** = success (`status: ok`), even if some chunks are waiting to retry (`retry_pending > 0`). **Non-zero** = the whole run needs retrying: either a hard failure (e.g. DB unreachable), or a **`degraded`** run where *every* classified chunk hit an infrastructure failure (`retry_pending == classified`, gated by `CRE_NOISE_FILTER_FAILURE_THRESHOLD`, default 1.0). Either way it is safe to retry the same `run_id` — B is idempotent and a retry re-processes only the `pending` rows.
 - **stdout** = a one-line JSON summary:
 ```json
 {"run_id":"20260201T020000Z","read":512,"parse_errors":0,"dropped_noise":172,
  "kept_knowledge":300,"kept_uncertain":40,"inserted":338,"deduped":2,
- "dry_run":false,"status":"ok"}
+ "retry_pending":0,"dry_run":false,"status":"ok"}
 ```
 
 | Field | Meaning |
@@ -92,7 +93,8 @@ The process runs the gate (regex path filter → sanitize → LLM classify), wri
 | `kept_knowledge` / `kept_uncertain` | classified as KNOWLEDGE / UNCERTAIN |
 | `inserted` | rows written to `knowledge_queue` |
 | `deduped` | keepers skipped as duplicate content |
-| `status` | `ok` (per-chunk errors are contained, not fatal) |
+| `retry_pending` | chunks whose **LLM call failed** (infrastructure) — **not** written; their `harvest_input` rows are left `pending` for a later retry |
+| `status` | `ok`, or `degraded` when every classified chunk was an infra failure (→ non-zero exit, retry the run) |
 
 ---
 
@@ -115,8 +117,8 @@ The orchestrator **serialises** the steps: call B only after A has finished writ
 ## 7. Guarantees
 
 - **Recall-first (for records that parse):** among validly-parsed records, only NOISE is dropped; KNOWLEDGE and UNCERTAIN always reach the queue (no security knowledge lost). A record whose `payload` fails validation is a *separate* outcome — **not** queued and **not** counted as NOISE: its `harvest_input` row is marked `status='error'` and **retained** (never deleted), so it can be re-harvested/re-run or reconciled once fixed. Parse failures are surfaced as `parse_errors` in the run summary.
-- **Idempotent:** input rows are marked `processed`; re-invoking the same `run_id` is safe. `UNIQUE(content_hash)` collapses duplicate content.
-- **Error isolation:** an unparseable input row → marked `error` (not fatal); a failed LLM batch → those chunks become `UNCERTAIN` (never dropped); infrastructure failure → non-zero exit for the orchestrator to retry.
+- **Idempotent:** handled input rows are marked `processed` (infra-failed ones stay `pending`); re-invoking the same `run_id` is safe and re-processes only what's left. `UNIQUE(content_hash)` collapses duplicate content.
+- **Error isolation & retry:** an unparseable *input* row → marked `error` (not fatal). An **LLM-call (infrastructure) failure** → that chunk is **not** written and its `harvest_input` row stays `pending`, so a later run retries it (surfaced as `retry_pending`); if *every* classified chunk fails this way the run is `degraded` and exits non-zero so the orchestrator retries. **Unparseable model output** (the LLM answered, but with junk) → a genuine `UNCERTAIN` row (written, reaches C), not retried — retrying tends to reproduce it.
 
 ---
 

--- a/docs/gsoc_2026_module_b/module_b_runbook.md
+++ b/docs/gsoc_2026_module_b/module_b_runbook.md
@@ -77,7 +77,7 @@ The process runs the gate (regex path filter → sanitize → LLM classify), wri
 
 ## 4. Completion signal (how the orchestrator knows it's done)
 
-- **Exit code `0`** = success (`status: ok`), even if some chunks are waiting to retry (`retry_pending > 0`). **Non-zero** = the whole run needs retrying: either a hard failure (e.g. DB unreachable), or a **`degraded`** run where *every* classified chunk hit an infrastructure failure (`retry_pending == classified`, gated by `CRE_NOISE_FILTER_FAILURE_THRESHOLD`, default 1.0). Either way it is safe to retry the same `run_id` — B is idempotent and a retry re-processes only the `pending` rows.
+- **Exit code `0`** = success (`status: ok`), even if some chunks are waiting to retry (`retry_pending > 0`). **Non-zero** = the whole run needs retrying: either a hard failure (e.g. DB unreachable), or a **`degraded`** run where the infra-failure ratio (`retry_pending / classified`) reached `CRE_NOISE_FILTER_FAILURE_THRESHOLD` — at the **default 1.0** that means *every* classified chunk failed; a lower threshold trips on a partial failure (a clean run is never degraded). Either way it is safe to retry the same `run_id` — B is idempotent and a retry re-processes only the `pending` rows.
 - **stdout** = a one-line JSON summary:
 ```json
 {"run_id":"20260201T020000Z","read":512,"parse_errors":0,"dropped_noise":172,
@@ -94,7 +94,7 @@ The process runs the gate (regex path filter → sanitize → LLM classify), wri
 | `inserted` | rows written to `knowledge_queue` |
 | `deduped` | keepers skipped as duplicate content |
 | `retry_pending` | chunks whose **LLM call failed** (infrastructure) — **not** written; their `harvest_input` rows are left `pending` for a later retry |
-| `status` | `ok`, or `degraded` when every classified chunk was an infra failure (→ non-zero exit, retry the run) |
+| `status` | `ok`, or `degraded` when the infra-failure ratio reaches `CRE_NOISE_FILTER_FAILURE_THRESHOLD` (default 1.0 = all classified chunks failed) → non-zero exit, retry the run |
 
 ---
 
@@ -118,7 +118,7 @@ The orchestrator **serialises** the steps: call B only after A has finished writ
 
 - **Recall-first (for records that parse):** among validly-parsed records, only NOISE is dropped; KNOWLEDGE and UNCERTAIN always reach the queue (no security knowledge lost). A record whose `payload` fails validation is a *separate* outcome — **not** queued and **not** counted as NOISE: its `harvest_input` row is marked `status='error'` and **retained** (never deleted), so it can be re-harvested/re-run or reconciled once fixed. Parse failures are surfaced as `parse_errors` in the run summary.
 - **Idempotent:** handled input rows are marked `processed` (infra-failed ones stay `pending`); re-invoking the same `run_id` is safe and re-processes only what's left. `UNIQUE(content_hash)` collapses duplicate content.
-- **Error isolation & retry:** an unparseable *input* row → marked `error` (not fatal). An **LLM-call (infrastructure) failure** → that chunk is **not** written and its `harvest_input` row stays `pending`, so a later run retries it (surfaced as `retry_pending`); if *every* classified chunk fails this way the run is `degraded` and exits non-zero so the orchestrator retries. **Unparseable model output** (the LLM answered, but with junk) → a genuine `UNCERTAIN` row (written, reaches C), not retried — retrying tends to reproduce it.
+- **Error isolation & retry:** an unparseable *input* row → marked `error` (not fatal). An **LLM-call (infrastructure) failure** → that chunk is **not** written and its `harvest_input` row stays `pending`, so a later run retries it (surfaced as `retry_pending`); if the infra-failure ratio reaches `CRE_NOISE_FILTER_FAILURE_THRESHOLD` (default 1.0 = all classified chunks) the run is `degraded` and exits non-zero so the orchestrator retries. **Unparseable model output** (the LLM answered, but with junk) → a genuine `UNCERTAIN` row (written, reaches C), not retried — retrying tends to reproduce it.
 
 ---
 


### PR DESCRIPTION
## Problem

Module B's Stage-2 classifier is "mark-and-continue": when an LLM call fails (rate-limit exhaustion, network, auth), the affected chunks are written to `knowledge_queue` as `UNCERTAIN` with `confidence = 0.0`, and their `harvest_input` rows are marked `processed`. Because the queue dedups on `content_hash` (`ON CONFLICT DO NOTHING`), that conf-0.0 row is then **pinned forever** — a later run can neither re-read the input (no longer `pending`) nor replace the row. A transient outage permanently degrades a possibly-`KNOWLEDGE` chunk to `UNCERTAIN 0.0`; a whole-run outage produces an all-`UNCERTAIN` run that still exits `0`, so the orchestrator has no signal to retry.

Not a data-loss bug (recall-first still holds — the chunk reaches Module C as `UNCERTAIN`), but a real robustness gap: B treats an **infrastructure failure** (should be retried) the same as a **genuine `UNCERTAIN` verdict** (should be persisted).

## Fix

The classifier now distinguishes the two (`is_infra_failure`): only the LLM-call-exception path (`llm_call_failed`) is retryable; unparseable model output (`malformed_output`) stays a persisted `UNCERTAIN` (retrying junk would loop).

- **Leave infra-failed chunks `pending`.** They are not written, and their `harvest_input` rows are left `pending` for a natural retry on a subsequent run. Surfaced as a new `retry_pending` field in the JSON summary. The successfully-classified rows still commit (idempotent).
- **Signal the orchestrator on a total wipeout.** `status="degraded"` and a non-zero exit when `retry_pending / classified >= CRE_NOISE_FILTER_FAILURE_THRESHOLD` (default **1.0** — only when *every* classified chunk failed). A partial failure stays `ok` (exit 0) with `retry_pending > 0` for the orchestrator to drain.

## Verification

- **+6 tests → 103 noise_filter tests green**; `black --check` clean.
- **Live Postgres (Docker pgvector, full `flask db upgrade`):**
  - normal run → `retry_pending 0, status ok`, exit 0, rows `processed`, keepers queued;
  - forced outage (bogus model) → `retry_pending N, status degraded`, **exit 1**, rows stay `pending`, nothing written;
  - re-run same `run_id` with a working model → the `pending` rows drain, exit 0.
- **Classification unchanged:** the labeled-set eval still scores **0.930 accuracy / KNOWLEDGE recall 1.000 / 0 leakage** (identical to the mid-eval); this change only alters infra-failure handling.

Docs: `module_b_runbook.md` updated (§1 env var, §4 summary `retry_pending` + `degraded`, §7 guarantees).
