### PR TITLE
GSoC Module_A-week8: feat(harvester): chunking retrieval (stacked on top of #1038 )

### DIFF
--- a/application/tests/harvester_test/artifact_registry_test.py
+++ b/application/tests/harvester_test/artifact_registry_test.py
@@ -1,0 +1,99 @@
+import unittest
+from datetime import datetime
+
+from application.utils.harvester.artifact_registry import ArtifactRegistry
+from application.utils.harvester.models import ArtifactRegistryRecord
+
+
+class ArtifactRegistryTests(unittest.TestCase):
+    def test_insert_record(self):
+        registry = ArtifactRegistry()
+
+        record = ArtifactRegistryRecord(
+            artifact_id="art:test:file.md",
+            repository="OWASP/ASVS",
+            locator_path="file.md",
+            content_hash="abc",
+            last_commit_sha="123",
+            last_pipeline_run="run1",
+            last_processed_at=datetime.now(),
+            status="new",
+        )
+
+        registry.upsert(record)
+
+        self.assertTrue(registry.exists(record.artifact_id))
+
+    def test_get_record(self):
+        registry = ArtifactRegistry()
+
+        record = ArtifactRegistryRecord(
+            artifact_id="art:test:file.md",
+            repository="OWASP/ASVS",
+            locator_path="file.md",
+            content_hash="abc",
+            last_commit_sha="123",
+            last_pipeline_run="run1",
+            last_processed_at=datetime.now(),
+            status="new",
+        )
+
+        registry.upsert(record)
+
+        stored = registry.get(record.artifact_id)
+        assert stored is not None
+
+        self.assertEqual(stored.content_hash, "abc")
+
+    def test_update_record(self):
+        registry = ArtifactRegistry()
+
+        record = ArtifactRegistryRecord(
+            artifact_id="art:test:file.md",
+            repository="OWASP/ASVS",
+            locator_path="file.md",
+            content_hash="abc",
+            last_commit_sha="123",
+            last_pipeline_run="run1",
+            last_processed_at=datetime.now(),
+            status="new",
+        )
+
+        registry.upsert(record)
+
+        record.content_hash = "xyz"
+        record.status = "updated"
+
+        registry.upsert(record)
+
+        stored = registry.get(record.artifact_id)
+        assert stored is not None
+
+        self.assertEqual(stored.content_hash, "xyz")
+        self.assertEqual(stored.status, "updated")
+
+    def test_all_records(self):
+        registry = ArtifactRegistry()
+
+        for i in range(3):
+            registry.upsert(
+                ArtifactRegistryRecord(
+                    artifact_id=f"art:{i}",
+                    repository="repo",
+                    locator_path=f"{i}.md",
+                    content_hash=str(i),
+                    last_commit_sha="sha",
+                    last_pipeline_run="run",
+                    last_processed_at=datetime.now(),
+                    status="new",
+                )
+            )
+
+        self.assertEqual(
+            len(registry.all()),
+            3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/checkpoint_manager_test.py
+++ b/application/tests/harvester_test/checkpoint_manager_test.py
@@ -1,0 +1,68 @@
+import unittest
+from datetime import datetime
+
+from application.utils.harvester.checkpoint_manager import CheckpointManager
+from application.utils.harvester.models import CheckpointRecord
+
+
+class CheckpointManagerTests(unittest.TestCase):
+    def test_save_checkpoint(self):
+        manager = CheckpointManager()
+
+        checkpoint = CheckpointRecord(
+            repository="OWASP/ASVS",
+            pipeline_run_id="run1",
+            last_processed_commit="abc123",
+            status="running",
+            updated_at=datetime.now(),
+        )
+
+        manager.save(checkpoint)
+
+        self.assertIsNotNone(manager.get("OWASP/ASVS"))
+
+    def test_update_commit(self):
+        manager = CheckpointManager()
+
+        checkpoint = CheckpointRecord(
+            repository="OWASP/ASVS",
+            pipeline_run_id="run1",
+            last_processed_commit="abc123",
+            status="running",
+            updated_at=datetime.now(),
+        )
+
+        manager.save(checkpoint)
+
+        manager.update_commit(
+            "OWASP/ASVS",
+            "deadbeef",
+        )
+
+        stored = manager.get("OWASP/ASVS")
+        assert stored is not None
+
+        self.assertEqual(stored.last_processed_commit, "deadbeef")
+
+    def test_mark_completed(self):
+        manager = CheckpointManager()
+
+        checkpoint = CheckpointRecord(
+            repository="OWASP/ASVS",
+            pipeline_run_id="run1",
+            last_processed_commit="abc123",
+            status="running",
+            updated_at=datetime.now(),
+        )
+
+        manager.save(checkpoint)
+        manager.mark_completed("OWASP/ASVS")
+
+        stored = manager.get("OWASP/ASVS")
+        assert stored is not None
+
+        self.assertEqual(stored.status, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/chunk_pipeline_test.py
+++ b/application/tests/harvester_test/chunk_pipeline_test.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import Mock
+
+from application.utils.harvester.chunk_pipeline import DocumentChunkPipeline
+from application.utils.harvester.models import Document, IngestChunkRecord
+
+
+class DocumentChunkPipelineTests(unittest.TestCase):
+    def test_invalid_record_is_rejected_before_return(self):
+        document = Mock(spec=Document)
+        document.text = "Some document text."
+
+        chunker = Mock()
+        chunker.chunk.return_value = ["chunk"]
+
+        record_builder = Mock()
+        invalid_record = Mock(spec=IngestChunkRecord)
+        record_builder.build.return_value = [invalid_record]
+
+        validator = Mock()
+        validator.validate.side_effect = ValueError("invalid chunk record")
+
+        pipeline = DocumentChunkPipeline(
+            chunker=chunker,
+            record_builder=record_builder,
+            validator=validator,
+        )
+
+        with self.assertRaisesRegex(ValueError, "invalid chunk record"):
+            pipeline.chunk(document)
+
+        validator.validate.assert_called_once_with(invalid_record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/chunk_record_builder_test.py
+++ b/application/tests/harvester_test/chunk_record_builder_test.py
@@ -269,6 +269,68 @@ class ChunkRecordBuilderTests(unittest.TestCase):
             [],
         )
 
+    def test_empty_document_produces_no_records(self):
+        document = self._document(text="", headings=[])
+
+        records = ChunkRecordBuilder().build(document, [])
+
+        self.assertEqual(records, [])
+
+    def test_chunk_text_matches_source_span(self):
+        text = "# Root\n\nFirst paragraph.\n\nSecond paragraph."
+
+        document = self._document(text=text, headings=[])
+
+        chunks = [
+            ChunkInfo(
+                text="First paragraph.",
+                start_char_idx=text.index("First"),
+                end_char_idx=text.index("First") + len("First paragraph."),
+            )
+        ]
+
+        records = ChunkRecordBuilder().build(document, chunks)
+
+        record = records[0]
+
+        self.assertEqual(
+            record.text,
+            text[record.span.start_char_idx : record.span.end_char_idx],
+        )
+
+    def test_chunk_order_is_deterministic(self):
+        text = "# Root\n\nFirst.\n\nSecond."
+
+        document = self._document(text=text, headings=[])
+
+        first_start = text.index("First")
+        second_start = text.index("Second")
+
+        chunks = [
+            ChunkInfo(
+                text="First.",
+                start_char_idx=first_start,
+                end_char_idx=first_start + len("First."),
+            ),
+            ChunkInfo(
+                text="Second.",
+                start_char_idx=second_start,
+                end_char_idx=second_start + len("Second."),
+            ),
+        ]
+
+        records = ChunkRecordBuilder().build(document, chunks)
+
+        self.assertEqual(
+            [record.span.index for record in records],
+            [0, 1],
+        )
+
+        self.assertEqual(
+            [record.span.total for record in records],
+            [2, 2],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/application/tests/harvester_test/chunk_record_builder_test.py
+++ b/application/tests/harvester_test/chunk_record_builder_test.py
@@ -1,0 +1,274 @@
+import unittest
+
+from application.utils.harvester.chunk_record_builder import (
+    ChunkRecordBuilder,
+)
+from application.utils.harvester.chunker import ChunkInfo
+from application.utils.harvester.models import (
+    Document,
+    HeadingNode,
+    Locator,
+    SourceInfo,
+)
+
+
+class ChunkRecordBuilderTests(unittest.TestCase):
+    def _document(self, text: str, headings: list[HeadingNode]) -> Document:
+        return Document(
+            schema_version="0.2.0",
+            artifact_id="art:OWASP/ASVS:README.md",
+            pipeline_run_id="run-1",
+            text=text,
+            source=SourceInfo(
+                type="github",
+                repository="OWASP/ASVS",
+                commit_sha="abc123",
+                committed_at=None,
+            ),
+            locator=Locator(
+                kind="repo_path",
+                id="README.md",
+                path="README.md",
+            ),
+            heading_structure=headings,
+        )
+
+    def test_builds_chunk_record(self):
+        text = "# Root\n\nFirst paragraph."
+
+        document = self._document(
+            text,
+            [
+                HeadingNode(
+                    level=1,
+                    text="Root",
+                    start_line=1,
+                    end_line=3,
+                )
+            ],
+        )
+
+        chunk = ChunkInfo(
+            text=text,
+            start_char_idx=0,
+            end_char_idx=len(text),
+        )
+
+        records = ChunkRecordBuilder().build(
+            document,
+            [chunk],
+        )
+
+        self.assertEqual(len(records), 1)
+
+        record = records[0]
+
+        self.assertEqual(
+            record.artifact_id,
+            document.artifact_id,
+        )
+
+        self.assertEqual(
+            record.text,
+            text,
+        )
+
+        self.assertEqual(
+            record.span.index,
+            0,
+        )
+
+        self.assertEqual(
+            record.span.total,
+            1,
+        )
+
+        self.assertEqual(
+            record.span.heading_path,
+            ["Root"],
+        )
+
+        self.assertEqual(
+            record.span.start_char_idx,
+            0,
+        )
+
+        self.assertEqual(
+            record.span.end_char_idx,
+            len(text),
+        )
+
+        self.assertEqual(
+            record.span.start_line,
+            1,
+        )
+
+        self.assertEqual(
+            record.span.end_line,
+            3,
+        )
+
+    def test_heading_path_follows_chunk_start(self):
+        text = "# Root\n\nroot content\n\n## Child\n\nchild content"
+
+        document = self._document(
+            text,
+            [
+                HeadingNode(
+                    level=1,
+                    text="Root",
+                    start_line=1,
+                    end_line=7,
+                ),
+                HeadingNode(
+                    level=2,
+                    text="Child",
+                    start_line=5,
+                    end_line=7,
+                ),
+            ],
+        )
+
+        root_end = text.index("## Child")
+
+        chunks = [
+            ChunkInfo(
+                text=text[:root_end],
+                start_char_idx=0,
+                end_char_idx=root_end,
+            ),
+            ChunkInfo(
+                text=text[root_end:],
+                start_char_idx=root_end,
+                end_char_idx=len(text),
+            ),
+        ]
+
+        records = ChunkRecordBuilder().build(
+            document,
+            chunks,
+        )
+
+        self.assertEqual(
+            records[0].span.heading_path,
+            ["Root"],
+        )
+
+        self.assertEqual(
+            records[1].span.heading_path,
+            ["Root", "Child"],
+        )
+
+    def test_line_ranges_are_derived_from_character_offsets(self):
+        text = "one\ntwo\nthree\nfour"
+
+        document = self._document(text, [])
+
+        chunks = [
+            ChunkInfo(
+                text="two\nthree",
+                start_char_idx=4,
+                end_char_idx=13,
+            )
+        ]
+
+        records = ChunkRecordBuilder().build(
+            document,
+            chunks,
+        )
+
+        self.assertEqual(
+            records[0].span.start_line,
+            2,
+        )
+
+        self.assertEqual(
+            records[0].span.end_line,
+            3,
+        )
+
+    def test_chunk_ids_are_deterministic(self):
+        text = "# Root\n\nContent"
+
+        document = self._document(
+            text,
+            [
+                HeadingNode(
+                    level=1,
+                    text="Root",
+                    start_line=1,
+                    end_line=3,
+                )
+            ],
+        )
+
+        chunk = ChunkInfo(
+            text=text,
+            start_char_idx=0,
+            end_char_idx=len(text),
+        )
+
+        builder = ChunkRecordBuilder()
+
+        first = builder.build(document, [chunk])
+        second = builder.build(document, [chunk])
+
+        self.assertEqual(
+            first[0].chunk_id,
+            second[0].chunk_id,
+        )
+
+    def test_chunk_ids_include_heading_path_and_content_hash(self):
+        text = "# Root\n\nContent"
+
+        document = self._document(
+            text,
+            [
+                HeadingNode(
+                    level=1,
+                    text="Root",
+                    start_line=1,
+                    end_line=3,
+                )
+            ],
+        )
+
+        chunk = ChunkInfo(
+            text=text,
+            start_char_idx=0,
+            end_char_idx=len(text),
+        )
+
+        record = ChunkRecordBuilder().build(
+            document,
+            [chunk],
+        )[0]
+
+        self.assertTrue(
+            record.chunk_id.startswith("chk:art:OWASP/ASVS:README.md:Root:")
+        )
+
+    def test_empty_heading_path_is_allowed(self):
+        text = "Plain text without headings."
+
+        document = self._document(text, [])
+
+        chunk = ChunkInfo(
+            text=text,
+            start_char_idx=0,
+            end_char_idx=len(text),
+        )
+
+        record = ChunkRecordBuilder().build(
+            document,
+            [chunk],
+        )[0]
+
+        self.assertEqual(
+            record.span.heading_path,
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/chunk_record_builder_test.py
+++ b/application/tests/harvester_test/chunk_record_builder_test.py
@@ -331,6 +331,46 @@ class ChunkRecordBuilderTests(unittest.TestCase):
             [2, 2],
         )
 
+    def test_chunk_ids_differ_for_identical_text_at_different_offsets(self):
+        text = "# Root\n\nRepeated.\n\nRepeated."
+        document = self._document(
+            text=text,
+            headings=[
+                HeadingNode(
+                    level=1,
+                    text="Root",
+                    start_line=1,
+                    end_line=5,
+                )
+            ],
+        )
+
+        first_start = text.index("Repeated.")
+        second_start = text.index("Repeated.", first_start + 1)
+
+        chunks = [
+            ChunkInfo(
+                text="Repeated.",
+                start_char_idx=first_start,
+                end_char_idx=first_start + len("Repeated."),
+            ),
+            ChunkInfo(
+                text="Repeated.",
+                start_char_idx=second_start,
+                end_char_idx=second_start + len("Repeated."),
+            ),
+        ]
+
+        records = ChunkRecordBuilder().build(
+            document,
+            chunks,
+        )
+
+        self.assertNotEqual(
+            records[0].chunk_id,
+            records[1].chunk_id,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/application/tests/harvester_test/chunk_record_validator_test.py
+++ b/application/tests/harvester_test/chunk_record_validator_test.py
@@ -1,0 +1,81 @@
+import unittest
+
+from application.utils.harvester.chunk_record_validator import (
+    ChunkRecordValidator,
+)
+from application.utils.harvester.models import (
+    IngestChunkRecord,
+    SpanInfo,
+)
+
+
+def valid_record() -> IngestChunkRecord:
+    return IngestChunkRecord(
+        schema_version="0.2.0",
+        chunk_id="chk:art:OWASP/OpenCRE:README.md:abc123",
+        artifact_id="art:OWASP/OpenCRE:README.md",
+        text="Some valid chunk content.",
+        span=SpanInfo(
+            heading_path=["Introduction"],
+            start_line=1,
+            end_line=2,
+            index=0,
+            total=1,
+            start_char_idx=0,
+            end_char_idx=25,
+        ),
+    )
+
+
+class ChunkRecordValidatorTests(unittest.TestCase):
+    def test_valid_record(self):
+        ChunkRecordValidator().validate(valid_record())
+
+    def test_empty_text_is_rejected(self):
+        record = valid_record()
+        record.text = "   "
+
+        with self.assertRaises(ValueError):
+            ChunkRecordValidator().validate(record)
+
+    def test_invalid_chunk_id_is_rejected(self):
+        record = valid_record()
+        record.chunk_id = "invalid-id"
+
+        with self.assertRaises(ValueError):
+            ChunkRecordValidator().validate(record)
+
+    def test_missing_span_index_is_rejected(self):
+        record = valid_record()
+        record.span.index = None
+
+        with self.assertRaises(ValueError):
+            ChunkRecordValidator().validate(record)
+
+    def test_index_outside_total_is_rejected(self):
+        record = valid_record()
+        record.span.index = 1
+        record.span.total = 1
+
+        with self.assertRaises(ValueError):
+            ChunkRecordValidator().validate(record)
+
+    def test_invalid_character_range_is_rejected(self):
+        record = valid_record()
+        record.span.start_char_idx = 25
+        record.span.end_char_idx = 10
+
+        with self.assertRaises(ValueError):
+            ChunkRecordValidator().validate(record)
+
+    def test_invalid_line_range_is_rejected(self):
+        record = valid_record()
+        record.span.start_line = 5
+        record.span.end_line = 3
+
+        with self.assertRaises(ValueError):
+            ChunkRecordValidator().validate(record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/chunker_test.py
+++ b/application/tests/harvester_test/chunker_test.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest.mock import patch
+
+from application.utils.harvester.chunker import (
+    ChunkInfo,
+    DocumentChunker,
+)
+
+
+class DocumentChunkerTests(unittest.TestCase):
+    @patch("application.utils.harvester.chunker.HuggingFaceEmbedding")
+    @patch("application.utils.harvester.chunker.SemanticSplitterNodeParser")
+    def test_empty_document_returns_no_chunks(
+        self,
+        splitter_cls,
+        embedding_cls,
+    ):
+        chunker = DocumentChunker()
+
+        self.assertEqual(chunker.chunk(""), [])
+        splitter_cls.assert_not_called()
+
+    @patch("application.utils.harvester.chunker.HuggingFaceEmbedding")
+    @patch("application.utils.harvester.chunker.SemanticSplitterNodeParser")
+    def test_whitespace_document_returns_no_chunks(
+        self,
+        splitter_cls,
+        embedding_cls,
+    ):
+        chunker = DocumentChunker()
+
+        self.assertEqual(chunker.chunk("   \n\n  "), [])
+        splitter_cls.assert_not_called()
+
+    @patch("application.utils.harvester.chunker.HuggingFaceEmbedding")
+    @patch("application.utils.harvester.chunker.SemanticSplitterNodeParser")
+    def test_chunks_preserve_node_boundaries(
+        self,
+        splitter_cls,
+        embedding_cls,
+    ):
+        node = type(
+            "Node",
+            (),
+            {
+                "start_char_idx": 0,
+                "end_char_idx": 12,
+                "get_content": lambda self: "# Heading\ntext",
+            },
+        )()
+
+        splitter_cls.return_value.get_nodes_from_documents.return_value = [
+            node,
+        ]
+
+        chunker = DocumentChunker()
+
+        chunks = chunker.chunk("# Heading\ntext")
+
+        self.assertEqual(
+            chunks,
+            [
+                ChunkInfo(
+                    text="# Heading\ntext",
+                    start_char_idx=0,
+                    end_char_idx=12,
+                )
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/chunker_test.py
+++ b/application/tests/harvester_test/chunker_test.py
@@ -68,6 +68,52 @@ class DocumentChunkerTests(unittest.TestCase):
             ],
         )
 
+    @patch("application.utils.harvester.chunker.HuggingFaceEmbedding")
+    @patch("application.utils.harvester.chunker.SemanticSplitterNodeParser")
+    def test_chunking_preserves_node_order(
+        self,
+        splitter_cls,
+        embedding_cls,
+    ):
+        first = type(
+            "Node",
+            (),
+            {
+                "start_char_idx": 0,
+                "end_char_idx": 6,
+                "get_content": lambda self: "First.",
+            },
+        )()
+
+        second = type(
+            "Node",
+            (),
+            {
+                "start_char_idx": 8,
+                "end_char_idx": 15,
+                "get_content": lambda self: "Second.",
+            },
+        )()
+
+        splitter_cls.return_value.get_nodes_from_documents.return_value = [
+            first,
+            second,
+        ]
+
+        chunker = DocumentChunker()
+
+        chunks = chunker.chunk("First.\n\nSecond.")
+
+        self.assertEqual(
+            [(c.start_char_idx, c.end_char_idx) for c in chunks],
+            [(0, 6), (8, 15)],
+        )
+
+        self.assertEqual(
+            [c.text for c in chunks],
+            ["First.", "Second."],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/application/tests/harvester_test/chunking_benchmark_test.py
+++ b/application/tests/harvester_test/chunking_benchmark_test.py
@@ -1,0 +1,46 @@
+import time
+import unittest
+
+from application.utils.harvester.chunker import DocumentChunker
+
+
+class ChunkingBenchmarkTests(unittest.TestCase):
+    def test_chunking_benchmark(self):
+        text = (
+            "# Introduction\n\n" + "Python functions define reusable behavior. "
+            "Variables store values and expressions compute results. "
+            * 20
+            + "\n\n## Architecture\n\n"
+            + "The architecture separates ingestion from retrieval. "
+            "Each component has a clearly defined responsibility. "
+            * 20
+            + "\n\n## Storage\n\n"
+            + "Persistent state is protected by transactional operations. "
+            "Commit and rollback provide atomicity and consistency. " * 20
+        )
+
+        start = time.perf_counter()
+
+        chunks = DocumentChunker().chunk(text)
+
+        elapsed = time.perf_counter() - start
+
+        self.assertGreater(len(chunks), 0)
+        self.assertTrue(all(chunk.text.strip() for chunk in chunks))
+        self.assertTrue(
+            all(
+                0 <= chunk.start_char_idx < chunk.end_char_idx <= len(text)
+                for chunk in chunks
+            )
+        )
+
+        print(
+            f"\nChunking benchmark: "
+            f"{len(chunks)} chunks, "
+            f"{elapsed:.3f}s, "
+            f"input={len(text)} chars"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/chunking_benchmark_test.py
+++ b/application/tests/harvester_test/chunking_benchmark_test.py
@@ -1,9 +1,14 @@
+import os
 import time
 import unittest
 
 from application.utils.harvester.chunker import DocumentChunker
 
 
+@unittest.skipUnless(
+    os.getenv("RUN_CHUNKING_BENCHMARK") == "1",
+    "Chunking benchmark requires RUN_CHUNKING_BENCHMARK=1",
+)
 class ChunkingBenchmarkTests(unittest.TestCase):
     def test_chunking_benchmark(self):
         text = (

--- a/application/tests/harvester_test/chunking_benchmark_test.py
+++ b/application/tests/harvester_test/chunking_benchmark_test.py
@@ -13,12 +13,10 @@ class ChunkingBenchmarkTests(unittest.TestCase):
     def test_chunking_benchmark(self):
         text = (
             "# Introduction\n\n" + "Python functions define reusable behavior. "
-            "Variables store values and expressions compute results. "
-            * 20
+            "Variables store values and expressions compute results. " * 20
             + "\n\n## Architecture\n\n"
             + "The architecture separates ingestion from retrieval. "
-            "Each component has a clearly defined responsibility. "
-            * 20
+            "Each component has a clearly defined responsibility. " * 20
             + "\n\n## Storage\n\n"
             + "Persistent state is protected by transactional operations. "
             "Commit and rollback provide atomicity and consistency. " * 20

--- a/application/tests/harvester_test/content_hash_test.py
+++ b/application/tests/harvester_test/content_hash_test.py
@@ -1,0 +1,35 @@
+import unittest
+
+from application.utils.harvester.content_hash import (
+    generate_content_hash,
+)
+
+
+class ContentHashTests(unittest.TestCase):
+    def test_same_text_same_hash(self):
+        text = "Hello World"
+
+        self.assertEqual(
+            generate_content_hash(text),
+            generate_content_hash(text),
+        )
+
+    def test_different_text_different_hash(self):
+        self.assertNotEqual(
+            generate_content_hash("Hello"),
+            generate_content_hash("World"),
+        )
+
+    def test_empty_string(self):
+        digest = generate_content_hash("")
+
+        self.assertEqual(len(digest), 64)
+
+    def test_hash_is_hex(self):
+        digest = generate_content_hash("OpenCRE")
+
+        int(digest, 16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/deduplication_metrics_test.py
+++ b/application/tests/harvester_test/deduplication_metrics_test.py
@@ -1,0 +1,35 @@
+import unittest
+
+from application.utils.harvester.deduplication_metrics import DeduplicationMetrics
+from application.utils.harvester.models import DeduplicationStatus
+
+
+class DeduplicationMetricsTests(unittest.TestCase):
+    def test_records_new_document(self):
+        metrics = DeduplicationMetrics()
+
+        metrics.record(DeduplicationStatus.NEW)
+
+        self.assertEqual(metrics.total_artifacts_scanned, 1)
+        self.assertEqual(metrics.artifacts_new, 1)
+        self.assertEqual(metrics.artifacts_emitted, 1)
+
+    def test_records_updated_document(self):
+        metrics = DeduplicationMetrics()
+
+        metrics.record(DeduplicationStatus.UPDATED)
+
+        self.assertEqual(metrics.artifacts_updated, 1)
+        self.assertEqual(metrics.artifacts_emitted, 1)
+
+    def test_records_unchanged_document(self):
+        metrics = DeduplicationMetrics()
+
+        metrics.record(DeduplicationStatus.UNCHANGED)
+
+        self.assertEqual(metrics.artifacts_unchanged, 1)
+        self.assertEqual(metrics.artifacts_skipped, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/diff_normalizer_test.py
+++ b/application/tests/harvester_test/diff_normalizer_test.py
@@ -9,7 +9,6 @@ from application.utils.harvester.models import (
     DiffBlock,
 )
 
-
 DIFF_METADATA = {
     "repository": "OWASP/ASVS",
     "commit_sha": "abc123",

--- a/application/tests/harvester_test/diff_parser_test.py
+++ b/application/tests/harvester_test/diff_parser_test.py
@@ -5,6 +5,7 @@ from application.utils.harvester.diff_parser import (
     DiffParser,
 )
 
+
 TEST_REPOSITORY = "OWASP/ASVS"
 TEST_COMMIT_SHA = "abc123"
 TEST_COMMITTED_AT = datetime.now(UTC)

--- a/application/tests/harvester_test/diff_parser_test.py
+++ b/application/tests/harvester_test/diff_parser_test.py
@@ -5,6 +5,10 @@ from application.utils.harvester.diff_parser import (
     DiffParser,
 )
 
+TEST_REPOSITORY = "OWASP/ASVS"
+TEST_COMMIT_SHA = "abc123"
+TEST_COMMITTED_AT = datetime.now(UTC)
+
 
 TEST_REPOSITORY = "OWASP/ASVS"
 TEST_COMMIT_SHA = "abc123"

--- a/application/tests/harvester_test/diff_parser_test.py
+++ b/application/tests/harvester_test/diff_parser_test.py
@@ -5,10 +5,6 @@ from application.utils.harvester.diff_parser import (
     DiffParser,
 )
 
-TEST_REPOSITORY = "OWASP/ASVS"
-TEST_COMMIT_SHA = "abc123"
-TEST_COMMITTED_AT = datetime.now(UTC)
-
 
 TEST_REPOSITORY = "OWASP/ASVS"
 TEST_COMMIT_SHA = "abc123"

--- a/application/tests/harvester_test/diff_pipeline_test.py
+++ b/application/tests/harvester_test/diff_pipeline_test.py
@@ -13,7 +13,6 @@ from application.utils.harvester.git_repository_client import GitRepositoryClien
 class DiffPipelineBenchmark(unittest.TestCase):
     """
     Simple benchmark to ensure the complete diff pipeline remains fast.
-
     This is not intended as a strict performance benchmark, only as a
     regression guard against accidental slowdowns.
     """
@@ -63,3 +62,7 @@ class DiffPipelineBenchmark(unittest.TestCase):
 
         print(f"\nPipeline took {elapsed:.3f}s")
         self.assertLess(elapsed, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/diff_pipeline_test.py
+++ b/application/tests/harvester_test/diff_pipeline_test.py
@@ -1,8 +1,8 @@
-from datetime import UTC, datetime
 import os
 import subprocess
 import time
 import unittest
+from datetime import UTC, datetime
 
 from application.utils.harvester.diff_normalizer import DiffNormalizer
 from application.utils.harvester.diff_parser import DiffParser
@@ -10,6 +10,10 @@ from application.utils.harvester.diff_retriever import DiffRetriever
 from application.utils.harvester.git_repository_client import GitRepositoryClient
 
 
+@unittest.skipUnless(
+    os.getenv("RUN_DIFF_PIPELINE_BENCHMARK") == "1",
+    "Diff pipeline benchmark requires RUN_DIFF_PIPELINE_BENCHMARK=1",
+)
 class DiffPipelineBenchmark(unittest.TestCase):
     """
     Simple benchmark to ensure the complete diff pipeline remains fast.

--- a/application/tests/harvester_test/diff_pipeline_test.py
+++ b/application/tests/harvester_test/diff_pipeline_test.py
@@ -1,8 +1,8 @@
 from datetime import UTC, datetime
+import os
 import subprocess
 import time
 import unittest
-import os
 
 from application.utils.harvester.diff_normalizer import DiffNormalizer
 from application.utils.harvester.diff_parser import DiffParser

--- a/application/tests/harvester_test/diff_pipeline_test.py
+++ b/application/tests/harvester_test/diff_pipeline_test.py
@@ -19,7 +19,6 @@ class DiffPipelineBenchmark(unittest.TestCase):
     """
 
     def test_pipeline_benchmark(self):
-
         if os.getenv("OPENCRE_RUN_NETWORK_TESTS") != "1":
             self.skipTest("Network benchmark disabled")
 
@@ -29,9 +28,7 @@ class DiffPipelineBenchmark(unittest.TestCase):
             "master",
         )
         client.sync()
-
         head_commit = client.get_current_commit_sha()
-
         previous_commit = subprocess.run(
             [
                 "git",
@@ -51,23 +48,18 @@ class DiffPipelineBenchmark(unittest.TestCase):
         normalizer = DiffNormalizer()
 
         start = time.perf_counter()
-
         diff = retriever.get_diff(
             previous_commit,
             head_commit,
         )
-
         blocks = parser.parse(
             diff,
             repository="OWASP/ASVS",
             commit_sha=head_commit,
             committed_at=datetime.now(UTC),
         )
-
         normalizer.normalize(blocks)
-
         elapsed = time.perf_counter() - start
 
         print(f"\nPipeline took {elapsed:.3f}s")
-
         self.assertLess(elapsed, 5)

--- a/application/tests/harvester_test/diff_retriever_test.py
+++ b/application/tests/harvester_test/diff_retriever_test.py
@@ -16,10 +16,8 @@ class DiffRetrieverTests(unittest.TestCase):
             MagicMock(stdout="def456\n"),
             MagicMock(stdout=b"diff --git a/README.md b/README.md\n"),
         ]
-
         client = MagicMock()
         client.get_local_path.return_value = "/tmp/repo"
-
         retriever = DiffRetriever(client)
 
         diff = retriever.get_diff(
@@ -31,7 +29,6 @@ class DiffRetrieverTests(unittest.TestCase):
             diff,
             "diff --git a/README.md b/README.md\n",
         )
-
         mock_run.assert_has_calls(
             [
                 call(
@@ -88,7 +85,6 @@ class DiffRetrieverTests(unittest.TestCase):
 
         client = MagicMock()
         client.get_local_path.return_value = "/tmp/repo"
-
         retriever = DiffRetriever(client)
 
         with self.assertRaises(ValueError):

--- a/application/tests/harvester_test/diff_retriever_test.py
+++ b/application/tests/harvester_test/diff_retriever_test.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
-from unittest.mock import patch
 from unittest.mock import call
+from unittest.mock import patch
 
 from application.utils.harvester.diff_retriever import (
     DiffRetriever,

--- a/application/tests/harvester_test/diff_retriever_test.py
+++ b/application/tests/harvester_test/diff_retriever_test.py
@@ -18,6 +18,7 @@ class DiffRetrieverTests(unittest.TestCase):
         ]
         client = MagicMock()
         client.get_local_path.return_value = "/tmp/repo"
+
         retriever = DiffRetriever(client)
 
         diff = retriever.get_diff(
@@ -29,6 +30,7 @@ class DiffRetrieverTests(unittest.TestCase):
             diff,
             "diff --git a/README.md b/README.md\n",
         )
+
         mock_run.assert_has_calls(
             [
                 call(

--- a/application/tests/harvester_test/diff_retriever_test.py
+++ b/application/tests/harvester_test/diff_retriever_test.py
@@ -16,11 +16,11 @@ class DiffRetrieverTests(unittest.TestCase):
             MagicMock(stdout="def456\n"),
             MagicMock(stdout=b"diff --git a/README.md b/README.md\n"),
         ]
+
         client = MagicMock()
         client.get_local_path.return_value = "/tmp/repo"
 
         retriever = DiffRetriever(client)
-
         diff = retriever.get_diff(
             "abc123",
             "def456",
@@ -87,6 +87,7 @@ class DiffRetrieverTests(unittest.TestCase):
 
         client = MagicMock()
         client.get_local_path.return_value = "/tmp/repo"
+
         retriever = DiffRetriever(client)
 
         with self.assertRaises(ValueError):

--- a/application/tests/harvester_test/document_builder_test.py
+++ b/application/tests/harvester_test/document_builder_test.py
@@ -1,0 +1,65 @@
+import unittest
+from datetime import datetime
+
+from application.utils.harvester.document_builder import (
+    DocumentBuilder,
+)
+from application.utils.harvester.models import (
+    DiffBlock,
+)
+
+
+class DocumentBuilderTests(unittest.TestCase):
+    def test_build_document(self):
+        block = DiffBlock(
+            file_path="README.md",
+            repository="OWASP/ASVS",
+            commit_sha="abc123",
+            committed_at=datetime.now(),
+            added_lines=["Hello"],
+        )
+
+        document = DocumentBuilder().build(
+            block,
+            "# Title\n\nHello",
+            pipeline_run_id="20260714T120000Z",
+        )
+
+        self.assertEqual(
+            document.schema_version,
+            "0.2.0",
+        )
+
+        self.assertEqual(
+            document.artifact_id,
+            "art:OWASP/ASVS:README.md",
+        )
+
+        self.assertEqual(
+            document.pipeline_run_id,
+            "20260714T120000Z",
+        )
+
+        self.assertEqual(
+            document.text,
+            "# Title\n\nHello",
+        )
+
+        self.assertEqual(
+            document.source.repository,
+            "OWASP/ASVS",
+        )
+
+        self.assertEqual(
+            document.locator.path,
+            "README.md",
+        )
+
+        self.assertEqual(
+            len(document.heading_structure),
+            1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/document_deduplicator_test.py
+++ b/application/tests/harvester_test/document_deduplicator_test.py
@@ -1,0 +1,71 @@
+import unittest
+from datetime import datetime
+
+from application.utils.harvester.artifact_registry import ArtifactRegistry
+from application.utils.harvester.document_deduplicator import (
+    DocumentDeduplicator,
+)
+from application.utils.harvester.models import (
+    DeduplicationStatus,
+    Document,
+    Locator,
+    SourceInfo,
+)
+
+
+class DocumentDeduplicatorTests(unittest.TestCase):
+    def create_document(self, text: str) -> Document:
+        return Document(
+            schema_version="0.2.0",
+            artifact_id="art:test:file.md",
+            pipeline_run_id="run1",
+            text=text,
+            source=SourceInfo(
+                type="github",
+                repository="OWASP/ASVS",
+                commit_sha="abc123",
+                committed_at=datetime.now(),
+            ),
+            locator=Locator(
+                kind="repo_path",
+                id="file.md",
+                path="file.md",
+            ),
+            heading_structure=[],
+            span=None,
+        )
+
+    def test_new_document(self):
+        registry = ArtifactRegistry()
+
+        deduplicator = DocumentDeduplicator(registry)
+        result = deduplicator.process(self.create_document("hello"))
+        self.assertEqual(result, DeduplicationStatus.NEW)
+
+    def test_unchanged_document(self):
+        registry = ArtifactRegistry()
+
+        deduplicator = DocumentDeduplicator(registry)
+        document = self.create_document("hello")
+
+        deduplicator.process(document)
+        result = deduplicator.process(document)
+
+        self.assertEqual(result, DeduplicationStatus.UNCHANGED)
+
+    def test_updated_document(self):
+        registry = ArtifactRegistry()
+
+        deduplicator = DocumentDeduplicator(registry)
+
+        deduplicator.process(self.create_document("hello"))
+
+        result = deduplicator.process(
+            self.create_document("changed"),
+        )
+
+        self.assertEqual(result, DeduplicationStatus.UPDATED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/document_validator_test.py
+++ b/application/tests/harvester_test/document_validator_test.py
@@ -1,0 +1,85 @@
+import unittest
+from datetime import datetime
+
+from application.utils.harvester.document_validator import (
+    DocumentValidator,
+)
+from application.utils.harvester.models import (
+    Document,
+    HeadingNode,
+    Locator,
+    SourceInfo,
+)
+
+
+def make_document() -> Document:
+    return Document(
+        schema_version="0.2.0",
+        artifact_id="art:OWASP/ASVS:README.md",
+        pipeline_run_id="20260714T120000Z",
+        text="# Title",
+        source=SourceInfo(
+            type="github",
+            repository="OWASP/ASVS",
+            commit_sha="abc123",
+            committed_at=datetime.now(),
+        ),
+        locator=Locator(
+            kind="repo_path",
+            id="README.md",
+            path="README.md",
+        ),
+        heading_structure=[
+            HeadingNode(
+                level=1,
+                text="Title",
+                start_line=1,
+                end_line=1,
+            )
+        ],
+        span=None,
+    )
+
+
+class DocumentValidatorTests(unittest.TestCase):
+    def test_valid_document(self):
+        validator = DocumentValidator()
+
+        self.assertTrue(validator.validate(make_document()))
+
+    def test_missing_artifact_id(self):
+        validator = DocumentValidator()
+
+        document = make_document()
+        document.artifact_id = ""
+
+        self.assertFalse(validator.validate(document))
+
+    def test_missing_text(self):
+        validator = DocumentValidator()
+
+        document = make_document()
+        document.text = ""
+
+        self.assertFalse(validator.validate(document))
+
+    def test_invalid_source_type(self):
+        validator = DocumentValidator()
+
+        document = make_document()
+        document.source.type = "gitlab"
+
+        self.assertFalse(validator.validate(document))
+
+    def test_non_markdown_document_is_valid(self):
+        validator = DocumentValidator()
+
+        document = make_document()
+        document.heading_structure = []
+        document.text = '{"hello": "world"}'
+
+        self.assertTrue(validator.validate(document))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/git_repository_client_test.py
+++ b/application/tests/harvester_test/git_repository_client_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import tempfile
 from pathlib import Path
 
+from unittest.mock import MagicMock
 from application.utils.harvester.git_repository_client import (
     GitRepositoryClient,
 )
@@ -152,6 +153,33 @@ class GitRepositoryClientTests(unittest.TestCase):
             client.clone()
 
         mock_run.assert_called()
+
+    @patch("application.utils.harvester.git_repository_client.subprocess.run")
+    def test_get_file_at_commit(self, mock_run):
+
+        mock_run.return_value = MagicMock(stdout="# Hello\nWorld\n")
+
+        client = GitRepositoryClient("OWASP", "ASVS", "master")
+
+        client.get_local_path = MagicMock(return_value="/tmp/repo")
+
+        content = client.get_file_at_commit("abc123", "README.md")
+
+        self.assertEqual(content, "# Hello\nWorld\n")
+
+        mock_run.assert_called_once_with(
+            [
+                "git",
+                "-C",
+                "/tmp/repo",
+                "show",
+                "abc123:README.md",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
 
 
 if __name__ == "__main__":

--- a/application/tests/harvester_test/heading_extractor_test.py
+++ b/application/tests/harvester_test/heading_extractor_test.py
@@ -1,0 +1,107 @@
+import unittest
+
+from application.utils.harvester.heading_extractor import (
+    HeadingExtractor,
+)
+
+
+class HeadingExtractorTests(unittest.TestCase):
+    def test_single_heading(self):
+        text = """
+# Title
+
+Hello
+
+World
+"""
+
+        headings = HeadingExtractor().extract(text)
+
+        self.assertEqual(len(headings), 1)
+
+        self.assertEqual(headings[0].text, "Title")
+        self.assertEqual(headings[0].level, 1)
+        self.assertEqual(headings[0].start_line, 2)
+
+    def test_nested_headings(self):
+        text = """
+# Root
+
+## Child One
+
+content
+
+## Child Two
+
+more
+
+# Second Root
+"""
+
+        headings = HeadingExtractor().extract(text)
+
+        self.assertEqual(len(headings), 4)
+
+        self.assertEqual(headings[0].text, "Root")
+        self.assertEqual(headings[1].text, "Child One")
+        self.assertEqual(headings[2].text, "Child Two")
+        self.assertEqual(headings[3].text, "Second Root")
+
+    def test_heading_ranges(self):
+        text = """
+# Root
+
+text
+
+## Child
+
+child
+
+# Next
+"""
+
+        headings = HeadingExtractor().extract(text)
+        self.assertEqual(headings[0].end_line, 9)
+        self.assertEqual(headings[1].end_line, 9)
+        self.assertEqual(headings[2].end_line, 10)
+
+    def test_ignore_non_headings(self):
+        text = """
+Hello
+
+###Heading
+
+####NoSpace
+
+## Valid Heading
+"""
+
+        headings = HeadingExtractor().extract(text)
+        self.assertEqual(len(headings), 1)
+        self.assertEqual(headings[0].text, "Valid Heading")
+
+    def test_heading_stops_at_same_level(self):
+        text = """
+# Root
+
+## A
+
+### X
+
+## B
+
+    content
+    """
+
+        headings = HeadingExtractor().extract(text)
+
+        self.assertEqual(headings[1].text, "A")
+        self.assertEqual(headings[2].text, "X")
+        self.assertEqual(headings[3].text, "B")
+
+        self.assertEqual(headings[1].end_line, 7)
+        self.assertEqual(headings[2].end_line, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/tests/harvester_test/incremental_pipeline_test.py
+++ b/application/tests/harvester_test/incremental_pipeline_test.py
@@ -1,0 +1,76 @@
+import unittest
+from datetime import datetime
+
+from application.utils.harvester.artifact_registry import ArtifactRegistry
+from application.utils.harvester.checkpoint_manager import CheckpointManager
+from application.utils.harvester.document_deduplicator import (
+    DocumentDeduplicator,
+)
+from application.utils.harvester.incremental_pipeline import (
+    IncrementalPipeline,
+)
+from application.utils.harvester.models import (
+    Document,
+    Locator,
+    SourceInfo,
+)
+
+
+class IncrementalPipelineTests(unittest.TestCase):
+    def make_document(self, text: str) -> Document:
+
+        return Document(
+            schema_version="0.2.0",
+            artifact_id="art:test:file.md",
+            pipeline_run_id="run1",
+            text=text,
+            source=SourceInfo(
+                type="github",
+                repository="OWASP/ASVS",
+                commit_sha="abc123",
+                committed_at=datetime.now(),
+            ),
+            locator=Locator(
+                kind="repo_path",
+                id="file.md",
+                path="file.md",
+            ),
+            heading_structure=[],
+            span=None,
+        )
+
+    def test_only_new_and_updated_are_emitted(self):
+        registry = ArtifactRegistry()
+
+        dedup = DocumentDeduplicator(
+            registry,
+        )
+
+        checkpoints = CheckpointManager()
+
+        pipeline = IncrementalPipeline(
+            dedup,
+            checkpoints,
+        )
+
+        docs = [
+            self.make_document("hello"),
+            self.make_document("hello"),
+            self.make_document("changed"),
+        ]
+
+        emitted = pipeline.process(
+            "OWASP/ASVS",
+            "run1",
+            docs,
+        )
+
+        self.assertEqual(len(emitted), 2)
+        checkpoint = checkpoints.get("OWASP/ASVS")
+
+        assert checkpoint is not None
+        self.assertEqual(checkpoint.status, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -34,8 +34,10 @@ from .heading_extractor import (
 from .document_builder import DocumentBuilder
 from .document_validator import DocumentValidator
 from .content_hash import generate_content_hash
+from .artifact_registry import ArtifactRegistry
 
 __all__ = [
+    "ArtifactRegistry",
     "build_repository_cache_path",
     "ChunkingConfig",
     "ConfigLoaderError",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -21,6 +21,7 @@ from .file_filter import FileFilter
 from .filtering_metrics import FilteringMetricsCollector
 from .diff_retriever import DiffRetriever
 
+
 from .filtering_benchmark import (
     FilteringBenchmark,
     FilteringBenchmarkResult,
@@ -38,6 +39,7 @@ from .artifact_registry import ArtifactRegistry
 from .document_deduplicator import DocumentDeduplicator
 from .checkpoint_manager import CheckpointManager
 from .incremental_pipeline import IncrementalPipeline
+from .deduplication_metrics import DeduplicationMetrics
 
 __all__ = [
     "ArtifactRegistry",
@@ -45,6 +47,7 @@ __all__ = [
     "CheckpointManager",
     "ChunkingConfig",
     "ConfigLoaderError",
+    "DeduplicationMetrics",
     "DiffRetriever",
     "DocumentBuilder",
     "DocumentDeduplicator",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -37,6 +37,7 @@ from .content_hash import generate_content_hash
 from .artifact_registry import ArtifactRegistry
 from .document_deduplicator import DocumentDeduplicator
 from .checkpoint_manager import CheckpointManager
+from .incremental_pipeline import IncrementalPipeline
 
 __all__ = [
     "ArtifactRegistry",
@@ -56,6 +57,7 @@ __all__ = [
     "generate_content_hash",
     "HeadingExtractor",
     "HeadingNode",
+    "IncrementalPipeline",
     "PathRules",
     "PollingConfig",
     "RepositoryClient",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -32,6 +32,7 @@ from .heading_extractor import (
 )
 
 from .document_builder import DocumentBuilder
+from .document_validator import DocumentValidator
 
 __all__ = [
     "build_repository_cache_path",
@@ -39,6 +40,7 @@ __all__ = [
     "ConfigLoaderError",
     "DiffRetriever",
     "DocumentBuilder",
+    "DocumentValidator",
     "GitRepositoryClient",
     "FileFilter",
     "FilteringMetricsCollector",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -31,11 +31,14 @@ from .heading_extractor import (
     HeadingNode,
 )
 
+from .document_builder import DocumentBuilder
+
 __all__ = [
     "build_repository_cache_path",
     "ChunkingConfig",
     "ConfigLoaderError",
     "DiffRetriever",
+    "DocumentBuilder",
     "GitRepositoryClient",
     "FileFilter",
     "FilteringMetricsCollector",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -33,6 +33,7 @@ from .heading_extractor import (
 
 from .document_builder import DocumentBuilder
 from .document_validator import DocumentValidator
+from .content_hash import generate_content_hash
 
 __all__ = [
     "build_repository_cache_path",
@@ -46,6 +47,7 @@ __all__ = [
     "FilteringMetricsCollector",
     "FilteringBenchmark",
     "FilteringBenchmarkResult",
+    "generate_content_hash",
     "HeadingExtractor",
     "HeadingNode",
     "PathRules",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -26,6 +26,11 @@ from .filtering_benchmark import (
     FilteringBenchmarkResult,
 )
 
+from .heading_extractor import (
+    HeadingExtractor,
+    HeadingNode,
+)
+
 __all__ = [
     "build_repository_cache_path",
     "ChunkingConfig",
@@ -36,6 +41,8 @@ __all__ = [
     "FilteringMetricsCollector",
     "FilteringBenchmark",
     "FilteringBenchmarkResult",
+    "HeadingExtractor",
+    "HeadingNode",
     "PathRules",
     "PollingConfig",
     "RepositoryClient",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -36,10 +36,12 @@ from .document_validator import DocumentValidator
 from .content_hash import generate_content_hash
 from .artifact_registry import ArtifactRegistry
 from .document_deduplicator import DocumentDeduplicator
+from .checkpoint_manager import CheckpointManager
 
 __all__ = [
     "ArtifactRegistry",
     "build_repository_cache_path",
+    "CheckpointManager",
     "ChunkingConfig",
     "ConfigLoaderError",
     "DiffRetriever",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -35,6 +35,7 @@ from .document_builder import DocumentBuilder
 from .document_validator import DocumentValidator
 from .content_hash import generate_content_hash
 from .artifact_registry import ArtifactRegistry
+from .document_deduplicator import DocumentDeduplicator
 
 __all__ = [
     "ArtifactRegistry",
@@ -43,6 +44,7 @@ __all__ = [
     "ConfigLoaderError",
     "DiffRetriever",
     "DocumentBuilder",
+    "DocumentDeduplicator",
     "DocumentValidator",
     "GitRepositoryClient",
     "FileFilter",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -39,16 +39,19 @@ from .document_deduplicator import DocumentDeduplicator
 from .checkpoint_manager import CheckpointManager
 from .incremental_pipeline import IncrementalPipeline
 from .deduplication_metrics import DeduplicationMetrics
+from .chunker import ChunkInfo, DocumentChunker
 
 __all__ = [
     "ArtifactRegistry",
     "build_repository_cache_path",
+    "ChunkInfo",
     "CheckpointManager",
     "ChunkingConfig",
     "ConfigLoaderError",
     "DeduplicationMetrics",
     "DiffRetriever",
     "DocumentBuilder",
+    "DocumentChunker",
     "DocumentDeduplicator",
     "DocumentValidator",
     "GitRepositoryClient",

--- a/application/utils/harvester/__init__.py
+++ b/application/utils/harvester/__init__.py
@@ -21,7 +21,6 @@ from .file_filter import FileFilter
 from .filtering_metrics import FilteringMetricsCollector
 from .diff_retriever import DiffRetriever
 
-
 from .filtering_benchmark import (
     FilteringBenchmark,
     FilteringBenchmarkResult,

--- a/application/utils/harvester/artifact_id.py
+++ b/application/utils/harvester/artifact_id.py
@@ -1,0 +1,11 @@
+def generate_artifact_id(repository: str, file_path: str) -> str:
+    """
+    Generate a stable artifact identifier for a repository file.
+
+    Example:
+        repository = "OWASP/ASVS"
+        file_path = "5.0/en/0x01-Frontispiece.md"
+
+        -> art:OWASP/ASVS:5.0/en/0x01-Frontispiece.md
+    """
+    return f"art:{repository}:{file_path}"

--- a/application/utils/harvester/artifact_registry.py
+++ b/application/utils/harvester/artifact_registry.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from .models import ArtifactRegistryRecord
+
+
+class ArtifactRegistry:
+    """
+    In-memory registry for artifact deduplication.
+    """
+
+    def __init__(self):
+        self._records: dict[str, ArtifactRegistryRecord] = {}
+
+    def get(self, artifact_id: str) -> ArtifactRegistryRecord | None:
+        return self._records.get(artifact_id)
+
+    def exists(self, artifact_id: str) -> bool:
+        return artifact_id in self._records
+
+    def upsert(self, record: ArtifactRegistryRecord) -> None:
+        record.last_processed_at = datetime.now()
+        self._records[record.artifact_id] = record
+
+    def all(self) -> list[ArtifactRegistryRecord]:
+        return list(self._records.values())

--- a/application/utils/harvester/checkpoint_manager.py
+++ b/application/utils/harvester/checkpoint_manager.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from .models import CheckpointRecord
+
+
+class CheckpointManager:
+    """
+    Stores pipeline checkpoints for incremental processing.
+    """
+
+    def __init__(self):
+        self._checkpoints: dict[str, CheckpointRecord] = {}
+
+    def save(self, checkpoint: CheckpointRecord) -> None:
+        self._checkpoints[checkpoint.repository] = checkpoint
+
+    def get(self, repository: str) -> CheckpointRecord | None:
+        return self._checkpoints.get(repository)
+
+    def update_commit(self, repository: str, commit_sha: str) -> None:
+        checkpoint = self._checkpoints.get(repository)
+
+        if checkpoint is None:
+            return
+
+        checkpoint.last_processed_commit = commit_sha
+        checkpoint.updated_at = datetime.now()
+
+    def mark_completed(self, repository: str) -> None:
+        checkpoint = self._checkpoints.get(repository)
+
+        if checkpoint is None:
+            return
+
+        checkpoint.status = "completed"
+        checkpoint.updated_at = datetime.now()

--- a/application/utils/harvester/chunk_pipeline.py
+++ b/application/utils/harvester/chunk_pipeline.py
@@ -1,0 +1,26 @@
+from .chunk_record_builder import ChunkRecordBuilder
+from .chunker import DocumentChunker
+from .models import Document, IngestChunkRecord
+
+
+class DocumentChunkPipeline:
+    """
+    Runs semantic chunking followed by structure-aware RFC
+    chunk-record construction.
+    """
+
+    def __init__(
+        self,
+        chunker: DocumentChunker | None = None,
+        record_builder: ChunkRecordBuilder | None = None,
+    ) -> None:
+        self._chunker = chunker or DocumentChunker()
+        self._record_builder = record_builder or ChunkRecordBuilder()
+
+    def chunk(self, document: Document) -> list[IngestChunkRecord]:
+        chunks = self._chunker.chunk(document.text)
+
+        return self._record_builder.build(
+            document,
+            chunks,
+        )

--- a/application/utils/harvester/chunk_pipeline.py
+++ b/application/utils/harvester/chunk_pipeline.py
@@ -1,4 +1,5 @@
 from .chunk_record_builder import ChunkRecordBuilder
+from .chunk_record_validator import ChunkRecordValidator
 from .chunker import DocumentChunker
 from .models import Document, IngestChunkRecord
 
@@ -6,21 +7,28 @@ from .models import Document, IngestChunkRecord
 class DocumentChunkPipeline:
     """
     Runs semantic chunking followed by structure-aware RFC
-    chunk-record construction.
+    chunk-record construction and validation.
     """
 
     def __init__(
         self,
         chunker: DocumentChunker | None = None,
         record_builder: ChunkRecordBuilder | None = None,
+        validator: ChunkRecordValidator | None = None,
     ) -> None:
         self._chunker = chunker or DocumentChunker()
         self._record_builder = record_builder or ChunkRecordBuilder()
+        self._validator = validator or ChunkRecordValidator()
 
     def chunk(self, document: Document) -> list[IngestChunkRecord]:
         chunks = self._chunker.chunk(document.text)
 
-        return self._record_builder.build(
+        records = self._record_builder.build(
             document,
             chunks,
         )
+
+        for record in records:
+            self._validator.validate(record)
+
+        return records

--- a/application/utils/harvester/chunk_record_builder.py
+++ b/application/utils/harvester/chunk_record_builder.py
@@ -1,0 +1,149 @@
+import hashlib
+from dataclasses import dataclass
+
+from .models import Document, IngestChunkRecord, SpanInfo
+from .chunker import ChunkInfo
+
+
+@dataclass(slots=True)
+class ChunkRecordBuilder:
+    """
+    Converts semantic ChunkInfo objects into structure-aware
+    ingestion chunk records.
+    """
+
+    SCHEMA_VERSION = "0.2.0"
+
+    def build(
+        self,
+        document: Document,
+        chunks: list[ChunkInfo],
+    ) -> list[IngestChunkRecord]:
+        total = len(chunks)
+
+        records: list[IngestChunkRecord] = []
+
+        for index, chunk in enumerate(chunks):
+            heading_path = self._heading_path_for_chunk(
+                document,
+                chunk,
+            )
+
+            content_hash = hashlib.sha256(chunk.text.encode("utf-8")).hexdigest()
+
+            chunk_id = self._chunk_id(
+                artifact_id=document.artifact_id,
+                heading_path=heading_path,
+                content_hash=content_hash,
+            )
+
+            start_line, end_line = self._line_range(
+                document.text,
+                chunk.start_char_idx,
+                chunk.end_char_idx,
+            )
+
+            records.append(
+                IngestChunkRecord(
+                    schema_version=self.SCHEMA_VERSION,
+                    chunk_id=chunk_id,
+                    artifact_id=document.artifact_id,
+                    text=chunk.text,
+                    span=SpanInfo(
+                        heading_path=heading_path,
+                        start_line=start_line,
+                        end_line=end_line,
+                        index=index,
+                        total=total,
+                        start_char_idx=chunk.start_char_idx,
+                        end_char_idx=chunk.end_char_idx,
+                    ),
+                )
+            )
+
+        return records
+
+    @staticmethod
+    def _heading_path_for_chunk(
+        document: Document,
+        chunk: ChunkInfo,
+    ) -> list[str]:
+        """
+        Determine the Markdown heading hierarchy containing the
+        beginning of the chunk.
+
+        A heading is considered active when its range contains
+        the chunk's starting line.
+        """
+
+        start_line, _ = ChunkRecordBuilder._line_range(
+            document.text,
+            chunk.start_char_idx,
+            chunk.end_char_idx,
+        )
+
+        active = [
+            heading
+            for heading in document.heading_structure
+            if heading.start_line <= start_line <= heading.end_line
+        ]
+
+        active.sort(key=lambda heading: heading.start_line)
+
+        path: list[str] = []
+
+        for heading in active:
+            while len(path) >= heading.level:
+                path.pop()
+
+            path.append(heading.text)
+
+        return path
+
+    @staticmethod
+    def _line_range(
+        text: str,
+        start_char_idx: int,
+        end_char_idx: int,
+    ) -> tuple[int, int]:
+        """
+        Convert zero-based character offsets into one-based
+        inclusive line numbers.
+
+        The end offset is treated as exclusive.
+        """
+
+        if not 0 <= start_char_idx < end_char_idx <= len(text):
+            raise ValueError("Chunk character offsets are outside the source document")
+
+        start_line = (
+            text.count(
+                "\n",
+                0,
+                start_char_idx,
+            )
+            + 1
+        )
+
+        end_position = end_char_idx - 1
+
+        end_line = (
+            text.count(
+                "\n",
+                0,
+                end_position,
+            )
+            + 1
+        )
+
+        return start_line, end_line
+
+    @staticmethod
+    def _chunk_id(
+        artifact_id: str,
+        heading_path: list[str],
+        content_hash: str,
+    ) -> str:
+        heading = "/".join(heading_path)
+
+        return f"chk:{artifact_id}:{heading}:{content_hash}"

--- a/application/utils/harvester/chunk_record_builder.py
+++ b/application/utils/harvester/chunk_record_builder.py
@@ -34,6 +34,8 @@ class ChunkRecordBuilder:
             chunk_id = self._chunk_id(
                 artifact_id=document.artifact_id,
                 heading_path=heading_path,
+                start_char_idx=chunk.start_char_idx,
+                end_char_idx=chunk.end_char_idx,
                 content_hash=content_hash,
             )
 
@@ -142,8 +144,13 @@ class ChunkRecordBuilder:
     def _chunk_id(
         artifact_id: str,
         heading_path: list[str],
+        start_char_idx: int,
+        end_char_idx: int,
         content_hash: str,
     ) -> str:
         heading = "/".join(heading_path)
 
-        return f"chk:{artifact_id}:{heading}:{content_hash}"
+        return (
+            f"chk:{artifact_id}:{heading}:"
+            f"{start_char_idx}-{end_char_idx}:{content_hash}"
+        )

--- a/application/utils/harvester/chunk_record_validator.py
+++ b/application/utils/harvester/chunk_record_validator.py
@@ -1,0 +1,48 @@
+from .models import IngestChunkRecord
+
+
+class ChunkRecordValidator:
+    """
+    Validates RFC-facing ingestion chunk records.
+    """
+
+    def validate(self, record: IngestChunkRecord) -> None:
+        if not record.schema_version.strip():
+            raise ValueError("Chunk record schema_version must not be empty")
+
+        if not record.chunk_id.startswith("chk:"):
+            raise ValueError("Chunk record chunk_id must start with 'chk:'")
+
+        if not record.artifact_id.strip():
+            raise ValueError("Chunk record artifact_id must not be empty")
+
+        if not record.text.strip():
+            raise ValueError("Chunk record text must not be empty")
+
+        span = record.span
+
+        if span.index is None or span.total is None:
+            raise ValueError("Chunk record span must contain index and total")
+
+        if span.index < 0:
+            raise ValueError("Chunk record span.index must be non-negative")
+
+        if span.total <= 0:
+            raise ValueError("Chunk record span.total must be positive")
+
+        if span.index >= span.total:
+            raise ValueError("Chunk record span.index must be less than total")
+
+        if span.start_char_idx is None or span.end_char_idx is None:
+            raise ValueError("Chunk record span must contain character offsets")
+
+        if span.start_char_idx >= span.end_char_idx:
+            raise ValueError(
+                "Chunk record start_char_idx must be less than end_char_idx"
+            )
+
+        if span.start_line <= 0:
+            raise ValueError("Chunk record start_line must be positive")
+
+        if span.end_line < span.start_line:
+            raise ValueError("Chunk record end_line must not precede start_line")

--- a/application/utils/harvester/chunker.py
+++ b/application/utils/harvester/chunker.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+
+from llama_index.core import Document as LlamaDocument
+from llama_index.core.node_parser import SemanticSplitterNodeParser
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from llama_index.core.schema import TextNode
+from typing import cast
+
+
+@dataclass(slots=True)
+class ChunkInfo:
+    text: str
+    start_char_idx: int
+    end_char_idx: int
+
+
+class DocumentChunker:
+    """
+    Splits documents into semantically coherent chunks while
+    preserving the original document text boundaries.
+    """
+
+    DEFAULT_BUFFER_SIZE = 1
+    DEFAULT_BREAKPOINT_PERCENTILE = 95
+    DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+    def __init__(
+        self,
+        embedding_model: str = DEFAULT_EMBEDDING_MODEL,
+        buffer_size: int = DEFAULT_BUFFER_SIZE,
+        breakpoint_percentile_threshold: int = DEFAULT_BREAKPOINT_PERCENTILE,
+    ) -> None:
+        self._embedding_model = embedding_model
+        self._buffer_size = buffer_size
+        self._breakpoint_percentile_threshold = breakpoint_percentile_threshold
+        self._splitter: SemanticSplitterNodeParser | None = None
+
+    def _get_splitter(self) -> SemanticSplitterNodeParser:
+        if self._splitter is None:
+            embed_model = HuggingFaceEmbedding(
+                model_name=self._embedding_model,
+            )
+
+            self._splitter = SemanticSplitterNodeParser(
+                buffer_size=self._buffer_size,
+                breakpoint_percentile_threshold=self._breakpoint_percentile_threshold,
+                embed_model=embed_model,
+            )
+
+        return self._splitter
+
+    def chunk(self, text: str) -> list[ChunkInfo]:
+        if not text.strip():
+            return []
+
+        document = LlamaDocument(text=text)
+
+        nodes = self._get_splitter().get_nodes_from_documents([document])
+
+        chunks: list[ChunkInfo] = []
+
+        for node in nodes:
+            text_node = cast(TextNode, node)
+
+            start = text_node.start_char_idx
+            end = text_node.end_char_idx
+
+            if start is None or end is None:
+                continue
+
+            chunks.append(
+                ChunkInfo(
+                    text=text_node.get_content(),
+                    start_char_idx=start,
+                    end_char_idx=end,
+                )
+            )
+
+        return chunks

--- a/application/utils/harvester/content_hash.py
+++ b/application/utils/harvester/content_hash.py
@@ -1,0 +1,13 @@
+import hashlib
+
+
+def generate_content_hash(text: str) -> str:
+    """
+    Generate a deterministic SHA-256 hash for document content.
+
+    Used for artifact-level deduplication.
+    """
+
+    return hashlib.sha256(
+        text.encode("utf-8"),
+    ).hexdigest()

--- a/application/utils/harvester/deduplication_metrics.py
+++ b/application/utils/harvester/deduplication_metrics.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from .models import DeduplicationStatus
+
+
+@dataclass(slots=True)
+class DeduplicationMetrics:
+    total_artifacts_scanned: int = 0
+
+    artifacts_new: int = 0
+    artifacts_updated: int = 0
+    artifacts_unchanged: int = 0
+
+    artifacts_emitted: int = 0
+    artifacts_skipped: int = 0
+
+    def record(self, status: DeduplicationStatus) -> None:
+        self.total_artifacts_scanned += 1
+
+        if status is DeduplicationStatus.NEW:
+            self.artifacts_new += 1
+            self.artifacts_emitted += 1
+
+        elif status is DeduplicationStatus.UPDATED:
+            self.artifacts_updated += 1
+            self.artifacts_emitted += 1
+
+        elif status is DeduplicationStatus.UNCHANGED:
+            self.artifacts_unchanged += 1
+            self.artifacts_skipped += 1

--- a/application/utils/harvester/diff_normalizer.py
+++ b/application/utils/harvester/diff_normalizer.py
@@ -1,6 +1,7 @@
 import re
 import unicodedata
 
+from application.utils.harvester import repository_client
 from .models import DiffBlock
 
 

--- a/application/utils/harvester/diff_normalizer.py
+++ b/application/utils/harvester/diff_normalizer.py
@@ -1,6 +1,6 @@
-import textacy.preprocessing as prep
+import re
+import unicodedata
 
-from application.utils.harvester import repository_client
 from .models import DiffBlock
 
 
@@ -13,8 +13,8 @@ class DiffNormalizer:
     """
 
     def normalize_line(self, line: str) -> str:
-        line = prep.normalize.unicode(line)
-        line = prep.normalize.whitespace(line)
+        line = unicodedata.normalize("NFKC", line)
+        line = re.sub(r"\s+", " ", line)
         return line.strip()
 
     def normalize(self, blocks: list[DiffBlock]) -> list[DiffBlock]:

--- a/application/utils/harvester/diff_normalizer.py
+++ b/application/utils/harvester/diff_normalizer.py
@@ -1,15 +1,26 @@
 import textacy.preprocessing as prep
 
+from application.utils.harvester import repository_client
 from .models import DiffBlock
 
 
 class DiffNormalizer:
+    """
+    Normalizes extracted diff content.
+
+    Whitespace is collapsed, Unicode normalized,
+    and empty lines removed.
+    """
+
     def normalize_line(self, line: str) -> str:
         line = prep.normalize.unicode(line)
         line = prep.normalize.whitespace(line)
         return line.strip()
 
     def normalize(self, blocks: list[DiffBlock]) -> list[DiffBlock]:
+        """
+        Normalize every added line in each DiffBlock.
+        """
         normalized: list[DiffBlock] = []
 
         for block in blocks:

--- a/application/utils/harvester/diff_normalizer.py
+++ b/application/utils/harvester/diff_normalizer.py
@@ -1,26 +1,15 @@
-import re
-import unicodedata
+import textacy.preprocessing as prep
 
 from .models import DiffBlock
 
 
 class DiffNormalizer:
-    """
-    Normalizes extracted diff content.
-
-    Whitespace is collapsed, Unicode normalized,
-    and empty lines removed.
-    """
-
     def normalize_line(self, line: str) -> str:
-        line = unicodedata.normalize("NFKC", line)
-        line = re.sub(r"\s+", " ", line)
+        line = prep.normalize.unicode(line)
+        line = prep.normalize.whitespace(line)
         return line.strip()
 
     def normalize(self, blocks: list[DiffBlock]) -> list[DiffBlock]:
-        """
-        Normalize every added line in each DiffBlock.
-        """
         normalized: list[DiffBlock] = []
 
         for block in blocks:

--- a/application/utils/harvester/diff_retriever.py
+++ b/application/utils/harvester/diff_retriever.py
@@ -40,6 +40,7 @@ class DiffRetriever:
             base_commit,
             target_commit,
         )
+
         base_commit = self._resolve_commit(base_commit)
         target_commit = self._resolve_commit(target_commit)
 

--- a/application/utils/harvester/diff_retriever.py
+++ b/application/utils/harvester/diff_retriever.py
@@ -11,9 +11,7 @@ class DiffRetriever:
     Retrieves unified git diffs between two commits.
 
     This class is responsible only for retrieving raw diff text.
-
     Parsing and normalization are handled by downstream components.
-
     """
 
     MAX_DIFF_SIZE_BYTES = 50 * 1024 * 1024
@@ -34,7 +32,6 @@ class DiffRetriever:
         Raises:
             subprocess.CalledProcessError:
                 If git diff fails.
-
             ValueError:
                 If the diff exceeds the configured size limit.
         """
@@ -43,7 +40,6 @@ class DiffRetriever:
             base_commit,
             target_commit,
         )
-
         base_commit = self._resolve_commit(base_commit)
         target_commit = self._resolve_commit(target_commit)
 
@@ -69,9 +65,7 @@ class DiffRetriever:
             raise
 
         diff_bytes = result.stdout
-
         diff_size = len(diff_bytes)
-
         if diff_size > self.MAX_DIFF_SIZE_BYTES:
             raise ValueError(
                 f"Diff size ({diff_size} bytes) exceeds "

--- a/application/utils/harvester/diff_retriever.py
+++ b/application/utils/harvester/diff_retriever.py
@@ -8,7 +8,6 @@ logger = logging.getLogger(__name__)
 
 class DiffRetriever:
     """
-
     Retrieves unified git diffs between two commits.
 
     This class is responsible only for retrieving raw diff text.

--- a/application/utils/harvester/document_builder.py
+++ b/application/utils/harvester/document_builder.py
@@ -1,0 +1,46 @@
+from .artifact_id import generate_artifact_id
+from .heading_extractor import HeadingExtractor
+from .models import (
+    DiffBlock,
+    Document,
+    Locator,
+    SourceInfo,
+)
+
+
+class DocumentBuilder:
+    """
+    Builds structured Document objects from parsed diffs.
+
+    This bridges raw git diff ingestion and downstream
+    semantic chunking.
+    """
+
+    SCHEMA_VERSION = "0.2.0"
+
+    def build(self, block: DiffBlock, full_text: str, pipeline_run_id: str) -> Document:
+        artifact_id = generate_artifact_id(
+            block.repository,
+            block.file_path,
+        )
+
+        headings = HeadingExtractor().extract(full_text)
+
+        return Document(
+            schema_version=self.SCHEMA_VERSION,
+            artifact_id=artifact_id,
+            pipeline_run_id=pipeline_run_id,
+            text=full_text,
+            heading_structure=headings,
+            source=SourceInfo(
+                type="github",
+                repository=block.repository,
+                commit_sha=block.commit_sha,
+                committed_at=block.committed_at,
+            ),
+            locator=Locator(
+                kind="repo_path",
+                id=block.file_path,
+                path=block.file_path,
+            ),
+        )

--- a/application/utils/harvester/document_deduplicator.py
+++ b/application/utils/harvester/document_deduplicator.py
@@ -1,0 +1,59 @@
+from .artifact_registry import ArtifactRegistry
+from .content_hash import generate_content_hash
+from .models import (
+    ArtifactRegistryRecord,
+    DeduplicationStatus,
+    Document,
+)
+from datetime import datetime
+
+
+class DocumentDeduplicator:
+    """
+    Performs artifact-level deduplication.
+
+    Documents are classified as:
+        - NEW
+        - UPDATED
+        - UNCHANGED
+    """
+
+    def __init__(self, registry: ArtifactRegistry):
+        self._registry = registry
+
+    def process(self, document: Document) -> DeduplicationStatus:
+        content_hash = generate_content_hash(document.text)
+
+        existing = self._registry.get(document.artifact_id)
+
+        if existing is None:
+            self._registry.upsert(
+                ArtifactRegistryRecord(
+                    artifact_id=document.artifact_id,
+                    repository=document.source.repository,
+                    locator_path=document.locator.path,
+                    content_hash=content_hash,
+                    last_commit_sha=document.source.commit_sha,
+                    last_pipeline_run=document.pipeline_run_id,
+                    last_processed_at=datetime.now(),
+                    status=DeduplicationStatus.NEW.value,
+                )
+            )
+
+            return DeduplicationStatus.NEW
+
+        if existing.content_hash == content_hash:
+            existing.status = DeduplicationStatus.UNCHANGED.value
+
+            self._registry.upsert(existing)
+
+            return DeduplicationStatus.UNCHANGED
+
+        existing.content_hash = content_hash
+        existing.last_commit_sha = document.source.commit_sha
+        existing.last_pipeline_run = document.pipeline_run_id
+        existing.status = DeduplicationStatus.UPDATED.value
+
+        self._registry.upsert(existing)
+
+        return DeduplicationStatus.UPDATED

--- a/application/utils/harvester/document_validator.py
+++ b/application/utils/harvester/document_validator.py
@@ -1,0 +1,42 @@
+from .models import Document
+
+
+class DocumentValidator:
+    """
+    Validates structured Document objects before indexing.
+
+    Ensures every required metadata field has been populated.
+    """
+
+    def validate(self, document: Document) -> bool:
+        if not document.schema_version:
+            return False
+
+        if not document.artifact_id.startswith("art:"):
+            return False
+
+        if not document.pipeline_run_id:
+            return False
+
+        if not document.text:
+            return False
+
+        if document.source.type != "github":
+            return False
+
+        if not document.source.repository:
+            return False
+
+        if not document.source.commit_sha:
+            return False
+
+        if document.source.committed_at is None:
+            return False
+
+        if document.locator.kind != "repo_path":
+            return False
+
+        if not document.locator.path:
+            return False
+
+        return True

--- a/application/utils/harvester/git_repository_client.py
+++ b/application/utils/harvester/git_repository_client.py
@@ -284,3 +284,34 @@ class GitRepositoryClient(RepositoryClient):
 
     def verify_repository_integrity(self) -> bool:
         return self.is_valid_repository(self.local_path)
+
+    def get_file_at_commit(self, commit_sha: str, file_path: str) -> str:
+        """
+        Retrieve the contents of a file at a specific commit.
+
+        Args:
+            commit_sha:
+                Commit to read from.
+
+            file_path:
+                Repository-relative file path.
+
+        Returns:
+            File contents as a string.
+        """
+
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.get_local_path()),
+                "show",
+                f"{commit_sha}:{file_path}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+
+        return result.stdout

--- a/application/utils/harvester/heading_extractor.py
+++ b/application/utils/harvester/heading_extractor.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class HeadingNode:
+    """
+    Represents a Markdown heading within a document.
+    """
+
+    level: int
+    text: str
+    start_line: int
+    end_line: int
+
+
+class HeadingExtractor:
+    """
+    Extracts Markdown headings and their line ranges.
+
+    Heading ranges extend until the next heading of the same
+    or higher level, or the end of the document.
+    """
+
+    def extract(self, text: str) -> list[HeadingNode]:
+        lines = text.splitlines()
+
+        headings: list[HeadingNode] = []
+
+        for line_number, line in enumerate(lines, start=1):
+            stripped = line.lstrip()
+
+            if not stripped.startswith("#"):
+                continue
+
+            hashes = len(stripped) - len(stripped.lstrip("#"))
+
+            if hashes == 0:
+                continue
+
+            if len(stripped) > hashes and stripped[hashes] != " ":
+                continue
+
+            headings.append(
+                HeadingNode(
+                    level=hashes,
+                    text=stripped[hashes:].strip(),
+                    start_line=line_number,
+                    end_line=len(lines),
+                )
+            )
+
+        for index, heading in enumerate(headings):
+            for next_heading in headings[index + 1 :]:
+                if next_heading.level <= heading.level:
+                    heading.end_line = next_heading.start_line - 1
+                    break
+
+        return headings

--- a/application/utils/harvester/heading_extractor.py
+++ b/application/utils/harvester/heading_extractor.py
@@ -1,16 +1,5 @@
 from dataclasses import dataclass
-
-
-@dataclass(slots=True)
-class HeadingNode:
-    """
-    Represents a Markdown heading within a document.
-    """
-
-    level: int
-    text: str
-    start_line: int
-    end_line: int
+from .models import HeadingNode
 
 
 class HeadingExtractor:

--- a/application/utils/harvester/incremental_pipeline.py
+++ b/application/utils/harvester/incremental_pipeline.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from .checkpoint_manager import CheckpointManager
+from .deduplication_metrics import DeduplicationMetrics
 from .document_deduplicator import (
     DeduplicationStatus,
     DocumentDeduplicator,
@@ -20,14 +21,17 @@ class IncrementalPipeline:
     def __init__(
         self, deduplicator: DocumentDeduplicator, checkpoint_manager: CheckpointManager
     ):
+
         self._deduplicator = deduplicator
         self._checkpoint_manager = checkpoint_manager
+        self.metrics = DeduplicationMetrics()
 
     def process(
         self, repository: str, pipeline_run_id: str, documents: list[Document]
     ) -> list[Document]:
 
         emitted: list[Document] = []
+        metrics = DeduplicationMetrics()
 
         if documents:
             self._checkpoint_manager.save(
@@ -43,6 +47,7 @@ class IncrementalPipeline:
         for document in documents:
             status = self._deduplicator.process(document)
 
+            metrics.record(status)
             self._checkpoint_manager.update_commit(
                 repository,
                 document.source.commit_sha,
@@ -55,4 +60,5 @@ class IncrementalPipeline:
             repository,
         )
 
+        self.metrics = metrics
         return emitted

--- a/application/utils/harvester/incremental_pipeline.py
+++ b/application/utils/harvester/incremental_pipeline.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from .checkpoint_manager import CheckpointManager
+from .document_deduplicator import (
+    DeduplicationStatus,
+    DocumentDeduplicator,
+)
+from .models import (
+    CheckpointRecord,
+    Document,
+)
+
+
+class IncrementalPipeline:
+    """
+    Coordinates document deduplication and checkpoint updates.
+
+    Only NEW or UPDATED documents are emitted downstream.
+    """
+
+    def __init__(
+        self, deduplicator: DocumentDeduplicator, checkpoint_manager: CheckpointManager
+    ):
+        self._deduplicator = deduplicator
+        self._checkpoint_manager = checkpoint_manager
+
+    def process(
+        self, repository: str, pipeline_run_id: str, documents: list[Document]
+    ) -> list[Document]:
+
+        emitted: list[Document] = []
+
+        if documents:
+            self._checkpoint_manager.save(
+                CheckpointRecord(
+                    repository=repository,
+                    pipeline_run_id=pipeline_run_id,
+                    last_processed_commit="",
+                    status="running",
+                    updated_at=datetime.now(),
+                )
+            )
+
+        for document in documents:
+            status = self._deduplicator.process(document)
+
+            self._checkpoint_manager.update_commit(
+                repository,
+                document.source.commit_sha,
+            )
+
+            if status != DeduplicationStatus.UNCHANGED:
+                emitted.append(document)
+
+        self._checkpoint_manager.mark_completed(
+            repository,
+        )
+
+        return emitted

--- a/application/utils/harvester/models.py
+++ b/application/utils/harvester/models.py
@@ -46,7 +46,7 @@ class SourceInfo:
     type: str
     repository: str
     commit_sha: str
-    committed_at: datetime
+    committed_at: datetime | None
 
 
 @dataclass(slots=True)
@@ -84,4 +84,4 @@ class Document:
     source: SourceInfo
     locator: Locator
     heading_structure: list[HeadingNode]
-    span: SpanInfo
+    span: SpanInfo | None = None

--- a/application/utils/harvester/models.py
+++ b/application/utils/harvester/models.py
@@ -85,3 +85,20 @@ class Document:
     locator: Locator
     heading_structure: list[HeadingNode]
     span: SpanInfo | None = None
+
+
+@dataclass(slots=True)
+class ArtifactRegistryRecord:
+    """
+    Tracks the processing state of an artifact.
+    Used for deduplication across pipeline runs.
+    """
+
+    artifact_id: str
+    repository: str
+    locator_path: str
+    content_hash: str
+    last_commit_sha: str
+    last_pipeline_run: str
+    last_processed_at: datetime
+    status: str

--- a/application/utils/harvester/models.py
+++ b/application/utils/harvester/models.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from pydantic import BaseModel
+from enum import Enum
 
 
 @dataclass(slots=True)
@@ -102,3 +103,9 @@ class ArtifactRegistryRecord:
     last_pipeline_run: str
     last_processed_at: datetime
     status: str
+
+
+class DeduplicationStatus(str, Enum):
+    NEW = "new"
+    UPDATED = "updated"
+    UNCHANGED = "unchanged"

--- a/application/utils/harvester/models.py
+++ b/application/utils/harvester/models.py
@@ -109,3 +109,12 @@ class DeduplicationStatus(str, Enum):
     NEW = "new"
     UPDATED = "updated"
     UNCHANGED = "unchanged"
+
+
+@dataclass(slots=True)
+class CheckpointRecord:
+    repository: str
+    pipeline_run_id: str
+    last_processed_commit: str
+    status: str
+    updated_at: datetime

--- a/application/utils/harvester/models.py
+++ b/application/utils/harvester/models.py
@@ -39,3 +39,49 @@ class DiffBlock:
     repository: str
     commit_sha: str
     committed_at: datetime | None = None
+
+
+@dataclass(slots=True)
+class SourceInfo:
+    type: str
+    repository: str
+    commit_sha: str
+    committed_at: datetime
+
+
+@dataclass(slots=True)
+class Locator:
+    kind: str
+    id: str
+    path: str
+
+
+@dataclass(slots=True)
+class SpanInfo:
+    heading_path: list[str]
+    start_line: int
+    end_line: int
+    index: int | None = None
+    total: int | None = None
+    start_char_idx: int | None = None
+    end_char_idx: int | None = None
+
+
+@dataclass(slots=True)
+class HeadingNode:
+    level: int
+    text: str
+    start_line: int
+    end_line: int
+
+
+@dataclass(slots=True)
+class Document:
+    schema_version: str
+    artifact_id: str
+    pipeline_run_id: str
+    text: str
+    source: SourceInfo
+    locator: Locator
+    heading_structure: list[HeadingNode]
+    span: SpanInfo

--- a/application/utils/harvester/models.py
+++ b/application/utils/harvester/models.py
@@ -119,3 +119,16 @@ class CheckpointRecord:
     last_processed_commit: str
     status: str
     updated_at: datetime
+
+
+@dataclass(slots=True)
+class IngestChunkRecord:
+    """
+    RFC-facing representation of a semantically chunked document.
+    """
+
+    schema_version: str
+    chunk_id: str
+    artifact_id: str
+    text: str
+    span: SpanInfo

--- a/application/utils/harvester/models.py
+++ b/application/utils/harvester/models.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from datetime import datetime
-from pydantic import BaseModel
 from enum import Enum
+
+from pydantic import BaseModel
 
 
 @dataclass(slots=True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -89,3 +89,7 @@ pytest-playwright
 
 # Local stdio MCP server (issue #1003 v1) — not needed on Heroku slug
 mcp==2.0.0
+
+# LlamaIndex
+llama-index-core
+llama-index-embeddings-huggingface

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,8 @@ compliance-trestle
 posthog
 
 typing_extensions
+
+
+llama-index-core
+llama-index-embeddings-huggingface
+textacy


### PR DESCRIPTION
Week 8: Semantic Document Chunking Pipeline
Summary

Adds a document chunking foundation to the harvester pipeline: documents produced by earlier pipeline stages are now split into semantically coherent chunks, enriched with heading-path/line-range metadata, converted into RFC-facing ingestion records, and validated before being returned. Also includes CI stability fixes and dependency cleanup surfaced during review.

What's new

Semantic chunking (chunker.py)

DocumentChunker wraps LlamaIndex's SemanticSplitterNodeParser + HuggingFaceEmbedding (sentence-transformers/all-MiniLM-L6-v2 by default) to split document text into semantically coherent segments.
Returns ChunkInfo objects (text, start_char_idx, end_char_idx) preserving exact offsets into the source text.
Empty/whitespace-only documents short-circuit to [] without invoking the splitter.

Structure-aware chunk records (chunk_record_builder.py)

ChunkRecordBuilder converts ChunkInfo objects into IngestChunkRecords, resolving:
the active Markdown heading path for each chunk (based on the chunk's starting line and the document's heading_structure)
1-based inclusive line ranges derived from character offsets
deterministic chunk_ids built from artifact ID, heading path, char offsets, and a content hash — so identical text at different offsets gets distinct IDs, while rebuilding the same chunk twice is idempotent
span.index / span.total for chunk ordering

Validation (chunk_record_validator.py)

ChunkRecordValidator enforces non-empty text/IDs, valid chunk_id prefix, consistent span.index/span.total, valid char and line ranges before a record is considered usable.

Pipeline glue (chunk_pipeline.py)

DocumentChunkPipeline composes chunker → record builder → validator into a single chunk(document) call, validating every record before returning them (fixed in the CodeRabbit follow-up — the pipeline previously skipped validation, so invalid records from a swapped-in chunker/builder could bypass it).

Benchmark

chunking_benchmark_test.py added as an opt-in benchmark (RUN_CHUNKING_BENCHMARK=1), consistent with the existing diff-pipeline benchmark pattern, so it doesn't hit HuggingFace/network on every CI run.

Testing
chunker_test.py, chunk_record_builder_test.py, chunk_record_validator_test.py, chunk_pipeline_test.py — new unit tests covering empty input, node-boundary/order preservation, heading-path resolution, chunk ID determinism/uniqueness, and validator rejection paths.
chunking_benchmark_test.py — opt-in perf smoke test, skipped by default.
Full harvester test suite passes locally (pytest application/tests/harvester_test/).

High-level architecture
<img width="1147" height="102" alt="image" src="https://github.com/user-attachments/assets/de122237-a25e-4c01-8045-7123a0eba27a" />

Data-flow diagram
<img width="487" height="731" alt="image" src="https://github.com/user-attachments/assets/18001efc-f33e-4143-b588-3e59229da969" />

Chunk processing sequence
<img width="1023" height="557" alt="image" src="https://github.com/user-attachments/assets/0cc5d15a-efcc-4ac3-a604-585e813c6ea3" />


Domain model diagram
<img width="715" height="600" alt="image" src="https://github.com/user-attachments/assets/9218918b-e0c7-4344-a70d-a74cf1aa4ebb" />

Current boundary diagram
<img width="1248" height="187" alt="image" src="https://github.com/user-attachments/assets/0ca1a2be-eedc-4737-96cf-d95881adabcd" />

smoke tests:

<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/0e6da3ea-d232-4eee-a85f-34ed81e508f2" />

<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/cefa9d26-9542-40d7-91c8-c399a79c74dd" />

<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/3c5525ee-09a8-4bff-ae27-97b0b0fd4161" />

<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/3c5525ee-09a8-4bff-ae27-97b0b0fd4161" />

<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/7fe6276a-6c58-40ee-927f-a0845a33e978" />


<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/3c5525ee-09a8-4bff-ae27-97b0b0fd4161" />

<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/7fe6276a-6c58-40ee-927f-a0845a33e978" />

<img width="1470" height="928" alt="image" src="https://github.com/user-attachments/assets/3c5525ee-09a8-4bff-ae27-97b0b0fd4161" />


