### PR TITLE
fix: improve scroll handling and bouncing arrow btn visibility logic

### DIFF
--- a/application/frontend/src/pages/Search/Search.tsx
+++ b/application/frontend/src/pages/Search/Search.tsx
@@ -19,32 +19,37 @@ export const SearchPage = () => {
 
   useEffect(() => {
     const mobileMenu = document.querySelector('.navbar__mobile-menu');
-    const observer = new MutationObserver(() => {
-      if (mobileMenu?.classList.contains('is-open')) {
-        setIsArrowVisible(false);
-      } else {
-        setIsArrowVisible(true);
-      }
-    });
-    if (mobileMenu) {
-      observer.observe(mobileMenu, { attributes: true, attributeFilter: ['class'] });
-    }
+    const scrollContainer = document.getElementById('mount') ?? window;
 
     const handleScroll = () => {
+      if (mobileMenu?.classList.contains('is-open')) {
+        setIsArrowVisible(false);
+        return;
+      }
+
       const footer = document.getElementById('page-footer');
       if (footer) {
         const footerTop = footer.getBoundingClientRect().top;
         const windowHeight = window.innerHeight;
-        if (footerTop < windowHeight) {
+        if (footerTop <= windowHeight) {
           setIsArrowVisible(false);
         } else {
           setIsArrowVisible(true);
         }
       }
     };
-    window.addEventListener('scroll', handleScroll);
+
+    const observer = new MutationObserver(handleScroll);
+    if (mobileMenu) {
+      observer.observe(mobileMenu, { attributes: true, attributeFilter: ['class'] });
+    }
+
+    handleScroll();
+    scrollContainer.addEventListener('scroll', handleScroll);
+    window.addEventListener('resize', handleScroll);
     return () => {
-      window.removeEventListener('scroll', handleScroll);
+      scrollContainer.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
       observer.disconnect();
     };
   }, []);


### PR DESCRIPTION
Fixes #1055 

## Summary

this PR fixes the bouncing arrow visibility on the footer on the landing page

- listen for scroll events on the app’s #mount container instead of window
- hide the bouncing arrow btn when the footer enters the viewport.

## Validation

`yarn build` passes

## Screenshots

### Before

<img width="1907" height="745" alt="image" src="https://github.com/user-attachments/assets/8d433ee2-96e1-4a70-8e9f-b624368e4164" />

### after 

<img width="1907" height="745" alt="image" src="https://github.com/user-attachments/assets/8f69735f-30f2-4830-b730-d678c1f046e6" />
