### PR TITLE
fix(frontend,e2e): stop Cypress flakes from #mount scroll

### DIFF
--- a/application/frontend/src/pages/BrowseRootCres/browseRootCres.tsx
+++ b/application/frontend/src/pages/BrowseRootCres/browseRootCres.tsx
@@ -9,7 +9,7 @@ import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndica
 import { useEnvironment } from '../../hooks';
 import { applyFilters, filterContext } from '../../hooks/applyFilters';
 import { Document } from '../../types';
-import { groupLinksByType } from '../../utils';
+import { groupLinksByType, scrollMountToTop } from '../../utils';
 import { SearchResults } from '../Search/components/SearchResults';
 
 export const BrowseRootCres = () => {
@@ -20,7 +20,7 @@ export const BrowseRootCres = () => {
 
   useEffect(() => {
     setLoading(true);
-    window.scrollTo(0, 0);
+    scrollMountToTop();
 
     axios
       .get(`${apiUrl}/root_cres`)

--- a/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
+++ b/application/frontend/src/pages/CommonRequirementEnumeration/CommonRequirementEnumeration.tsx
@@ -12,7 +12,7 @@ import { DOCUMENT_TYPES } from '../../const';
 import { useEnvironment } from '../../hooks';
 import { applyFilters, filterContext } from '../../hooks/applyFilters';
 import { Document } from '../../types';
-import { groupLinksByType } from '../../utils';
+import { groupLinksByType, scrollMountToTop } from '../../utils';
 import { getDocumentDisplayName, getDocumentTypeText, orderLinksByType } from '../../utils/document';
 
 const MAX_LENGTH_FOR_AUTO_EXPAND = 5;
@@ -33,7 +33,7 @@ export const CommonRequirementEnumeration = () => {
   useEffect(() => {
     setLoading(true);
     setShowAll({});
-    window.scrollTo(0, 0);
+    scrollMountToTop();
 
     const params = source ? { params: { source } } : undefined;
     axios

--- a/application/frontend/src/pages/Graph/Graph.tsx
+++ b/application/frontend/src/pages/Graph/Graph.tsx
@@ -22,6 +22,7 @@ import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndica
 import { DOCUMENT_TYPES } from '../../const';
 import { useEnvironment } from '../../hooks';
 import { Document, LinkedDocument } from '../../types';
+import { scrollMountToTop } from '../../utils';
 
 interface ReactFlowNode {}
 interface CREGraph {
@@ -99,7 +100,7 @@ export const Graph = () => {
 
   useEffect(() => {
     setLoading(true);
-    window.scrollTo(0, 0);
+    scrollMountToTop();
 
     axios
       .get(`${apiUrl}/id/${id}`)

--- a/application/frontend/src/pages/Search/SearchName.tsx
+++ b/application/frontend/src/pages/Search/SearchName.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndicator';
 import { useEnvironment } from '../../hooks';
 import { Document } from '../../types';
+import { scrollMountToTop } from '../../utils';
 import { groupBy } from '../../utils/document';
 import { SearchResults } from './components/SearchResults';
 
@@ -19,7 +20,7 @@ export const SearchName = () => {
   const [error, setError] = useState<string | Object | null>(null);
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    scrollMountToTop();
     setLoading(true);
     axios
       .get(`${apiUrl}/text_search`, { params: { text: searchTerm } })

--- a/application/frontend/src/pages/Standard/Standard.tsx
+++ b/application/frontend/src/pages/Standard/Standard.tsx
@@ -9,6 +9,7 @@ import { DocumentNode } from '../../components/DocumentNode';
 import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndicator';
 import { useEnvironment } from '../../hooks';
 import { Document, PaginatedResponse } from '../../types';
+import { scrollMountToTop } from '../../utils';
 import { getDocumentDisplayName } from '../../utils/document';
 
 export const Standard = () => {
@@ -24,7 +25,7 @@ export const Standard = () => {
   }
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    scrollMountToTop();
     setLoading(true);
     axios
       .get(`${apiUrl}/${type}/${id}?page=${page}`)

--- a/application/frontend/src/pages/Standard/StandardSection.tsx
+++ b/application/frontend/src/pages/Standard/StandardSection.tsx
@@ -10,7 +10,7 @@ import { LoadingAndErrorIndicator } from '../../components/LoadingAndErrorIndica
 import { DOCUMENT_TYPES, DOCUMENT_TYPE_NAMES, TOOL } from '../../const';
 import { useEnvironment } from '../../hooks';
 import { Document, PaginatedResponse } from '../../types';
-import { getDocumentDisplayName, groupLinksByType } from '../../utils';
+import { getDocumentDisplayName, groupLinksByType, scrollMountToTop } from '../../utils';
 import { getDocumentTypeText } from '../../utils/document';
 
 export const StandardSection = () => {
@@ -38,7 +38,7 @@ export const StandardSection = () => {
   };
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    scrollMountToTop();
     setLoading(true);
     axios
       .get(

--- a/application/frontend/src/utils/index.ts
+++ b/application/frontend/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { DBSchema, openDB } from 'idb';
 export { groupLinksByType, LinksByType, getDocumentDisplayName } from './document';
+export { scrollMountToTop } from './scroll';
 
 const DB_NAME = 'DataCacheDB';
 const STORE_NAME = 'KeyValStore';

--- a/application/frontend/src/utils/scroll.ts
+++ b/application/frontend/src/utils/scroll.ts
@@ -1,0 +1,16 @@
+/**
+ * Scroll the app's real scroll container to the top.
+ *
+ * `body` is `overflow: hidden` and `#mount` is `overflow-y: auto`
+ * (see `app.scss`), so `window.scrollTo(0, 0)` is a no-op and leaves
+ * SPA navigations scrolled mid-page. That clips page headings and makes
+ * Cypress `be.visible` flake on search / browse routes.
+ */
+export const scrollMountToTop = (): void => {
+  const mount = document.getElementById('mount');
+  if (mount) {
+    mount.scrollTop = 0;
+    return;
+  }
+  window.scrollTo(0, 0);
+};

--- a/cypress/e2e/cre.cy.js
+++ b/cypress/e2e/cre.cy.js
@@ -6,7 +6,7 @@ describe('OpenCRE CRE page', () => {
     cy.visit('/');
     cy.get('form#search-bar input[type="text"]').type(`${creId}{enter}`);
     cy.url().should('include', `/search/${creId}`);
-    cy.contains('h1', 'Matching CREs').should('be.visible');
+    cy.contains('h1', 'Matching CREs').scrollIntoView().should('be.visible');
     // Data-bearing: the CRE result row itself renders (fails on empty DB).
     cy.get('.standard-page__links-container').should('contain.text', 'Mutually authenticate');
   });

--- a/cypress/e2e/smoke.cy.js
+++ b/cypress/e2e/smoke.cy.js
@@ -12,13 +12,17 @@ describe('OpenCRE e2e smoke', () => {
     cy.visit('/');
     cy.get('form#search-bar input[type="text"]').type(`${term}{enter}`);
     cy.url().should('include', `/search/${term}`);
-    cy.contains('Results matching').should('be.visible');
+    // #mount is the scroll container (body is overflow:hidden). scrollIntoView
+    // keeps this assertion robust if SPA navigation left #mount mid-scroll.
+    cy.contains('Results matching').scrollIntoView().should('be.visible');
   });
 
   it('browse route is reachable', () => {
     cy.visit('/root_cres');
-    cy.contains('h1', 'Root CREs').should('be.visible');
-    // Data-bearing: the fixture root CRE 558-807 renders in the list.
+    cy.contains('h1', 'Root CREs').scrollIntoView().should('be.visible');
+    // Data-bearing: the fixture root CRE 558-807 renders in the list
+    // (scripts/seed_e2e_fixtures.py). Do not swap this for "Cryptography" —
+    // that CRE is the free-text search fixture, not the root-CRE contract.
     cy.get('.standard-page__links-container').should('contain.text', 'Mutually authenticate');
   });
 });


### PR DESCRIPTION
## Summary
- Root cause of intermittent `Test-e2e` failures on `main`: `smoke.cy.js` → `home search routes to search results page` times out because `h1.standard-page__heading` ("Results matching") is clipped by `#mount` (`overflow-y: auto`). `body` is `overflow: hidden`, so `window.scrollTo(0, 0)` in page mounts was a no-op.
- Add `scrollMountToTop()` and use it on Search / Root CREs / CRE / Standard / Graph mounts (same pattern Docs already documents).
- Harden smoke/cre heading asserts with `scrollIntoView`.
- Keep the `scripts/seed_e2e_fixtures.py` contract (`Mutually authenticate`, ASVS/V13.2.5). Do **not** swap root CRE asserts to `Cryptography` (that CRE is the free-text search fixture only).

## Why not #1050 as-is
#1050 correctly noticed the scrollIntoView need, but also:
1. Replaced root CRE `Mutually authenticate` with `Cryptography` (wrong fixture role).
2. Weakened `standard.cy.js` data-bearing asserts — those were already passing on main.

Supersedes #1050.

## Test plan
- [x] Confirmed failing main runs all flake on `home search` + clipped `standard-page__heading`
- [ ] CI `Test-e2e` green on this PR
- [ ] `make frontend` / lint as required by CI


Made with [Cursor](https://cursor.com)