### PR TITLE
docs: fix first-time contributor setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ OpenCRE consists of:
 # Contribute code or mappings
 
 To see how you can contribute to the application or to the data (catalog or standard mappings), see [Contributing](docs/CONTRIBUTING.md).
+
+If this is your first code contribution, start with the [first-time contributor setup guide](docs/developmentSetup.md), then read the contribution process and quality bar.
 We really welcome you!
 
 # Documentation
@@ -47,7 +49,7 @@ If you want to develop on OpenCRE or docker is not available in your environment
 ### Command Line
 
 To run outside of Docker you need to install OpenCRE.
-To install this application you need python3, yarn and virtualenv.
+To install this application you need Python 3.11.9, Node.js, Yarn Classic (the repository uses a Yarn v1 lockfile), and `virtualenv`. The Python version is pinned in `.python-version`; the repository does not currently pin a Node.js version.
 
 Clone the repository:
 
@@ -55,12 +57,7 @@ Clone the repository:
 git clone https://github.com/OWASP/OpenCRE
 ```
 
-(Recommended) Create and activate a Python virtual environment:
-
-```bash
-python3 -m venv venv
-source venv/bin/activate
-```
+`make install` creates and uses the project virtual environment. Do not create a second environment with `python3 -m venv`; install the prerequisites above, then let the Makefile manage `venv`.
 
 Install dependencies:
 
@@ -68,10 +65,9 @@ Install dependencies:
 make install
 ```
 
-Create the local schema and download the latest CRE graph from upstream:
+`make install` creates the local schema as part of installation. Download the latest CRE graph from upstream with:
 
 ```bash
-make migrate-upgrade
 make upstream-sync
 ```
 
@@ -156,7 +152,7 @@ make dev-flask
 Alternatively, you can use the dockerfile with:
 
 ```bash
-make docker && make docker-run
+make docker-dev && make docker-dev-run
 ```
 
 Some features like Gap Analysis require a neo4j DB running, you can start this with:
@@ -216,7 +212,7 @@ OpenCRE is fully supported on macOS. The following notes are optional and intend
 Install required tools using Homebrew:
 
 ```bash
-brew install python@3.11 yarn make
+brew install python@3.11 yarn make virtualenv
 ```
 
 > Note: Python 3.11 is recommended. Newer Python versions may cause dependency incompatibilities.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ You can reach us in the [OWASP Slack](https://owasp.org/slack/invite) at channel
 
 ## How Can I Contribute?
 
-The "Issues" page lists a number of features we would like to implement, we have tagged the ones we believe are easy to pick up with the tag `good first issue` and/or `beginner`. Alternatively you can contribute content (see below) or request features or mappings by opening an Issue.
+The "Issues" page lists a number of features we would like to implement, we have tagged the ones we believe are easy to pick up with the tag `good first issue` and/or `beginner`. For the canonical first-time setup, read the [development setup guide](developmentSetup.md). Alternatively you can contribute content (see below) or request features or mappings by opening an Issue.
 
 > **Note:** Due to a wave of low effort, poorly tested and often destructive AI-powered issues often created only for the sake of opening a pull request, we will be aggressively closing both issues and pull requests that link to issues not acknowledged by the maintainers.
 
@@ -78,7 +78,7 @@ Again, this only works if you have control over the content of the standard. Con
 
 ### Reporting Bugs
 
-When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/common-requirement-enumeration/.github/blob/main/.github/ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
+When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/OWASP/OpenCRE/blob/main/.github/ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -94,7 +94,7 @@ Please avoid opening GitHub issues for small frontend or cosmetic bugs such as:
 
 #### How Do I Submit A (Good) Bug Report?
 
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue and provide the following information by filling in [the template](https://github.com/common-requirement-enumeration/.github/blob/main/.github/ISSUE_TEMPLATE.md).
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue and provide the following information by filling in [the template](https://github.com/OWASP/OpenCRE/blob/main/.github/ISSUE_TEMPLATE.md).
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
@@ -109,7 +109,7 @@ Explain the problem and include additional details to help maintainers reproduce
 
 This section guides you through submitting an enhancement suggestion, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
-When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/OWASP/OpenCRE/blob/main/docs/ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
+When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/OWASP/OpenCRE/blob/main/.github/ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 

--- a/docs/developmentSetup.md
+++ b/docs/developmentSetup.md
@@ -76,8 +76,7 @@ npm install --global yarn
 
 ## Database installation
 
-openCRE uses [sqlite3](https://www.sqlite.org/index.html) for local development and [postgres](https://www.postgresql.org/) for production.
-Bothh are needed in order to run the project.
+OpenCRE uses [SQLite](https://www.sqlite.org/index.html) for the default local development database and [PostgreSQL](https://www.postgresql.org/) for production. You do not need to install both databases for the standard contributor path; install PostgreSQL locally only when you are explicitly testing the PostgreSQL-backed workflow.
 
 ### Linux
 
@@ -104,8 +103,16 @@ You can install the project by running `make install`.
 
 ### Testing that everything works
 
-If the tests pass, the project should be operational. You can run tests with
-`make test` and `make e2e` which runs both [unit tests](https://en.wikipedia.org/wiki/Unit_testing) and [end to end tests](https://www.browserstack.com/guide/end-to-end-testing).
+Before running the end-to-end checks, start the local services and seed the fixture database. Then run both [unit tests](https://en.wikipedia.org/wiki/Unit_testing) and [end to end tests](https://www.browserstack.com/guide/end-to-end-testing):
+
+```bash
+make start-containers
+make e2e-db
+make test
+make e2e
+```
+
+A working setup should finish without a test failure and should make the local application available at `http://localhost:5000`.
 
 ### Import the database
 
@@ -166,6 +173,14 @@ You can run the backend with `make dev-flask`. At the time of writing the backen
 
 You can run the frontend with `yarn start`. This should open a browser tab at the application's front page and also automatically reload the page whenever changes are detected. At the time of writing the frontend URL is `http://localhost:9001` by default.
 
+## Troubleshooting
+
+- **`virtualenv: command not found`:** install the `virtualenv` prerequisite, then rerun `make install`. Do not create a separate `venv` with a different tool.
+- **`make e2e` fails before the tests start:** make sure the local services are running and run `make e2e-db` first to seed the fixture database.
+- **Docker command not found:** use the Docker alternative from the main [README](../README.md), or install Docker before following that path.
+- **Database confusion:** the default local contributor path uses SQLite. Only add local PostgreSQL when you are testing the production-style database path.
+- **Frontend dependency failures:** the repository uses a Yarn v1 lockfile. Use Yarn Classic and keep the Node.js version consistent across contributors until the project adds an explicit Node.js engine constraint.
+
 ### Regenerating all embeddings (smart extract / new model)
 
 After changing embedding logic or models, wipe and rebuild stored vectors so the chatbot similarity search uses the new text:
@@ -182,4 +197,4 @@ This deletes every row in the `embeddings` table, then runs the same full pass a
 
 The chatbot matches your question to a **standard node embedding**, then answers using that node’s `embeddings_content`. When **`embeddings_url`** is set (e.g. OWASP AI Exchange with a `#fragment`), the API adds it as **`embeddingsUrl`** on the reference row alongside the unchanged catalog **`hyperlink`**; the UI shows a separate “Scoped source (embedding URL)” link. The LLM context includes an `Embeddings_URL` line for citations.
 
-This is it, please follow the [CONTRIBUTING](../CONTRIBUTING.md) guidlines while contributing and thank you for your interest in OpenCRE.
+This is it, please follow the [CONTRIBUTING](./CONTRIBUTING.md) guidelines while contributing and thank you for your interest in OpenCRE.


### PR DESCRIPTION
Closes #1051

## Summary
- Link the first-time contributor guide from the README and CONTRIBUTING guide.
- Remove the duplicate virtual-environment and migration steps.
- Correct the Docker target, issue-template links, database guidance, and E2E setup sequence.
- Add a setup checkpoint and troubleshooting section.

## Verification
- Checked every changed relative link resolves in the repository.
- Checked every documented Make target exists in the Makefile.
- Documentation-only change; no application behavior changed.